### PR TITLE
Use OpenSSL methods for version rather than macros

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -270,13 +270,13 @@ static int ssl_tmp_key_init_dh(int bits, int idx)
 TCN_IMPLEMENT_CALL(jint, SSL, version)(TCN_STDARGS)
 {
     UNREFERENCED_STDARGS;
-    return OPENSSL_VERSION_NUMBER;
+    return (jint) SSLeay();
 }
 
 TCN_IMPLEMENT_CALL(jstring, SSL, versionString)(TCN_STDARGS)
 {
     UNREFERENCED(o);
-    return AJP_TO_JSTRING(OPENSSL_VERSION_TEXT);
+    return AJP_TO_JSTRING(SSLeay_version(SSLEAY_VERSION));
 }
 
 /*


### PR DESCRIPTION
Motivation:

Netty's test for ALPN support in OpenSSL is dependent on
the `version()` method of tcnative.  However, this method
is currently using the macro OPENSSL_VERSION_NUMBER, which will
always return the version of OpenSSL that tcnative was built
against.  Need to change this so that version indicates the
runtime version of OpenSSL.

Modifications:

Changed the `version` and `versionString` methods to use the
OpenSSL methods `SSLeay` and `SSLeay_version`, respectively.

Result:

tcnative now indicates the OpenSSL version used at runtime.

Fixes #58