### PR TITLE
Removing unused variable in sslcontext.c

### DIFF
--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -936,7 +936,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateBio)(TCN_STDARGS, jlong c
 
     jboolean rv = JNI_TRUE;
     TCN_ALLOC_CSTRING(password);
-    const char *p;
     char err[256];
 
     UNREFERENCED(o);


### PR DESCRIPTION
Motivation:

Generally trying to cleanup build errors/warnings.

Modifications:

Modified the setCertificateBio method to remove unused variable.

Result:

Fixes build error.