### PR TITLE
Making it possible to define parameters for Diffie–Hellman key exchange.

### DIFF
--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -326,4 +326,15 @@ public final class SSLContext {
      * @param next_protos comma deliniated list of protocols in priority order
      */
     public static native void setNextProtos(long ctx, String next_protos);
+    
+    /**
+     * Set DH parameters
+     * @param ctx Server context to use.
+     * @param cert 
+     * 			DH param file
+     * 			(can be generated from e.g. {@code openssl dhparam -rand - 2048 > dhparam.pem} -
+     * 			see the <a href="https://www.openssl.org/docs/apps/dhparam.html">OpenSSL documentation</a>).
+     */
+    public static native void setTmpDH(long ctx, String cert)
+            throws Exception;
 }


### PR DESCRIPTION
Motivation:

Improving security of SSL transactions that use DHE-based ciphers. For
instance, it should be possible to change key size.

Modifications:

Adding a new native operation on OpenSSL that makes it possible to add
to an SSL context a file that defines DH parameters.

Result:

One can now create his/her dhparam key file using the following command
line:
openssl dhparam -rand - 2048 > /etc/ssl/certs/dhparam.pem
For parameters to be taken int o account, in Java, one should then call:
SSLContext.setTmpDH(sslContext.context(), "/etc/ssl/certs/dhparam.pem")
