### PR TITLE
Shade platform specific libraries into a single jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,14 @@
   <name>Netty/TomcatNative</name>
   <url>https://github.com/netty/netty-tcnative/</url>
   <description>
-    A Mavenized fork of Tomcat Native which incorporates various patches
+    A Mavenized fork of Tomcat Native which incorporates various patches.
+
+    Building this artifact produces a native library with a classifier matching the
+    os/arch of the build machine. The Java JNI bindings are exported with the 'java' classifier.
+
+    Prefer specifying a dependency on the shaded artifact (no classifier) which contains
+    the java bindings and prebuilt native libraries for all supported platforms.
+
   </description>
 
   <scm>
@@ -135,16 +142,41 @@
             </goals>
             <configuration>
               <target>
-                <copy todir="${nativeJarWorkdir}">
-                  <zipfileset src="${defaultJarFile}" />
-                </copy>
                 <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
-                  <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                  <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/${os.detected.classifier}/\1" />
                 </copy>
-                <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                <jar destfile="${nativeJarFile}" manifest="${project.build.directory}/classes/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/INDEX.LIST"/>
                 <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
               </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Produce a jar with a platfrom-specific classifier. -->
+            <id>default-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>${os.detected.classifier}</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Also produce a jar with 'java' classifier. This can be built on any platform. -->
+            <id>java-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>java</classifier>
             </configuration>
           </execution>
         </executions>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.0.18.Final</version>
+  </parent>
+  <artifactId>netty-tcnative</artifactId>
+  <version>1.1.32.Fork2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <properties>
+    <netty-tcnative.version>1.1.32.Fork2-SNAPSHOT</netty-tcnative.version>
+  </properties>
+
+  <name>Netty/TomcatNative</name>
+  <url>https://github.com/netty/netty-tcnative/</url>
+  <description>
+    A Mavenized fork of Tomcat Native which incorporates various patches.
+
+    This shaded jar contains the JNI Java bindings and the prebuilt native libraries for
+    all supported platforms.
+  </description>
+
+  <scm>
+    <url>https://github.com/netty/netty-tcnative</url>
+    <connection>scm:git:git://github.com/netty/netty-tcnative.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/netty/netty-tcnative.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <classifier>java</classifier>
+      <version>${netty-tcnative.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <classifier>osx-x86_64</classifier>
+      <version>${netty-tcnative.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <version>${netty-tcnative.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <classifier>windows-x86_64</classifier>
+      <version>${netty-tcnative.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createSourcesJar>true</createSourcesJar>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Override the parent POM's configuration. -->
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <arguments>-P restricted-release,sonatype-oss-release</arguments>
+          <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
- Split architecture specific libraries into their own artifacts with
  os-arch classifiers.
- Store libs under META-INF/native/${os.classifier}/
- Creates a "java" classifier for the Java JNI bindings
- Shade all supported platforms together with Java source for the main
  artifact.

https://github.com/netty/netty-tcnative/issues/24