### PR TITLE
Names of native libraries to be loaded changed to load the results of netty-tcnaytive instead of original tomcats' ones

### DIFF
--- a/src/main/java/org/apache/tomcat/jni/Library.java
+++ b/src/main/java/org/apache/tomcat/jni/Library.java
@@ -24,7 +24,7 @@ package org.apache.tomcat.jni;
 public final class Library {
 
     /* Default library names */
-    private static final String [] NAMES = {"tcnative-1", "libtcnative-1"};
+    private static final String [] NAMES = {"netty-tcnative", "libnetty-tcnative", "netty-tcnative-1", "libnetty-tcnative-1"};
     /*
      * A handle to the unique Library singleton instance.
      */


### PR DESCRIPTION
Originally ntetty-tcnative was trying to load original tomact libraries and not the results of its own build.

This change was tested on linux machines and is actively used as patch in RPM. 