### PR TITLE
BoringSSL Updates

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -665,7 +665,7 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
         TCN_FREE_CSTRING(engine);
         return (jint)APR_SUCCESS;
     }
-#ifndef OPENSSL_IS_BORINGSSL
+
     if (SSLeay() < 0x0090700L) {
         TCN_FREE_CSTRING(engine);
         tcn_ThrowAPRException(e, APR_EINVAL);
@@ -673,11 +673,13 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
         return (jint)APR_EINVAL;
     }
 
+#ifndef OPENSSL_IS_BORINGSSL
     /* We must register the library in full, to ensure our configuration
      * code can successfully test the SSL environment.
      */
     CRYPTO_malloc_init();
 #endif
+
     ERR_load_crypto_strings();
     SSL_load_error_strings();
     SSL_library_init();

--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -1412,23 +1412,21 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys)(TCN_STDARGS, jlong ct
  * https://android.googlesource.com/platform/external/openssl/+/master/patches/0003-jsse.patch
  */
 const char* SSL_CIPHER_authentication_method(const SSL_CIPHER* cipher){
+#ifndef OPENSSL_IS_BORINGSSL
     switch (cipher->algorithm_mkey)
         {
     case SSL_kRSA:
         return SSL_TXT_RSA;
     case SSL_kDHr:
         return SSL_TXT_DH "_" SSL_TXT_RSA;
-#ifndef OPENSSL_IS_BORINGSSL
+
     case SSL_kDHd:
         return SSL_TXT_DH "_" SSL_TXT_DSS;
-#endif
     case SSL_kEDH:
         switch (cipher->algorithm_auth)
             {
-#ifndef OPENSSL_IS_BORINGSSL
         case SSL_aDSS:
             return "DHE_" SSL_TXT_DSS;
-#endif
         case SSL_aRSA:
             return "DHE_" SSL_TXT_RSA;
         case SSL_aNULL:
@@ -1436,10 +1434,8 @@ const char* SSL_CIPHER_authentication_method(const SSL_CIPHER* cipher){
         default:
             return "UNKNOWN";
             }
-#ifndef OPENSSL_IS_BORINGSSL
     case SSL_kKRB5:
         return SSL_TXT_KRB5;
-#endif
     case SSL_kECDHr:
         return SSL_TXT_ECDH "_" SSL_TXT_RSA;
     case SSL_kECDHe:
@@ -1459,6 +1455,10 @@ const char* SSL_CIPHER_authentication_method(const SSL_CIPHER* cipher){
     default:
         return "UNKNOWN";
     }
+#else
+    return SSL_CIPHER_get_kx_name(cipher);
+#endif
+
 }
 
 static const char* SSL_authentication_method(const SSL* ssl) {


### PR DESCRIPTION
BoringSSL Updates

Motivation:
Some NOOP methods have been added to BoringSSL to reduce the need for conditional compile macros. SSL_CIPHER_get_kx_name should also be used instead of manually contructing the names.

Modifications:
- Use SSL_CIPHER_get_kx_name
- Remove conditional compile time macros where no longer needed

Result:
More correct code with less ifdefs.