### PR TITLE
Getting protocol for session

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1310,7 +1310,7 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getCipherForSSL)(TCN_STDARGS,
 }
 
 // Read which protocol was negotiated for the given SSL *.
-TCN_IMPLEMENT_CALL(jstring, SSL, getVersionForSSL)(TCN_STDARGS,
+TCN_IMPLEMENT_CALL(jstring, SSL, getVersion)(TCN_STDARGS,
                                                   jlong ssl /* SSL * */)
 {
     UNREFERENCED_STDARGS;

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -517,7 +517,7 @@ public final class SSL {
      * @param ssl the SSL instance (SSL *)
      * @return
      */
-    public static native String getVersionForSSL(long ssl);
+    public static native String getVersion(long ssl);
 
     /**
      * SSL_do_handshake


### PR DESCRIPTION
This simple pach would make possible to know what protocol is in use for a session.

If pulled, onc could later change OpenSslEngine.getSession() with:
SSLSession session = this.session;
        if (session == null) {
            this.session = session = new SSLSession() {
                ...
                public String getProtocol() {
                    SSL.getProtocolForSSL(ssl);
                }

instead of the current code
