### PR TITLE
Add methods to allow support of renegotiation

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1820,6 +1820,34 @@ TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
     ERR_clear_error();
 }
 
+TCN_IMPLEMENT_CALL(jint, SSL, renegotiate)(TCN_STDARGS,
+                                           jlong ssl /* SSL * */) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return 0;
+    }
+
+    UNREFERENCED(o);
+
+    return SSL_renegotiate(ssl_);
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS,
+                                           jlong ssl, /* SSL * */
+                                           jint state) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return;
+    }
+
+    UNREFERENCED(o);
+
+    SSL_set_state(ssl_, state);
+}
+
+
 /*** End Apple API Additions ***/
 
 #else
@@ -2206,5 +2234,17 @@ TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
     tcn_ThrowException(e, "Not implemented");
 }
 
+TCN_IMPLEMENT_CALL(jint, SSL, renegotiate)(TCN_STDARGS, jlong ssl) {
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  tcn_ThrowException(e, "Not implemented");
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS, jlong ssl, jint state) {
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  UNREFERENCED(state);
+  tcn_ThrowException(e, "Not implemented");
+}
 /*** End Apple API Additions ***/
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -234,6 +234,9 @@ public final class SSL {
     public static final int SSL_SELECTOR_FAILURE_NO_ADVERTISE = 0;
     public static final int SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL = 1;
 
+    public static final int SSL_ST_CONNECT = 0x1000;
+    public static final int SSL_ST_ACCEPT =  0x2000;
+
     /* Return OpenSSL version number */
     public static native int version();
 
@@ -702,4 +705,19 @@ public final class SSL {
      * Clear all the errors from the error queue that OpenSSL encountered on this thread.
      */
     public static native void clearError();
+
+    /**
+     * Call SSL_renegotiate.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the result of the operation
+     */
+    public static native int renegotiate(long ssl);
+
+    /**
+     * Call SSL_set_state.
+     *
+     * @param ssl the SSL instance (SSL *)
+     */
+    public static native void setState(long ssl, int state);
 }


### PR DESCRIPTION
Motivation:

Expose methods openssl methods to support renegotiation.

Modifications:

Add SSL.renegotiate and SSL.setState.

Result:

It's possible to implement renegotiation with tcnative now.