### PR TITLE
[#36] Enforce usage maven 3.1.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,24 @@
           <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-tools</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.1.1,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Motivation:

When using maven < 3.1 you see the follow exception:

Exception in thread "main" java.lang.NoClassDefFoundError: org/eclipse/aether/RepositorySystemSession

Modifications:

Enforce using maven 3.1.1+ so the user not get the "cryptic" exception

Result:

Better expierence for developers that try to build netty-tcnative.