### PR TITLE
Use weak definitions to make it usuable with openssl 1.0.1 and openssl 1...

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1409,8 +1409,18 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS,
 
 TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
                                                          jlong ssl /* SSL * */) {
-    // Only supported with openssl >= 1.0.2
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+    // Use weak linking with GCC as this will alow us to run the same packaged version with multiple
+    // version of openssl.
+    #if defined(__GNUC__) || defined(__GNUG__)
+        if (!SSL_get0_alpn_selected) {
+            UNREFERENCED(o);
+            UNREFERENCED(ssl);
+            return NULL;
+        }
+    #endif
+
+    // We can only support it when either use openssl version >= 1.0.2 or GCC as this way we can use weak linking
+    #if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(__GNUC__) || defined(__GNUG__)
         SSL *ssl_ = J2P(ssl, SSL *);
         const unsigned char *proto;
         unsigned int proto_len;

--- a/src/main/c/ssl_private.h
+++ b/src/main/c/ssl_private.h
@@ -341,4 +341,16 @@ int         SSL_callback_next_protos(SSL *, const unsigned char **, unsigned int
 int         SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int,void *);
 int         SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 
+
+#if defined(__GNUC__) || defined(__GNUG__)
+    // only supported with GCC, this will be used to support different openssl versions at the same time.
+    extern int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
+           unsigned protos_len) __attribute__((weak));
+    extern void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx, int (*cb) (SSL *ssl, const unsigned char **out,
+           unsigned char *outlen, const unsigned char *in, unsigned int inlen,
+           void *arg), void *arg) __attribute__((weak));
+    extern void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
+           unsigned *len) __attribute__((weak));
+#endif
+
 #endif /* SSL_PRIVATE_H */

--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -955,8 +955,18 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos)(TCN_STDARGS, jlong ctx, jobje
 TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray alpn_protos,
         jint selectorFailureBehavior)
 {
-    // Only supported with openssl >= 1.0.2
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+    // Only supported with GCC
+    #if defined(__GNUC__) || defined(__GNUG__)
+        if (!SSL_CTX_set_alpn_protos || !SSL_CTX_set_alpn_select_cb) {
+            UNREFERENCED_STDARGS;
+            UNREFERENCED(ctx);
+            UNREFERENCED(alpn_protos);
+            return;
+        }
+    #endif
+
+    // We can only support it when either use openssl version >= 1.0.2 or GCC as this way we can use weak linking
+    #if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(__GNUC__) || defined(__GNUG__)
         tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
         TCN_ASSERT(ctx != 0);


### PR DESCRIPTION
....0.2

Motivation:

To be able to support alpn when its avaible in the used openssl version we should use weak definitions.

Modifications:

Use weak definations for the needed openssl calls

Results:

Can now use alpn if supported on the openssl version while still work correctly if not avaible.