### PR TITLE
Fixing segfault with BoringSSL

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1615,6 +1615,12 @@ TCN_IMPLEMENT_CALL(jlong, SSL, getTime)(TCN_STDARGS, jlong ssl)
         return 0;
     }
 
+    if (ssl_->session == NULL) {
+        // BoringSSL does not protect against a NULL session. OpenSSL
+        // returns 0 if the session is NULL, so do that here.
+        return 0;
+    }
+
     UNREFERENCED(o);
 
     return SSL_get_time(ssl_->session);


### PR DESCRIPTION
Motivation:

BoringSSL's SSL_SESSION_get_time method does not guard against a null session, however OpenSSL's returns 0 if the session is null.  This seems to cause a segfault when starting up the connection:

Stack: [0x00007f877b516000,0x00007f877b617080],  sp=0x00007f877b614ea0,  free space=1019k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libnetty-tcnative.so+0xd449c]  SSL_SESSION_get_time+0xc
C  [libnetty-tcnative.so+0x79448]  Java_org_apache_tomcat_jni_SSL_getTime+0x78
j  org.apache.tomcat.jni.SSL.getTime(J)J+0
j  io.netty.handler.ssl.OpenSslEngine$OpenSslSession.<init>(Lio/netty/handler/ssl/OpenSslEngine;JLio/netty/handler/ssl/OpenSslSessionContext;)V+11
j  io.netty.handler.ssl.OpenSslEngine.<init>(JLio/netty/buffer/ByteBufAllocator;ZLio/netty/handler/ssl/OpenSslSessionContext;Lio/netty/handler/ssl/OpenSslApplicationProtocolNegotiator;Lio/netty/handler/ssl/OpenSslEngineMap;ZLjava/lang/String;I[Ljava/security/cert/Certificate;Lio/netty/handler/ssl/ClientAuth;)V+123
j  io.netty.handler.ssl.OpenSslContext.newEngine(Lio/netty/buffer/ByteBufAllocator;Ljava/lang/String;I)Ljavax/net/ssl/SSLEngine;+39
j  io.grpc.netty.ProtocolNegotiators$2$1.handlerAdded(Lio/netty/channel/ChannelHandlerContext;)V+24

Modifications:

Modified the getTime method in ssl.c to guard against a null session.

Result:

tcnative works with BoringSSL.