### PR TITLE
Fix double freeing of BIO

### DIFF
--- a/src/main/c/sslutils.c
+++ b/src/main/c/sslutils.c
@@ -463,7 +463,6 @@ int SSL_CTX_use_certificate_chain_bio(SSL_CTX *ctx, BIO *bio,
     /* optionally skip a leading server certificate */
     if (skipfirst) {
         if ((x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL)) == NULL) {
-            BIO_free(bio);
             return -1;
         }
         X509_free(x509);


### PR DESCRIPTION
Motivation:

Due an failure we called BIO_free(...) multiple times on a BIO on a failure.

Modifications:

Remove BIO_free(...) call.

Result:

No double free.