### PR TITLE
Add SSL.clearError() which allows to clear all pending errors from th…

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1781,6 +1781,13 @@ TCN_IMPLEMENT_CALL(jint, SSL, getHandshakeCount)(TCN_STDARGS, jlong ssl)
     return 0;
 }
 
+
+TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
+{
+    UNREFERENCED(o);
+    ERR_clear_error();
+}
+
 /*** End Apple API Additions ***/
 
 #else
@@ -2154,5 +2161,12 @@ TCN_IMPLEMENT_CALL(jint, SSL, getHandshakeCount)(TCN_STDARGS, jlong ssl)
     UNREFERENCED(ssl);
     tcn_ThrowException(e, "Not implemented");
 }
+
+TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
+{
+    UNREFERENCED(o);
+    tcn_ThrowException(e, "Not implemented");
+}
+
 /*** End Apple API Additions ***/
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -691,4 +691,9 @@ public final class SSL {
      * @return the number of handshakes done for this SSL instance.
      */
     public static native int getHandshakeCount(long ssl);
+
+    /**
+     * Clear all the errors from the error queue that OpenSSL encountered on this thread.
+     */
+    public static native void clearError();
 }


### PR DESCRIPTION
…e threads error queue.

Motivation:

ERR_clear_error() needs to be called before a SSL operation if a failure was detected before. Otherwise it may report incorrect results when calling SSL_get_error(...)

Modifications:

Add SSL.clearError()

Result:

It's now possible to clear the error queue.