### PR TITLE
des_read_pw_string not supported by BoringSSL

### DIFF
--- a/src/main/c/sslutils.c
+++ b/src/main/c/sslutils.c
@@ -131,9 +131,6 @@ int SSL_password_prompt(tcn_pass_cb_t *data)
 #elif !defined(OPENSSL_IS_BORINGSSL)
         EVP_read_pw_string(data->password, SSL_MAX_PASSWORD_LEN,
                            data->prompt, 0);
-#else
-        des_read_pw_string(data->password, SSL_MAX_PASSWORD_LEN,
-                           data->prompt, 0);
 #endif
         rv = (int)strlen(data->password);
     }


### PR DESCRIPTION
Motivation:
des_read_pw_string is not supported by BoringSSL and explicitly used by an ifdef is BoringSSL is being used.

Modifications:
- The SSL_password_prompt should not call des_read_pw_string when BoringSSL is used, and should return failure

Result:
des_read_pw_string is not used for BoringSSL.
Fixes netty#63