### PR TITLE
Fix memory leak due not release global reference when using a verifier

### DIFF
--- a/src/main/c/ssl_private.h
+++ b/src/main/c/ssl_private.h
@@ -268,6 +268,10 @@ struct tcn_ssl_ctxt_t {
 
     unsigned char   *next_proto_data;
     unsigned int    next_proto_len;
+
+    /* certificate verifier callback */
+    jobject verifier;
+    jmethodID verifier_method;
 };
 
   


### PR DESCRIPTION
Motivation:

We miss to delete the global reference to the verifier when free the ssl context.
This leads to a small memory leak,

Modifications:

- Store the reference to the verifier in th tcn_ssl_ctxt_t structure
- Correctly call DeleteGlobalRef when the ssl context is destroyed

Result:

No more memory leak when a verifier is used and the ssl context is destroyed.