### PR TITLE
Add support for ALPN for server and client side + support for NPN client...

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1394,7 +1394,7 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS,
 
     if (ssl_ == NULL) {
         tcn_ThrowException(e, "ssl is null");
-        return 0;
+        return NULL;
     }
 
     UNREFERENCED(o);
@@ -1406,6 +1406,31 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS,
 /*** End Twitter API Additions ***/
 
 /*** Apple API Additions ***/
+
+TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
+                                                         jlong ssl /* SSL * */) {
+    // Only supported with openssl >= 1.0.2
+    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+        SSL *ssl_ = J2P(ssl, SSL *);
+        const unsigned char *proto;
+        unsigned int proto_len;
+
+        if (ssl_ == NULL) {
+            tcn_ThrowException(e, "ssl is null");
+            return NULL;
+        }
+
+        UNREFERENCED(o);
+
+        SSL_get0_alpn_selected(ssl_, &proto, &proto_len);
+        return tcn_new_stringn(e, proto, proto_len);
+    #else
+        UNREFERENCED(o);
+        UNREFERENCED(ssl);
+        return NULL;
+    #endif
+}
+
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
                                                   jlong ssl /* SSL * */)
 {
@@ -1966,6 +1991,13 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS, jlong ssl)
 /*** End Twitter 1:1 API addition ***/
 
 /*** Begin Apple 1:1 API addition ***/
+
+TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS, jlong ssl) {
+    UNREFERENCED(o);
+    UNREFERENCED(ssl);
+    tcn_ThrowException(e, "Not implemented");
+    return NULL;
+}
 
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS, jlong ssl)
 {

--- a/src/main/c/ssl_private.h
+++ b/src/main/c/ssl_private.h
@@ -210,11 +210,16 @@
 #define OCSP_STATUS_REVOKED   1
 #define OCSP_STATUS_UNKNOWN   2
 
+#define MAX_ALPN_NPN_PROTO_SIZE 65535
 
 /* ECC: make sure we have at least 1.0.0 */
 #if !defined(OPENSSL_NO_EC) && defined(TLSEXT_ECPOINTFORMAT_uncompressed)
 #define HAVE_ECC              1
 #endif
+
+
+#define SSL_SELECTOR_FAILURE_NO_ADVERTISE                       0
+#define SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL            1
 
 extern void *SSL_temp_keys[SSL_TMP_KEY_MAX];
 
@@ -268,6 +273,12 @@ struct tcn_ssl_ctxt_t {
 
     unsigned char   *next_proto_data;
     unsigned int    next_proto_len;
+    int             next_selector_failure_behavior;
+
+    /* Holds the alpn protocols, each of them prefixed with the len of the protocol */
+    unsigned char   *alpn_proto_data;
+    unsigned int    alpn_proto_len;
+    int             alpn_selector_failure_behavior;
 };
 
   
@@ -323,5 +334,7 @@ int         SSL_CTX_use_certificate_chain(SSL_CTX *, const char *, int);
 int         SSL_callback_SSL_verify(int, X509_STORE_CTX *);
 int         SSL_rand_seed(const char *file);
 int         SSL_callback_next_protos(SSL *, const unsigned char **, unsigned int *, void *);
+int         SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int,void *);
+int         SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 
 #endif /* SSL_PRIVATE_H */

--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -60,6 +60,16 @@ static apr_status_t ssl_context_cleanup(void *data)
             SSL_BIO_close(c->bio_os);
             c->bio_os = NULL;
         }
+        if (c->next_proto_data) {
+            free(c->next_proto_data);
+            c->next_proto_data = NULL;
+        }
+        c->next_proto_len = 0;
+        if (c->alpn_proto_data) {
+            free(c->alpn_proto_data);
+            c->alpn_proto_data = NULL;
+        }
+        c->alpn_proto_len = 0;
     }
     return APR_SUCCESS;
 }
@@ -831,46 +841,132 @@ cleanup:
     return rv;
 }
 
-TCN_IMPLEMENT_CALL(void, SSLContext, setNextProtos)(TCN_STDARGS, jlong ctx,
-                                                    jstring next_protos)
+// Convert protos to wire format
+static int initProtocols(JNIEnv *e, const tcn_ssl_ctxt_t *c, unsigned char **proto_data,
+            unsigned int *proto_len, jobjectArray protos) {
+    int i;
+    unsigned char *p_data;
+    // We start with allocate 128 bytes which should be good enough for most use-cases while still be pretty low.
+    // We will call realloc to increate this if needed.
+    size_t p_data_size = 128;
+    size_t p_data_len = 0;
+    jstring proto_string;
+    const char *proto_chars;
+    size_t proto_chars_len;
+    int cnt;
+
+    if (protos == NULL) {
+        // Guard against NULL protos.
+        return -1;
+    }
+
+    cnt = (*e)->GetArrayLength(e, protos);
+
+    if (cnt == 0) {
+        // if cnt is 0 we not need to continue and can just fail fast.
+        return -1;
+    }
+
+    p_data = (unsigned char *) malloc(p_data_size);
+    if (p_data == NULL) {
+        // Not enough memory?
+        return -1;
+    }
+
+    for (i = 0; i < cnt; ++i) {
+         proto_string = (jstring) (*e)->GetObjectArrayElement(e, protos, i);
+         proto_chars = (*e)->GetStringUTFChars(e, proto_string, 0);
+
+         proto_chars_len = strlen(proto_chars);
+         if (proto_chars_len > 0 && proto_chars_len <= MAX_ALPN_NPN_PROTO_SIZE) {
+            // We need to add +1 as each protocol is prefixed by it's length (unsigned char).
+            // For all except of the last one we already have the extra space as everything is
+            // delimited by ','.
+            p_data_len += 1 + proto_chars_len;
+            if (p_data_len > p_data_size) {
+                // double size
+                p_data_size <<= 1;
+                p_data = realloc(p_data, p_data_size);
+                if (p_data == NULL) {
+                    // Not enough memory?
+                    (*e)->ReleaseStringUTFChars(e, proto_string, proto_chars);
+                    break;
+                }
+            }
+            // Write the length of the protocol and then increment before memcpy the protocol itself.
+            *p_data = proto_chars_len;
+            ++p_data;
+            memcpy(p_data, proto_chars, proto_chars_len);
+            p_data += proto_chars_len;
+         }
+
+         // Release the string to prevent memory leaks
+         (*e)->ReleaseStringUTFChars(e, proto_string, proto_chars);
+    }
+
+    if (p_data == NULL) {
+        // Something went wrong so update the proto_len and return -1
+        *proto_len = 0;
+        return -1;
+    } else {
+        if (*proto_data != NULL) {
+            // Free old data
+            free(*proto_data);
+        }
+        // Decrement pointer again as we incremented it while creating the protocols in wire format.
+        p_data -= p_data_len;
+        *proto_data = p_data;
+        *proto_len = p_data_len;
+        return 0;
+    }
+}
+
+TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray next_protos,
+        jint selectorFailureBehavior)
 {
-    int i, len, start = 0;
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
-    TCN_ALLOC_CSTRING(next_protos);
 
     TCN_ASSERT(ctx != 0);
     UNREFERENCED(o);
 
-    // Convert comma separated next_protos string to wire format
-    if (J2S(next_protos)) {
-        len = (int)strlen(J2S(next_protos));
-        if (len <= 65535) {
-        c->next_proto_len = (unsigned int)(strlen(J2S(next_protos)) + 1);
-            if ((c->next_proto_data = apr_palloc(c->pool, len + 1)) != NULL) {
-                c->next_proto_len = len + 1;
-                for (i = 0; i <= len; i++) {
-                    if (i == len || J2S(next_protos)[i] == ',') {
-                        if (i - start > 255) {
-                            c->next_proto_data = NULL;
-                            c->next_proto_len = 0;
-                            break;
-                        }
-                        (c->next_proto_data)[start] = i - start;
-                        start = i + 1;
-                    } else {
-                        (c->next_proto_data)[i+1] = J2S(next_protos)[i];
-                    }
-                }
-            }
+    if (initProtocols(e, c->pool, &c->next_proto_data, &c->next_proto_len, next_protos) == 0) {
+        c->next_selector_failure_behavior = selectorFailureBehavior;
+
+        // depending on if it's client mode or not we need to call different functions.
+        if (c->mode == SSL_MODE_CLIENT)  {
+            SSL_CTX_set_next_proto_select_cb(c->ctx, SSL_callback_select_next_proto, (void *)c);
+        } else {
+            SSL_CTX_set_next_protos_advertised_cb(c->ctx, SSL_callback_next_protos, (void *)c);
         }
     }
+}
 
-    // If conversion was successful set callback function
-    if (c->next_proto_data) {
-        SSL_CTX_set_next_protos_advertised_cb(c->ctx, SSL_callback_next_protos, (void *)c);
-    }
+TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray alpn_protos,
+        jint selectorFailureBehavior)
+{
+    // Only supported with openssl >= 1.0.2
+    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+        tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
-    TCN_FREE_CSTRING(next_protos);
+        TCN_ASSERT(ctx != 0);
+        UNREFERENCED(o);
+
+        if (initProtocols(e, c->pool, &c->alpn_proto_data, &c->alpn_proto_len, alpn_protos) == 0) {
+            c->alpn_selector_failure_behavior = selectorFailureBehavior;
+
+            // depending on if it's client mode or not we need to call different functions.
+            if (c->mode == SSL_MODE_CLIENT)  {
+                SSL_CTX_set_alpn_protos(c->ctx, c->alpn_proto_data, c->alpn_proto_len);
+            } else {
+                SSL_CTX_set_alpn_select_cb(c->ctx, SSL_callback_alpn_select_proto, (void *) c);
+
+            }
+        }
+    #else
+        UNREFERENCED_STDARGS;
+        UNREFERENCED(ctx);
+        UNREFERENCED(alpn_protos);
+    #endif
 }
 
 TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheMode)(TCN_STDARGS, jlong ctx, jlong mode)
@@ -1384,14 +1480,22 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificate)(TCN_STDARGS, jlong ctx,
     return JNI_FALSE;
 }
 
-TCN_IMPLEMENT_CALL(void, SSLContext, setNextProtos)(TCN_STDARGS, jlong ctx,
-                                                    jstring next_protos)
+TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray next_protos,
+        jint selectorFailureBehavior)
 {
     UNREFERENCED_STDARGS;
     UNREFERENCED(ctx);
     UNREFERENCED(next_protos);
 }
 
+
+TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray alpn_protos,
+        jint selectorFailureBehavior)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    UNREFERENCED(alpn_protos);
+}
 
 TCN_IMPLEMENT_CALL(jlong, SSLContext, setSessionCacheMode)(TCN_STDARGS, jlong ctx, jlong mode)
 {

--- a/src/main/c/sslutils.c
+++ b/src/main/c/sslutils.c
@@ -749,6 +749,79 @@ int SSL_callback_next_protos(SSL *ssl, const unsigned char **data,
     return SSL_TLSEXT_ERR_OK;
 }
 
+/* The code here is inspired by nghttp2
+ *
+ * See https://github.com/tatsuhiro-t/nghttp2/blob/ae0100a9abfcf3149b8d9e62aae216e946b517fb/src/shrpx_ssl.cc#L244 */
+int select_next_proto(SSL *ssl, unsigned char **out, unsigned char *outlen,
+        const unsigned char *in, unsigned int inlen, unsigned char *supported_protos, int supported_protos_len, int failure_behavior) {
+
+    int i = 0;
+    unsigned char target_proto_len;
+    unsigned char *p;
+    unsigned char *end;
+    unsigned char *proto;
+    unsigned char proto_len;
+
+    while (i < inlen) {
+        target_proto_len = *in;
+        ++in;
+
+        p = supported_protos;
+        end = supported_protos + supported_protos_len;
+
+        while (p < end) {
+            proto = p + 1;
+            proto_len = *p;
+
+            if (proto + proto_len <= end && target_proto_len == proto_len &&
+                    memcmp(in, proto, proto_len) == 0) {
+
+                // We found a match, so set the output and return with OK!
+                *out = proto;
+                *outlen = proto_len;
+
+                return SSL_TLSEXT_ERR_OK;
+            }
+            // Move on to the next protocol.
+            p += 1 + proto_len;
+        }
+
+        // increment len and pointers.
+        i += target_proto_len;
+        in += target_proto_len;
+    }
+
+    if (failure_behavior == SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL) {
+         // There were no match but we just select our last protocol and hope the other peer support it.
+         //
+         // decrement the pointer again so the pointer points to the start of the protocol.
+         p -= proto_len;
+         *out = p;
+         *outlen = proto_len;
+         return SSL_TLSEXT_ERR_OK;
+    }
+    // TODO: OpenSSL currently not support to fail with fatal error. Once this changes we can also support it here.
+    //       Issue https://github.com/openssl/openssl/issues/188 has been created for this.
+    // Nothing matched so not select anything and just accept.
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
+int SSL_callback_select_next_proto(SSL *ssl, unsigned char **out, unsigned char *outlen,
+                         const unsigned char *in, unsigned int inlen,
+                         void *arg) {
+    tcn_ssl_ctxt_t *ssl_ctxt = arg;
+    return select_next_proto(ssl, out, outlen, in, inlen, ssl_ctxt->next_proto_data, ssl_ctxt->next_proto_len, ssl_ctxt->next_selector_failure_behavior);
+}
+
+// Only supported with openssl >= 1.0.2
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+int SSL_callback_alpn_select_proto(SSL* ssl, const unsigned char **out, unsigned char *outlen,
+        const unsigned char *in, unsigned int inlen, void *arg) {
+    tcn_ssl_ctxt_t *ssl_ctxt = arg;
+    return select_next_proto(ssl, out, outlen, in, inlen, ssl_ctxt->alpn_proto_data, ssl_ctxt->alpn_proto_len, ssl_ctxt->alpn_selector_failure_behavior);
+}
+#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
+
 #ifdef HAVE_OPENSSL_OCSP
 
 /* Function that is used to do the OCSP verification */

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -231,6 +231,9 @@ public final class SSL {
     public static final long SSL_SESS_CACHE_OFF = 0x0000;
     public static final long SSL_SESS_CACHE_SERVER = 0x0002;
 
+    public static final int SSL_SELECTOR_FAILURE_NO_ADVERTISE = 0;
+    public static final int SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL = 1;
+
     /* Return OpenSSL version number */
     public static native int version();
 
@@ -562,7 +565,7 @@ public final class SSL {
 
     /**
      * SSL_get0_next_proto_negotiated
-     * @param ssl the SSL isntance (SSL *)
+     * @param ssl the SSL instance (SSL *)
      * @return
      */
     public static native String getNextProtoNegotiated(long ssl);
@@ -570,6 +573,13 @@ public final class SSL {
     /*
      * End Twitter API Additions
      */
+
+    /**
+     * SSL_get0_alpn_selected
+     * @param ssl the SSL instance (SSL *)
+     * @return
+     */
+    public static native String getAlpnSelected(long ssl);
 
     /**
      * Get the peer certificate chain or {@code null} if non was send.

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -363,10 +363,33 @@ public final class SSLContext {
     /**
      * Set next protocol for next protocol negotiation extension
      * @param ctx Server context to use.
-     * @param next_protos comma deliniated list of protocols in priority order
+     * @param nextProtos comma delimited list of protocols in priority order
+     *
+     * @deprecated use {@link #setNpnProtos(long, String[], int)}
      */
-    public static native void setNextProtos(long ctx, String next_protos);
-    
+    @Deprecated
+    public static void setNextProtos(long ctx, String nextProtos) {
+        setNpnProtos(ctx, nextProtos.split(","), SSL.SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL);
+    }
+
+    /**
+     * Set next protocol for next protocol negotiation extension
+     * @param ctx Server context to use.
+     * @param nextProtos protocols in priority order
+     * @param selectorFailureBehavior see {@link SSL#SSL_SELECTOR_FAILURE_NO_ADVERTISE}
+     *                                and {@link SSL#SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL}
+     */
+    public static native void setNpnProtos(long ctx, String[] nextProtos, int selectorFailureBehavior);
+
+    /**
+     * Set application layer protocol for application layer protocol negotiation extension
+     * @param ctx Server context to use.
+     * @param alpnProtos protocols in priority order
+     * @param selectorFailureBehavior see {@link SSL#SSL_SELECTOR_FAILURE_NO_ADVERTISE}
+     *                                and {@link SSL#SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL}
+     */
+    public static native void setAlpnProtos(long ctx, String[] alpnProtos, int selectorFailureBehavior);
+
     /**
      * Set DH parameters
      * @param ctx Server context to use.


### PR DESCRIPTION
... side

Motivation:

There is currently no support for ALPN, even now that openssl 1.0.2 supports it. This make it impossible to use it for example with HTTP2.
NPN was only supported when using in server mode, while we support client mode in general now.

Modification:

- Add support for ALPN support when openssl >= 1.0.2 (server and client)
- Add support for NPN when in client mode
- Respect failure behaviour

Result:

It's now possible to use ALPN / NPN on server and client side