### PR TITLE
Upgrade os-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.2.3.Final</version>
+        <version>1.3.0.Final</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

We need to use the new os-maven-plugin to be able to release for different flavors of linux at the same time.

Modifications:

Upgrade plugin.

Result:

Be able to release for multiple linux flavors.