### PR TITLE
Fix segfault when calling SSL.getCiphers() / SSL.getPeerCertChain() and ...

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1401,7 +1401,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     // Get a stack of all certs in the chain.
     STACK_OF(X509) *sk = SSL_get_peer_cert_chain(ssl_);
 
-    unsigned len = sk_num(sk);
+    int len = sk_num(sk);
     if (len <= 0) {
         // No peer certificate chain as no auth took place yet, or the auth was not successful.
         return NULL;
@@ -1609,7 +1609,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
     }
 
     STACK_OF(SSL_CIPHER) *sk = SSL_get_ciphers(ssl_);
-    unsigned len = sk_num(sk);
+    int len = sk_num(sk);
 
     if (len <= 0) {
         // No peer certificate chain as no auth took place yet, or the auth was not successful.


### PR DESCRIPTION
...no ciphers/certs are used.

Motivation:

Because of incorrect usage of unsigned we fail to detect if no ciphers/certs are used and so cause a segfault.

Modifications:
- Use int when call sk_num(...) to store the result

Result:

No more segfault
