### PR TITLE
Allow to explicit set and get the session_cache_mode

### DIFF
--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -832,6 +832,18 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setNextProtos)(TCN_STDARGS, jlong ctx,
     TCN_FREE_CSTRING(next_protos);
 }
 
+TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheMode)(TCN_STDARGS, jlong ctx, jlong mode)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+    return SSL_CTX_set_session_cache_mode(c->ctx, mode);
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSLContext, getSessionCacheMode)(TCN_STDARGS, jlong ctx)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+    return SSL_CTX_get_session_cache_mode(c->ctx);
+}
+
 TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheTimeout)(TCN_STDARGS, jlong ctx, jlong timeout)
 {
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
@@ -850,8 +862,8 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheSize)(TCN_STDARGS, jlong ct
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
     jlong rv = 0;
 
-    /* Prevent unbounded session cache sizes. */
-    if (size > 0) {
+    // Also allow size of 0 which is unlimited
+    if (size >= 0) {
       SSL_CTX_set_session_cache_mode(c->ctx, SSL_SESS_CACHE_SERVER);
       rv = SSL_CTX_sess_set_cache_size(c->ctx, size);
     }
@@ -1299,6 +1311,23 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setNextProtos)(TCN_STDARGS, jlong ctx,
     UNREFERENCED(ctx);
     UNREFERENCED(next_protos);
 }
+
+
+TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheMode)(TCN_STDARGS, jlong ctx, jlong mode)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    UNREFERENCED(mode);
+    return -1;
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSLContext, getSessionCacheMode)(TCN_STDARGS, jlong ctx)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    return -1;
+}
+
 
 TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheTimeout)(TCN_STDARGS, jlong ctx, jlong timeout)
 {

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -214,6 +214,11 @@ public final class SSL {
      * Add certificate chain number to that flag (0 ... verify depth)
      */
     public static final int SSL_INFO_CLIENT_CERT_CHAIN         = 0x0400;
+
+    /* Only support OFF and SERVER for now */
+    public static final long SSL_SESS_CACHE_OFF = 0x0000;
+    public static final long SSL_SESS_CACHE_SERVER = 0x0002;
+
     /* Return OpenSSL version number */
     public static native int version();
 

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -230,6 +230,16 @@ public final class SSLContext {
     public static native long getSessionCacheTimeout(long ctx);
 
     /**
+     * Set the mode of the internal session cache and return the previous used mode.
+     */
+    public static native long setSessionCacheMode(long ctx, long mode);
+
+    /**
+     * Get the mode of the current used internal session cache.
+     */
+    public static native long getSessionCacheMode(long ctx);
+
+    /**
      * Session resumption statistics methods.
      * http://www.openssl.org/docs/ssl/SSL_CTX_sess_number.html
      */


### PR DESCRIPTION
Motivation:

Sometimes it is useful to be able to explicit set the session_cache_mode or get the current used mode.

Modifications:
- add SSLContext.setSessionCacheMode(...) and SSLContext.getSessionCacheMode(...)
- allow to pass 0 into SSLContext.setSessionCacheSize(...) to allow unlimited size

Result:

It's now possible to set the cache mode on the fly.
