### PR TITLE
Allow to obtain session as byte[]

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1635,6 +1635,26 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     return rv;
 }
 
+TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+    UNREFERENCED(o);
+    SSL_SESSION *session = SSL_get_session(ssl);
+
+    int len;
+    char *session_id;
+
+    session_id = SSL_SESSION_get_id(session, &len);
+
+    if (len == 0 || session_id == NULL) {
+        return NULL;
+    }
+
+    jbyteArray bArray = (*e)->NewByteArray(e, len);
+    (*e)->SetByteArrayRegion(e, bArray, 0, len, (jbyte*) session_id);
+    return bArray;
+}
+
 /*** End Apple API Additions ***/
 
 #else
@@ -1982,4 +2002,12 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     tcn_ThrowException(e, "Not implemented");
     return JNI_FALSE;
 }
+TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
+{
+    UNREFERENCED(o);
+    UNREFERENCED(ssl);
+    tcn_ThrowException(e, "Not implemented");
+}
+
+/*** End Apple API Additions ***/
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -641,4 +641,11 @@ public final class SSL {
     public static native boolean setCipherSuites(long ssl, String ciphers)
             throws Exception;
 
+    /**
+     * Returns the session of as byte array representation.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the session as byte array representation obtained via i2d_SSL_SESSION.
+     */
+    public static native byte[] getSessionId(long ssl);
 }


### PR DESCRIPTION
Motivation:

Often it is useful to be able to get a session as a byte[] representation for later re-use or storage.

Modifications:

Add SSL.getSessionId(...) which allows to retrive a byte[] representation of the session.

Result:

It's now possible to store a session for later usage.
