### PR TITLE
Add support for client mode when constructed via SSL.newSSL(...)

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -40,6 +40,8 @@ tcn_pass_cb_t tcn_password_callback;
 /* Global reference to the pool used by the dynamic mutexes */
 static apr_pool_t *dynlockpool = NULL;
 
+static jclass byteArrayClass;
+
 /* Dynamic lock structure */
 struct CRYPTO_dynlock_value {
     apr_pool_t *pool;
@@ -703,6 +705,11 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
                               ssl_init_cleanup,
                               apr_pool_cleanup_null);
     TCN_FREE_CSTRING(engine);
+
+    // Cache the byte[].class for performance reasons
+    jclass clazz = (*e)->FindClass(e, "[B");
+    byteArrayClass = (jclass) (*e)->NewGlobalRef(e, clazz);
+
     return (jint)APR_SUCCESS;
 }
 
@@ -1156,6 +1163,13 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
     } else {
         SSL_set_connect_state(ssl);
     }
+
+    // Setup verify and seed
+    SSL_set_verify_result(ssl, X509_V_OK);
+    SSL_rand_seed(c->rand_file);
+
+    // Store for later usage in SSL_callback_SSL_verify
+    SSL_set_app_data2(ssl, c);
     return P2J(ssl);
 }
 
@@ -1364,6 +1378,88 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS,
     return tcn_new_stringn(e, proto, proto_len);
 }
 /*** End Twitter API Additions ***/
+
+/*** Apple API Additions ***/
+TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
+                                                  jlong ssl /* SSL * */)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return NULL;
+    }
+
+    UNREFERENCED(o);
+
+    // Get a stack of all certs in the chain.
+    STACK_OF(X509) *sk = SSL_get_peer_cert_chain(ssl_);
+
+    unsigned len = sk_num(sk);
+    if (len <= 0) {
+        // No peer certificate chain as no auth took place yet, or the auth was not successful.
+        return NULL;
+    }
+    unsigned i;
+    X509 *cert;
+    int length;
+    unsigned char *buf;
+
+    // Create the byte[][] array that holds all the certs
+    jobjectArray array = (*e)->NewObjectArray(e, len, byteArrayClass, NULL);
+
+    for(i = 0; i < len; i++) {
+        cert = (X509*) sk_value(sk, i);
+
+        buf = NULL;
+        length = i2d_X509(cert, &buf);
+        if (length < 0) {
+            // In case of error just return an empty byte[][]
+            return (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
+        }
+        jbyteArray bArray = (*e)->NewByteArray(e, length);
+        (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) buf);
+        (*e)->SetObjectArrayElement(e, array, i, bArray);
+
+        // Delete the local reference as we not know how long the chain is and local references are otherwise
+        // only freed once jni method returns.
+        (*e)->DeleteLocalRef(e, bArray);
+    }
+    return array;
+}
+
+TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
+                                                  jlong ssl /* SSL * */)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return NULL;
+    }
+
+    UNREFERENCED(o);
+
+    // Get a stack of all certs in the chain
+    X509 *cert = SSL_get_peer_certificate(ssl_);
+    if (cert == NULL) {
+        return NULL;
+    }
+    int length;
+    unsigned char *buf = NULL;
+
+    length = i2d_X509(cert, &buf);
+
+    jbyteArray bArray = (*e)->NewByteArray(e, length);
+    (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) buf);
+
+    // We need to free the cert as the reference count is incremented by one and it is not destroyed when the
+    // session is freed.
+    // See https://www.openssl.org/docs/ssl/SSL_get_peer_certificate.html
+    X509_free(cert);
+    return bArray;
+}
+/*** End Apple API Additions ***/
 
 #else
 #error OpenSSL is required!
@@ -1627,5 +1723,25 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS, jlong ssl)
 }
 
 /*** End Twitter 1:1 API addition ***/
+
+/*** Begin Apple 1:1 API addition ***/
+
+TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS, jlong ssl)
+{
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  tcn_ThrowException(e, "Not implemented");
+  return NULL;
+}
+
+TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS, jlong ssl)
+{
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  tcn_ThrowException(e, "Not implemented");
+  return NULL;
+}
+
+/*** End Apple API Additions ***/
 
 #endif

--- a/src/main/c/sslnetwork.c
+++ b/src/main/c/sslnetwork.c
@@ -144,6 +144,9 @@ static tcn_ssl_conn_t *ssl_create(JNIEnv *env, tcn_ssl_ctxt_t *ctx, apr_pool_t *
 
     SSL_set_app_data(ssl, (void *)con);
 
+    // Store for later usage in SSL_callback_SSL_verify
+    SSL_set_app_data2(ssl, ctx);
+
     if (ctx->mode) {
         /*
          *  Configure callbacks for SSL connection

--- a/src/main/c/sslutils.c
+++ b/src/main/c/sslutils.c
@@ -473,7 +473,7 @@ static int ssl_X509_STORE_lookup(X509_STORE *store, int yype,
     return rc;
 }
 
-static int ssl_verify_CRL(int ok, X509_STORE_CTX *ctx, tcn_ssl_conn_t *con)
+static int ssl_verify_CRL(int ok, X509_STORE_CTX *ctx, tcn_ssl_ctxt_t *c)
 {
     X509_OBJECT obj;
     X509_NAME *subject, *issuer;
@@ -525,7 +525,7 @@ static int ssl_verify_CRL(int ok, X509_STORE_CTX *ctx, tcn_ssl_conn_t *con)
      * the current certificate in order to verify it's integrity.
      */
     memset((char *)&obj, 0, sizeof(obj));
-    rc = ssl_X509_STORE_lookup(con->ctx->crl,
+    rc = ssl_X509_STORE_lookup(c->crl,
                                X509_LU_CRL, subject, &obj);
     crl = obj.data.crl;
 
@@ -579,7 +579,7 @@ static int ssl_verify_CRL(int ok, X509_STORE_CTX *ctx, tcn_ssl_conn_t *con)
      * the current certificate in order to check for revocation.
      */
     memset((char *)&obj, 0, sizeof(obj));
-    rc = ssl_X509_STORE_lookup(con->ctx->crl,
+    rc = ssl_X509_STORE_lookup(c->crl,
                                X509_LU_CRL, issuer, &obj);
 
     crl = obj.data.crl;
@@ -620,12 +620,13 @@ int SSL_callback_SSL_verify(int ok, X509_STORE_CTX *ctx)
    /* Get Apache context back through OpenSSL context */
     SSL *ssl = X509_STORE_CTX_get_ex_data(ctx,
                                           SSL_get_ex_data_X509_STORE_CTX_idx());
-    tcn_ssl_conn_t *con = (tcn_ssl_conn_t *)SSL_get_app_data(ssl);
+    tcn_ssl_ctxt_t *c = SSL_get_app_data2(ssl);
+
     /* Get verify ingredients */
     int errnum   = X509_STORE_CTX_get_error(ctx);
     int errdepth = X509_STORE_CTX_get_error_depth(ctx);
-    int verify   = con->ctx->verify_mode;
-    int depth    = con->ctx->verify_depth;
+    int verify   = c->verify_mode;
+    int depth    = c->verify_depth;
     int skip_crl = 0;
 
     if (verify == SSL_CVERIFY_UNSET ||
@@ -669,8 +670,8 @@ int SSL_callback_SSL_verify(int ok, X509_STORE_CTX *ctx)
     /*
      * Additionally perform CRL-based revocation checks
      */
-    if (ok && con->ctx->crl && !skip_crl) {
-        if (!(ok = ssl_verify_CRL(ok, ctx, con))) {
+    if (ok && c->crl && !skip_crl) {
+        if (!(ok = ssl_verify_CRL(ok, ctx, c))) {
             errnum = X509_STORE_CTX_get_error(ctx);
             /* TODO: Log something */
         }
@@ -679,10 +680,14 @@ int SSL_callback_SSL_verify(int ok, X509_STORE_CTX *ctx)
      * If we already know it's not ok, log the real reason
      */
     if (!ok) {
+        // Just in case that sslnetwork stuff was used, which is not true for netty but it can't harm to still
+        // guard against it.
+        tcn_ssl_conn_t *con = (tcn_ssl_conn_t *)SSL_get_app_data(ssl);
+
         /* TODO: Some logging
          * Certificate Verification: Error
          */
-        if (con->peer) {
+        if (con != NULL && con->peer) {
             X509_free(con->peer);
             con->peer = NULL;
         }

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -542,4 +542,14 @@ public final class SSL {
     /*
      * End Twitter API Additions
      */
+
+    /**
+     * Get the peer certificate chain or {@code null} if non was send.
+     */
+    public static native byte[][] getPeerCertChain(long ssl);
+
+    /**
+     * Get the peer certificate or {@code null} if non was send.
+     */
+    public static native byte[] getPeerCertificate(long ssl);
 }


### PR DESCRIPTION
Motivation:

At the moment it is not possible to use SSL in client mode with the added newSSL(...) abstraction as it will lead to a null pointer
and so segfaults. This is because we not setup our SSL object via SSLSocket and so the underlying datastructured are not set up
like expected.

Modifications:
- Store tcn_ssl_ctxt_t as data on the SSL object and use it to executed the SSL_callback_SSL_verify functions. Also add extra gards against
  null pointers.
- Correctly setup seed and verify during newSSL(...)

Result:

It's now possible to also use newSSL(...) and use it for client mode
