### PR TITLE
Do not call CONF_modules_unload for BoringSSL

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -302,7 +302,7 @@ static apr_status_t ssl_init_cleanup(void *data)
     /*
      * Try to kill the internals of the SSL library.
      */
-#if OPENSSL_VERSION_NUMBER >= 0x00907001
+#if OPENSSL_VERSION_NUMBER >= 0x00907001 && !defined(OPENSSL_IS_BORINGSSL)
     /* Corresponds to OPENSSL_load_builtin_modules():
      * XXX: borrowed from apps.h, but why not CONF_modules_free()
      * which also invokes CONF_modules_finish()?


### PR DESCRIPTION
Motivation:

For CONF_modules_unload, it looks like it should simply not be called for BoringSSL. It's intended to cleanup after calling OPENSSL_load_builtin_modules, which is not called for BoringSSL.

Modifications:

Modified ssl.c to not call CONF_modules_unload if BoringSSL

Result:

Addresses part of #65