### PR TITLE
Making it possible to have access to the chose session protocol (e.g. TLSv1.2 or SSLv3)

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1309,6 +1309,15 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getCipherForSSL)(TCN_STDARGS,
     return AJP_TO_JSTRING(SSL_get_cipher(J2P(ssl, SSL*)));
 }
 
+// Read which protocol was negotiated for the given SSL *.
+TCN_IMPLEMENT_CALL(jstring, SSL, getVersion)(TCN_STDARGS,
+                                                  jlong ssl /* SSL * */)
+{
+    UNREFERENCED_STDARGS;
+
+    return AJP_TO_JSTRING(SSL_get_version(J2P(ssl, SSL*)));
+}
+
 // Is the handshake over yet?
 TCN_IMPLEMENT_CALL(jint, SSL, isInInit)(TCN_STDARGS,
                                         jlong ssl /* SSL * */) {

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -513,6 +513,13 @@ public final class SSL {
     public static native String getCipherForSSL(long ssl);
 
     /**
+     * SSL_get_version
+     * @param ssl the SSL instance (SSL *)
+     * @return
+     */
+    public static native String getVersion(long ssl);
+
+    /**
      * SSL_do_handshake
      * @param ssl the SSL instance (SSL *)
      */


### PR DESCRIPTION
Motivation:

It is possible to check what is the chosen cipher for an SSL session,
which is properly reported in netty using the OpenSSL implementation for
SSLSession. However, protocol is reported as unknown. If using the JDK
implementation, it is correctly reported such as as SSLv3.

Knowing the session protocol can help in managing security properly,
e.g. for accepting SSLv3 or TLSv1 in some parts of an application for
compatibility, and allowing only TLSv1.1 or TLSv1.2 for more secured
parts, such as user authentication.

Modifications:

Just adding a new native operation to SSL to quary protocol of an
existing session thanks to its id.

Result:

It will be possible to implement getProtocol for the
OpenSslEngine.getSession().getProtocol() so that it has same behavior as
JDK implementation.
