### PR TITLE
Allow to correctly retrieve the number of handshakes for a ssl instance

### DIFF
--- a/src/main/c/ssl_private.h
+++ b/src/main/c/ssl_private.h
@@ -283,9 +283,6 @@ struct tcn_ssl_ctxt_t {
     unsigned char   *alpn_proto_data;
     unsigned int    alpn_proto_len;
     int             alpn_selector_failure_behavior;
-
-    /* Number of handshakes */
-    int             handshakeCount;
 };
 
   
@@ -319,9 +316,13 @@ typedef struct {
 /*
  *  Additional Functions
  */
-void        SSL_init_app_data2_idx(void);
+void        SSL_init_app_data2_3_idx(void);
+// The app_data2 is used to store the tcn_ssl_ctxt_t pointer for the SSL instance.
 void       *SSL_get_app_data2(SSL *);
 void        SSL_set_app_data2(SSL *, void *);
+// The app_data3 is used to store the handshakeCount pointer for the SSL instance.
+void       *SSL_get_app_data3(SSL *);
+void        SSL_set_app_data3(SSL *, void *);
 int         SSL_password_prompt(tcn_pass_cb_t *);
 int         SSL_password_callback(char *, int, int, void *);
 void        SSL_BIO_close(BIO *);

--- a/src/main/c/sslutils.c
+++ b/src/main/c/sslutils.c
@@ -55,8 +55,8 @@ static int ssl_ocsp_request(X509 *cert, X509 *issuer);
  * SSL_get_ex_new_index() is called, so we _must_ do this at startup.
  */
 static int SSL_app_data2_idx = -1;
-
-void SSL_init_app_data2_idx(void)
+static int SSL_app_data3_idx = -1;
+void SSL_init_app_data2_3_idx(void)
 {
     int i;
 
@@ -64,13 +64,22 @@ void SSL_init_app_data2_idx(void)
         return;
     }
 
-    /* we _do_ need to call this twice */
+    /* we _do_ need to call this two times */
     for (i = 0; i <= 1; i++) {
         SSL_app_data2_idx =
             SSL_get_ex_new_index(0,
                                  "Second Application Data for SSL",
                                  NULL, NULL, NULL);
     }
+
+    if (SSL_app_data3_idx > -1) {
+        return;
+    }
+
+    SSL_app_data3_idx =
+            SSL_get_ex_new_index(0,
+                                 "Third Application Data for SSL",
+                                  NULL, NULL, NULL);
 }
 
 void *SSL_get_app_data2(SSL *ssl)
@@ -82,6 +91,16 @@ void SSL_set_app_data2(SSL *ssl, void *arg)
 {
     SSL_set_ex_data(ssl, SSL_app_data2_idx, (char *)arg);
     return;
+}
+
+void *SSL_get_app_data3(SSL *ssl)
+{
+    return SSL_get_ex_data(ssl, SSL_app_data3_idx);
+}
+
+void SSL_set_app_data3(SSL *ssl, void *arg)
+{
+    SSL_set_ex_data(ssl, SSL_app_data3_idx, arg);
 }
 
 /* Simple echo password prompting */


### PR DESCRIPTION
Motivation:

In commit 1cd48327e711a230e325f74d3d09873d70043edd SSL.getHandshakeCount(...) was introduced. Unfortunally the implementation was not correct and so the returned number did not match the reality.

Modifications:

- Store the handshakeCount per SSL instance and so fix the implemented

Result:

SSL.getHandshakeCount(...) returns the correct number now.