### PR TITLE
Add methods to get and set the timout of a SSL session.

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1757,6 +1757,48 @@ TCN_IMPLEMENT_CALL(jlong, SSL, getTime)(TCN_STDARGS, jlong ssl)
     return SSL_get_time(ssl_->session);
 }
 
+
+TCN_IMPLEMENT_CALL(jlong, SSL, getTimeout)(TCN_STDARGS, jlong ssl)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return 0;
+    }
+
+    if (ssl_->session == NULL) {
+        // BoringSSL does not protect against a NULL session. OpenSSL
+        // returns 0 if the session is NULL, so do that here.
+        return 0;
+    }
+
+    UNREFERENCED(o);
+
+    return SSL_get_timeout(ssl_->session);
+}
+
+
+TCN_IMPLEMENT_CALL(jlong, SSL, setTimeout)(TCN_STDARGS, jlong ssl, jlong seconds)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return 0;
+    }
+    if (ssl_->session == NULL) {
+        // BoringSSL does not protect against a NULL session. OpenSSL
+        // returns 0 if the session is NULL, so do that here.
+        return 0;
+    }
+
+    UNREFERENCED(o);
+
+    return SSL_set_timeout(ssl_->session, seconds);
+}
+
+
 TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl,
                                                 jint level, jint depth)
 {
@@ -2315,6 +2357,23 @@ TCN_IMPLEMENT_CALL(jlong, SSL, getTime)(TCN_STDARGS, jlong ssl)
 {
   UNREFERENCED(o);
   UNREFERENCED(ssl);
+  tcn_ThrowException(e, "Not implemented");
+  return 0;
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSL, getTimeout)(TCN_STDARGS, jlong ssl)
+{
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  tcn_ThrowException(e, "Not implemented");
+  return 0;
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSL, setTimeout)(TCN_STDARGS, jlong ssl, jlong seconds)
+{
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  UNREFERENCED(seconds);
   tcn_ThrowException(e, "Not implemented");
   return 0;
 }

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -612,6 +612,21 @@ public final class SSL {
     public static native long getTime(long ssl);
 
     /**
+     * SSL_get_timeout
+     * @param ssl the SSL instance (SSL *)
+     * @return returns the timeout for the session ssl The time is given in seconds since the Epoch
+     */
+    public static native long getTimeout(long ssl);
+
+    /**
+     * SSL_set_timeout
+     * @param ssl the SSL instance (SSL *)
+     * @param seconds timeout in seconds
+     * @return returns the timeout for the session ssl before this call. The time is given in seconds since the Epoch
+     */
+    public static native long setTimeout(long ssl, long seconds);
+
+    /**
      * Set Type of Client Certificate verification and Maximum depth of CA Certificates
      * in Client Certificate verification.
      * <br />


### PR DESCRIPTION
Motivation:

To be able to fully implement SSLSession we need to be able to get and set the timeout of a SSL Session.

Modifications:

Add SSL.getTimeout(...) and SSL.setTimeout(...)

Result:

Be able to manipulate and get informations about the SSL Session timeout.