### PR TITLE
Release memory allocated by i2d_X509(...)

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1420,6 +1420,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
         buf = NULL;
         length = i2d_X509(cert, &buf);
         if (length < 0) {
+            OPENSSL_free(buf);
             // In case of error just return an empty byte[][]
             return (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
         }
@@ -1430,6 +1431,8 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
         // Delete the local reference as we not know how long the chain is and local references are otherwise
         // only freed once jni method returns.
         (*e)->DeleteLocalRef(e, bArray);
+
+        OPENSSL_free(buf);
     }
     return array;
 }
@@ -1463,6 +1466,9 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
     // session is freed.
     // See https://www.openssl.org/docs/ssl/SSL_get_peer_certificate.html
     X509_free(cert);
+
+    OPENSSL_free(buf);
+
     return bArray;
 }
 

--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -1121,6 +1121,8 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
         if (length < 0) {
             // In case of error just return an empty byte[][]
             array = (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
+            // We need to delete the local references so we not leak memory as this method is called via callback.
+            OPENSSL_free(buf);
             break;
         }
         jbyteArray bArray = (*e)->NewByteArray(e, length);
@@ -1130,6 +1132,7 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
         // Delete the local reference as we not know how long the chain is and local references are otherwise
         // only freed once jni method returns.
         (*e)->DeleteLocalRef(e, bArray);
+        OPENSSL_free(buf);
     }
 
     const char *authMethod = SSL_authentication_method(ssl);


### PR DESCRIPTION
Motivation:

As i2d_X509(...) allocates memory we need to call OPENSSL_free(...) on the pointer.

Modifications:

Call OPENSSL_free(...) on allocated memory by i2d_X509(...) and so remove memory leak.

Result:

No more memory leak.
