### PR TITLE
Allow to retrieve the number of renegations for a ssl instance

### DIFF
--- a/src/main/c/ssl_private.h
+++ b/src/main/c/ssl_private.h
@@ -283,6 +283,9 @@ struct tcn_ssl_ctxt_t {
     unsigned char   *alpn_proto_data;
     unsigned int    alpn_proto_len;
     int             alpn_selector_failure_behavior;
+
+    /* Number of handshakes */
+    int             handshakeCount;
 };
 
   

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -683,4 +683,12 @@ public final class SSL {
      * @return the session as byte array representation obtained via SSL_SESSION_get_id.
      */
     public static native byte[] getSessionId(long ssl);
+
+    /**
+     * Returns the number of handshakes done for this SSL instance. This also includes renegations.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the number of handshakes done for this SSL instance.
+     */
+    public static native int getHandshakeCount(long ssl);
 }


### PR DESCRIPTION
Motivation:

To allow rejection client initiated renegotiations we need a way to obtain the number of previous done renegations.

Modifications:

Add SSL.getRenegations(...).

Result:

It's now possible to obtain the number of renegations.