### PR TITLE
Remove duplicated definition

### DIFF
--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -1523,13 +1523,6 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, sessionMisses)(TCN_STDARGS, jlong ctx)
     return 0;
 }
 
-TCN_IMPLEMENT_CALL(jlong, SSLContext, sessionHits)(TCN_STDARGS, jlong ctx)
-{
-    UNREFERENCED_STDARGS;
-    UNREFERENCED(ctx);
-    return 0;
-}
-
 TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys)(TCN_STDARGS, jlong ctx, jbyteArray keys)
 {
     UNREFERENCED_STDARGS;


### PR DESCRIPTION
Motivation:

By mistake we duplicated the definition of a function.

Modifications:

Remove duplicate and so allow the compilation to sucess.

Result:

Be able to compile if HAVE_OPENSSL is not set