### PR TITLE
Allow to obtain session as byte[]

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1525,6 +1525,39 @@ TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl,
     SSL_set_verify(ssl_, verify, SSL_callback_SSL_verify);
 }
 
+TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return 0;
+    }
+
+    UNREFERENCED(o);
+    SSL_SESSION *session = SSL_get_session(ssl);
+
+    int len, j;
+    len = i2d_SSL_SESSION(session, NULL);
+    if (len == 0) {
+        return NULL;
+    }
+
+    char id[len];
+    char *p, *temp;
+
+    p = temp = id;
+
+    j = i2d_SSL_SESSION(session, &temp);
+    if (j == 0) {
+        return NULL;
+    }
+
+    jbyteArray bArray = (*e)->NewByteArray(e, len);
+    (*e)->SetByteArrayRegion(e, bArray, 0, len, (jbyte*) p);
+    return bArray;
+}
+
 /*** End Apple API Additions ***/
 
 #else
@@ -1839,5 +1872,13 @@ TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl,
     UNREFERENCED(ssl);
     tcn_ThrowException(e, "Not implemented");
 }
+
+TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
+{
+    UNREFERENCED(o);
+    UNREFERENCED(ssl);
+    tcn_ThrowException(e, "Not implemented");
+}
+
 /*** End Apple API Additions ***/
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -602,4 +602,12 @@ public final class SSL {
      *              verification.
      */
     public static native void setVerify(long ssl, int level, int depth);
+
+    /**
+     * Returns the session of as byte array representation.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the session as byte array representation obtained via i2d_SSL_SESSION.
+     */
+    public static native byte[] getSessionId(long ssl);
 }


### PR DESCRIPTION
Motivation:

Often it is useful to be able to get a session as a byte[] representation for later re-use or storage.

Modifications:

Add SSL.getSessionId(...) which allows to retrive a byte[] representation of the session.

Result:

It's now possible to store a session for later usage.
