### PR TITLE
Upgrade to latest os-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.3.0.Final</version>
+        <version>1.4.0.Final</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

A new version of the os-maven-plugin was released.

Modifications:

Upgrade to 1.4.0

Result:

Using latest release