### PR TITLE
Fix compile error if HAS_OPENSSL is not set

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -2126,7 +2126,6 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS, jlong ssl)
 TCN_IMPLEMENT_CALL(jstring, SSL, getErrorString)(TCN_STDARGS, jlong number)
 {
   UNREFERENCED(o);
-  UNREFERENCED(ssl);
   tcn_ThrowException(e, "Not implemented");
   return NULL;
 }


### PR DESCRIPTION
Motivation:

If HAS_OPENSSL is not set a compile is raised.

Modifications:

Fix compile error.

Result:

No compile error if HAS_OPENSSL is not set.