### PR TITLE
Allow to get the release against which tcnative was compiled.

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -2036,6 +2036,17 @@ TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS,
     SSL_set_state(ssl_, state);
 }
 
+TCN_IMPLEMENT_CALL(jint, SSL, release0)(TCN_STDARGS)
+{
+    UNREFERENCED_STDARGS;
+    #ifdef LIBRESSL_VERSION_NUMBER
+        return 1;
+    #elif defined(OPENSSL_IS_BORINGSSL)
+        return 2;
+    #else
+        return 0;
+    #endif
+}
 
 /*** End Apple API Additions ***/
 
@@ -2451,5 +2462,12 @@ TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS, jlong ssl, jint state) {
   UNREFERENCED(state);
   tcn_ThrowException(e, "Not implemented");
 }
+
+TCN_IMPLEMENT_CALL(jint, SSL, release0)(TCN_STDARGS)
+{
+    UNREFERENCED_STDARGS;
+    tcn_ThrowException(e, "Not implemented");
+}
+
 /*** End Apple API Additions ***/
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -237,11 +237,38 @@ public final class SSL {
     public static final int SSL_ST_CONNECT = 0x1000;
     public static final int SSL_ST_ACCEPT =  0x2000;
 
+    /**
+     * The actual release that is used and implement the OPENSSL API / ABI
+     */
+    public enum Release {
+        OPENSSL,
+        LIBRESSL,
+        BORINGSSL,
+    }
+
     /* Return OpenSSL version number */
     public static native int version();
 
     /* Return OpenSSL version string */
     public static native String versionString();
+
+    /**
+     * Returns the {@link Release} against which tcnative was compiled.
+     */
+    public static Release release() {
+        switch (release0()) {
+            case 0:
+                return Release.OPENSSL;
+            case 1:
+                return Release.LIBRESSL;
+            case 2:
+                return Release.BORINGSSL;
+            default:
+                throw new java.lang.Error();
+        }
+    }
+
+    private static native int release0();
 
     /**
      * Initialize OpenSSL support.


### PR DESCRIPTION
Motivation:

It's useful to detect against which openssl compatible project / release tcnative was compiled as some features may only work with one or the other.

Modifications:

Add method to SSL to detect it.

Result:

Possible to get informations about against which release it was compiled.