### PR TITLE
Not blindly cast to jlong when return a pointer to make it work on 32bit

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1067,7 +1067,7 @@ TCN_IMPLEMENT_CALL(jlong, SSL, newMemBIO)(TCN_STDARGS)
     // TODO: Use BIO_s_secmem() once included in stable release
     if ((bio = BIO_new(BIO_s_mem())) == NULL) {
         tcn_ThrowException(e, "Create BIO failed");
-        return (jlong) NULL;
+        return 0;
     }
     return P2J(bio);
 }


### PR DESCRIPTION
Motivation:

We blindly cast to jlong in one case when return a pointer and so it will not build on 32bit. Related to https://github.com/netty/netty/issues/4694.

Modifications:

Just return 0 on error and not try to cast to jlong.

Result:

Also builds on 32bit.