### PR TITLE
Generate custom classifier for fedora

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
                   <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                 </copy>
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+                <attachartifact file="${nativeJarFile}" classifier="${classifier_to_use}" type="jar" />
               </target>
             </configuration>
           </execution>
@@ -173,6 +173,33 @@
                 </requireMavenVersion>
               </rules>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <!--
+          Fedora-based systems use a different soname for OpenSSL than other linux distributions.
+          Use a custom classifier ending in "-fedora" when building on fedora-based systems.
+        -->
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <condition property="classifier_to_use"
+                           value="${os.detected.classifier}-fedora"
+                           else="${os.detected.classifier}">
+                  <isset property="os.detected.release.like.fedora"/>
+                </condition>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Motivation:

Fedora-based systems are the oddball out WRT OpenSSL's soname. When building on fedora-based systems, generate a custom classifier to differentiate it from other linux distributions.

Modifications:

Modified the pom.xml to use a custom classifier for fedora-like systems ending in `-fedora`.

Result:

The build automatically builds a different artifact for fedora-like systems.