### PR TITLE
Allow to compile tcnative against libressl 2.3.0

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -561,10 +561,12 @@ static int ssl_rand_save_file(const char *file)
 #ifndef OPENSSL_IS_BORINGSSL
     char buffer[APR_PATH_MAX];
     int n;
-    if (file == NULL)
+    if (file == NULL) {
         file = RAND_file_name(buffer, sizeof(buffer));
-    else if ((n = RAND_egd(file)) > 0) {
+#ifdef HAVE_SSL_RAND_EGD
+    } else if ((n = RAND_egd(file)) > 0) {
         return 0;
+#endif
     }
     if (file == NULL || !RAND_write_file(file))
         return 0;

--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -130,6 +130,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jlong pool,
             ctx = SSL_CTX_new(TLSv1_server_method());
         else
             ctx = SSL_CTX_new(TLSv1_method());
+#ifndef OPENSSL_NO_SSL3
     } else if (protocol == SSL_PROTOCOL_SSLV3) {
         if (mode == SSL_MODE_CLIENT)
             ctx = SSL_CTX_new(SSLv3_client_method());
@@ -137,6 +138,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jlong pool,
             ctx = SSL_CTX_new(SSLv3_server_method());
         else
             ctx = SSL_CTX_new(SSLv3_method());
+#endif
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_NO_SSL2)
     } else if (protocol == SSL_PROTOCOL_SSLV2) {
         if (mode == SSL_MODE_CLIENT)
@@ -154,6 +156,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jlong pool,
     } else if (protocol & SSL_PROTOCOL_TLSV1_1) {
         /* requested but not supported */
 #endif
+#ifndef OPENSSL_NO_SSL3
     } else {
         if (mode == SSL_MODE_CLIENT)
             ctx = SSL_CTX_new(SSLv23_client_method());
@@ -161,6 +164,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jlong pool,
             ctx = SSL_CTX_new(SSLv23_server_method());
         else
             ctx = SSL_CTX_new(SSLv23_method());
+#endif
     }
 
     if (!ctx) {


### PR DESCRIPTION
Motivation:

libressl 2.3.0 removed a few methods, so we need to guard against this via ifdefs.

Modifications:

Added pre-processor rules to be able to compile against libressl 2.3.0

Result:

tcnative can be compiled again libressl >= 2.3.0