### PR TITLE
Allow to set certificate and certificate chain via BIO.

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1043,6 +1043,21 @@ static BIO_METHOD *BIO_jbs()
     return(&jbs_methods);
 }
 
+
+TCN_IMPLEMENT_CALL(jlong, SSL, newMemBIO)(TCN_STDARGS)
+{
+    BIO *bio = NULL;
+
+    UNREFERENCED(o);
+
+    // TODO: Use BIO_s_secmem() once included in stable release
+    if ((bio = BIO_new(BIO_s_mem())) == NULL) {
+        tcn_ThrowException(e, "Create BIO failed");
+        return (jlong) NULL;
+    }
+    return P2J(bio);
+}
+
 TCN_IMPLEMENT_CALL(jlong, SSL, newBIO)(TCN_STDARGS, jlong pool,
                                        jobject callback)
 {
@@ -1082,6 +1097,7 @@ TCN_IMPLEMENT_CALL(jlong, SSL, newBIO)(TCN_STDARGS, jlong pool,
 init_failed:
     return 0;
 }
+
 
 TCN_IMPLEMENT_CALL(jint, SSL, closeBIO)(TCN_STDARGS, jlong bio)
 {
@@ -1871,6 +1887,12 @@ TCN_IMPLEMENT_CALL(jlong, SSL, newBIO)(TCN_STDARGS, jlong pool,
     UNREFERENCED_STDARGS;
     UNREFERENCED(pool);
     UNREFERENCED(callback);
+    return 0;
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSL, newMemBIO)(TCN_STDARGS)
+{
+    UNREFERENCED_STDARGS;
     return 0;
 }
 

--- a/src/main/c/ssl_private.h
+++ b/src/main/c/ssl_private.h
@@ -350,6 +350,7 @@ RSA        *SSL_callback_tmp_RSA(SSL *, int, int);
 DH         *SSL_callback_tmp_DH(SSL *, int, int);
 void        SSL_callback_handshake(const SSL *, int, int);
 int         SSL_CTX_use_certificate_chain(SSL_CTX *, const char *, int);
+int         SSL_CTX_use_certificate_chain_bio(SSL_CTX *, BIO *, int);
 int         SSL_callback_SSL_verify(int, X509_STORE_CTX *);
 int         SSL_rand_seed(const char *file);
 int         SSL_callback_next_protos(SSL *, const unsigned char **, unsigned int *, void *);

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -319,6 +319,12 @@ public final class SSL {
             throws Exception;
 
     /**
+     * Initialize new in-memory BIO that is located in the secure heap.
+     * @return New BIO handle
+     */
+    public static native long newMemBIO() throws Exception;
+
+    /**
      * Close BIO and dereference callback object
      * @param bio BIO to close and destroy.
      * @return APR Status code

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -186,6 +186,28 @@ public final class SSLContext {
      */
     public static native boolean setCertificateChainFile(long ctx, String file,
                                                          boolean skipfirst);
+    /**
+     * Set BIO of PEM-encoded Server CA Certificates
+     * <p>
+     * This directive sets the optional all-in-one file where you can assemble the
+     * certificates of Certification Authorities (CA) which form the certificate
+     * chain of the server certificate. This starts with the issuing CA certificate
+     * of of the server certificate and can range up to the root CA certificate.
+     * Such a file is simply the concatenation of the various PEM-encoded CA
+     * Certificate files, usually in certificate chain order.
+     * <p>
+     * But be careful: Providing the certificate chain works only if you are using
+     * a single (either RSA or DSA) based server certificate. If you are using a
+     * coupled RSA+DSA certificate pair, this will work only if actually both
+     * certificates use the same certificate chain. Otherwsie the browsers will be
+     * confused in this situation.
+     * @param ctx Server or Client context to use.
+     * @param bio BIO of PEM-encoded Server CA Certificates.
+     * @param skipfirst Skip first certificate if chain file is inside
+     *                  certificate file.
+     */
+    public static native boolean setCertificateChainBio(long ctx, long bio,
+                                                         boolean skipfirst);
 
     /**
      * Set Certificate
@@ -213,6 +235,32 @@ public final class SSLContext {
                                                 String key, String password,
                                                 int idx)
         throws Exception;
+
+    /**
+     * Set Certificate
+     * <br>
+     * Point setCertificate at a PEM encoded certificate stored in a BIO. If
+     * the certificate is encrypted, then you will be prompted for a
+     * pass phrase.  Note that a kill -HUP will prompt again. A test
+     * certificate can be generated with `make certificate' under
+     * built time. Keep in mind that if you've both a RSA and a DSA
+     * certificate you can configure both in parallel (to also allow
+     * the use of DSA ciphers, etc.)
+     * <br>
+     * If the key is not combined with the certificate, use key param
+     * to point at the key file.  Keep in mind that if
+     * you've both a RSA and a DSA private key you can configure
+     * both in parallel (to also allow the use of DSA ciphers, etc.)
+     * @param ctx Server or Client context to use.
+     * @param certBio Certificate BIO.
+     * @param keyBio Private Key BIO to use if not in cert.
+     * @param password Certificate password. If null and certificate
+     *                 is encrypted, password prompt will be displayed.
+     * @param idx Certificate index SSL_AIDX_RSA or SSL_AIDX_DSA.
+     */
+    public static native boolean setCertificateBio(long ctx, long certBio,
+                                                long keyBio, String password,
+                                                int idx) throws Exception;
 
     /**
      * Set the size of the internal session cache.


### PR DESCRIPTION
Motiviation:

It's useful to be able to set the certificate and certificate chain via a BIO and not be limited by the need to have it stored in the fs.

Modification:

- Add methods so its possible to set the certificate and certifcate chain via a BIO
- Add method which allows to create a in-memory BIO

Result:

It's now possible to also configure SSLContext via BIOs.