### PR TITLE
Fixing build issues

### DIFF
--- a/src/main/native-package/configure.ac
+++ b/src/main/native-package/configure.ac
@@ -28,7 +28,7 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
-${CFLAGS="-O3"}
+${CFLAGS="-O3 -Werror"}
 
 ## -----------------------------------------------
 ## Application Checks


### PR DESCRIPTION
Motivation:

Building against openssl and boringssl is yielding several errors. They can be supressed, but it would be better to address them.

Modifications:

Various changes to ssl.c, sslutils.c, and sslcontext.c.

Result:

Builds cleanly for both openssl and boringssl.