### PR TITLE
Fix incorrect values for SSL_OP_NO_TLSv1_1 and SSL_OP_NO_TLSv1_2

### DIFF
--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -137,8 +137,8 @@ public final class SSL {
     public static final int SSL_OP_NO_SSLv2                         = 0x01000000;
     public static final int SSL_OP_NO_SSLv3                         = 0x02000000;
     public static final int SSL_OP_NO_TLSv1                         = 0x04000000;
-    public static final int SSL_OP_NO_TLSv1_1                       = 0x08000000;
-    public static final int SSL_OP_NO_TLSv1_2                       = 0x10000000;
+    public static final int SSL_OP_NO_TLSv1_2                       = 0x08000000;
+    public static final int SSL_OP_NO_TLSv1_1                       = 0x10000000;
 
     public static final int SSL_OP_NO_TICKET                        = 0x00004000;
 


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=57432
http://svn.apache.org/viewvc?view=revision&revision=1659059