### PR TITLE
Fix segfault when SSL.getSessionId() is called and no SESSION exists.

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1752,9 +1752,13 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
         return NULL;
     }
     UNREFERENCED(o);
-    session = SSL_get_session(ssl);
-    session_id = SSL_SESSION_get_id(session, &len);
 
+    session = SSL_get_session(ssl_);
+    if (session == NULL) {
+        return NULL;
+    }
+
+    session_id = SSL_SESSION_get_id(session, &len);
     if (len == 0 || session_id == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Motivation:

Due a missing NULL check a segfault was produced when try to call SSL.getSessionId() while not SESSION eists.

Modifications:

Add missing NULL check.

Result:

No more segfault possible.