### PR TITLE
Add support for SSL_CTX_set_session_id_context

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1535,7 +1535,7 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
     }
 
     UNREFERENCED(o);
-    SSL_SESSION *session = SSL_get_session(ssl);
+    SSL_SESSION *session = SSL_get_session(ssl_);
 
     int len, j;
     len = i2d_SSL_SESSION(session, NULL);

--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -1160,6 +1160,24 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
     }
 }
 
+TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong ctx, jbyteArray sidCtx)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    UNREFERENCED(o);
+    TCN_ASSERT(ctx != 0);
+
+    int len = (*e)->GetArrayLength(e, sidCtx) ;
+    unsigned char buf[len];
+
+    (*e)->GetByteArrayRegion(e, sidCtx, 0, len, (jbyte*) buf);
+
+    int res = SSL_CTX_set_session_id_context(c->ctx, buf, len);
+    if (res == 1) {
+        return JNI_TRUE;
+    }
+    return JNI_FALSE;
+}
 #else
 /* OpenSSL is not supported.
  * Create empty stubs.
@@ -1462,5 +1480,12 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
     UNREFERENCED_STDARGS;
     UNREFERENCED(ctx);
     UNREFERENCED(verifier);
+}
+TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong ctx, jbyteArray sidCtx)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    UNREFERENCED(sidCtx);
+    return JNI_FALSE;
 }
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -375,4 +375,15 @@ public final class SSLContext {
      */
     public static native void setTmpECDHByCurveName(long ctx, String curveName)
             throws Exception;
+
+    /**
+     * Set the context within which session be reused (server side only)
+     * http://www.openssl.org/docs/ssl/SSL_CTX_set_session_id_context.html
+     *
+     * @param ctx Server context to use.
+     * @param sidCtx can be any kind of binary data, it is therefore possible to use e.g. the name
+     *               of the application and/or the hostname and/or service name
+     * @return {@code true} if success, {@code false} otherwise.
+     */
+    public static native boolean setSessionIdContext(long ctx, byte[] sidCtx);
 }


### PR DESCRIPTION
Motivation:

Openssl supports to set the context for which a session can be used. To support this we need to add support for SSL_CTX_set_session_id_context

Modifications:
- Implement JNI call for SSL_CTX_set_session_id_context

Result:

It's now possible to set the context for which a session can be used.
