### PR TITLE
Correctly validate session keys

### DIFF
--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -1331,7 +1331,7 @@ static int ssl_tlsext_ticket_key_cb(SSL *s, unsigned char key_name[16], unsigned
     }
 }
 
-TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys)(TCN_STDARGS, jlong ctx, jbyteArray keys)
+TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys0)(TCN_STDARGS, jlong ctx, jbyteArray keys)
 {
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
     jbyte* b;
@@ -1339,16 +1339,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys)(TCN_STDARGS, jlong ct
     tcn_ssl_ticket_key_t* ticket_keys;
     int i;
     int cnt;
-
-    if (((*e)->GetArrayLength(e, keys) % SSL_SESSION_TICKET_KEY_SIZE) != 0) {
-        if (c->bio_os) {
-            BIO_printf(c->bio_os, "[ERROR] Session ticket keys provided were wrong size.");
-        }
-        else {
-            fprintf(stderr, "[ERROR] Session ticket keys provided were wrong size.");
-        }
-        exit(1);
-    }
 
     cnt = (*e)->GetArrayLength(e, keys) / SSL_SESSION_TICKET_KEY_SIZE;
     b = (*e)->GetByteArrayElements(e, keys, NULL);
@@ -1906,7 +1896,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, sessionMisses)(TCN_STDARGS, jlong ctx)
     return 0;
 }
 
-TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys)(TCN_STDARGS, jlong ctx, jbyteArray keys)
+TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys0)(TCN_STDARGS, jlong ctx, jbyteArray keys)
 {
     UNREFERENCED_STDARGS;
     UNREFERENCED(ctx);

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -328,14 +328,23 @@ public final class SSLContext {
             dstCurPos += SessionTicketKey.HMAC_KEY_SIZE;
             System.arraycopy(key.getAesKey(), 0, binaryKeys, dstCurPos, SessionTicketKey.AES_KEY_SIZE);
         }
-        setSessionTicketKeys(ctx, binaryKeys);
+        setSessionTicketKeys0(ctx, binaryKeys);
     }
 
     /**
      * Set TLS session keys. This allows us to share keys across TFEs.
      */
     @Deprecated
-    public static native void setSessionTicketKeys(long ctx, byte[] keys);
+    public static void setSessionKeys(long ctx, byte[] keys) {
+        if (keys.length % SessionTicketKey.TICKET_KEY_SIZE != 0) {
+            throw new IllegalArgumentException("Session ticket keys provided were wrong size. keys.length % " + SessionTicketKey.TICKET_KEY_SIZE + " must be 0");
+        }
+        setSessionTicketKeys0(ctx, keys);
+    }
+    /**
+     * Set TLS session keys. This allows us to share keys across TFEs.
+     */
+    private static native void setSessionTicketKeys0(long ctx, byte[] keys);
 
     /**
      * Set File and Directory of concatenated PEM-encoded CA Certificates


### PR DESCRIPTION
Motivation:

If the user passed in an array that has the wrong length for session keys we failed and exist the program. This makes no sense as this will just crash the JVM. We should better validate and throw an IllegalArgumentException in this case.

Modifications:

- Move the validation to the java code
- throw IllegalArgumentException on invalid array length.

Result:

Not crashing the JVM when an array with invalid length is given.