### PR TITLE
Making it possible to define the elliptic curve by name for ECDHE

### DIFF
--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -490,6 +490,50 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDH)(TCN_STDARGS, jlong ctx,
     TCN_FREE_CSTRING(file);
 }
 
+TCN_IMPLEMENT_CALL(void, SSLContext, setTmpECDHByCurveName)(TCN_STDARGS, jlong ctx,
+                                                                  jstring curveName)
+{
+#ifdef HAVE_ECC
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+    TCN_ALLOC_CSTRING(curveName);
+    UNREFERENCED(o);
+    TCN_ASSERT(ctx != 0);
+    TCN_ASSERT(curveName);
+    
+    // First try to get curve by name
+    int i;
+    i = OBJ_sn2nid(J2S(curveName));
+    if (!i) {
+        tcn_Throw(e, "Can't configure elliptic curve: unknown curve name %s", J2S(curveName));
+        TCN_FREE_CSTRING(curveName);
+        return;
+    }
+    
+    EC_KEY  *ecdh;
+    ecdh = EC_KEY_new_by_curve_name(i);
+    if (!ecdh) {
+        tcn_Throw(e, "Can't configure elliptic curve: unknown curve name %s", J2S(curveName));
+        TCN_FREE_CSTRING(curveName);
+        return;
+    }
+    
+    // Setting found curve to context
+    if (1 != SSL_CTX_set_tmp_ecdh(c->ctx, ecdh)) {
+        EC_KEY_free(ecdh);
+        char err[256];
+        ERR_error_string(ERR_get_error(), err);
+        tcn_Throw(e, "Error while configuring elliptic curve %s: %s", J2S(curveName), err);
+        TCN_FREE_CSTRING(curveName);
+        return;
+    }
+    EC_KEY_free(ecdh);
+    TCN_FREE_CSTRING(curveName);
+#else
+	tcn_Throw(e, "Cant't configure elliptic curve: unsupported by this OpenSSL version");
+	return;
+#endif
+}
+
 TCN_IMPLEMENT_CALL(void, SSLContext, setShutdownType)(TCN_STDARGS, jlong ctx,
                                                       jint type)
 {

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -335,4 +335,13 @@ public final class SSLContext {
      */
     public static native void setTmpDH(long ctx, String cert)
             throws Exception;
+    
+    /**
+     * Set ECDH elliptic curve by name
+     * @param ctx Server context to use.
+     * @param curveName the name of the elliptic curve to use
+     *             (available names can be obtained from {@code openssl ecparam -list_curves}).
+     */
+    public static native void setTmpECDHByCurveName(long ctx, String curveName)
+            throws Exception;
 }


### PR DESCRIPTION
Diffie–Hellman.

Motivation:

Improving security of SSL transactions that use ECDHE-based ciphers.

Modifications:

Adding a new native operation on OpenSSL that makes it possible to set
the elliptic curve by meely giving its name. An exception is thrown in
case the curve is not found or fails to load.

Result:

One can now setup his/his elliptic curve as can be chosen in the liste
generated by:
openssl ecparam -list_curves
This is done e.g. by calling:
SSLContext.setTmpECDHByCurveName(sslContext.context(), "secp256k1")
Note that secp256k1 is the default value.
