### PR TITLE
Add method to clear options set by SSL_set_options

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -1870,6 +1870,21 @@ TCN_IMPLEMENT_CALL(void, SSL, setOptions)(TCN_STDARGS, jlong ssl,
     SSL_set_options(ssl_, opt);
 }
 
+TCN_IMPLEMENT_CALL(void, SSL, clearOptions)(TCN_STDARGS, jlong ssl,
+                                                 jint opt)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return;
+    }
+
+    UNREFERENCED_STDARGS;
+
+    SSL_clear_options(ssl_, opt);
+}
+
 TCN_IMPLEMENT_CALL(jint, SSL, getOptions)(TCN_STDARGS, jlong ssl)
 {
     SSL *ssl_ = J2P(ssl, SSL *);
@@ -2391,6 +2406,15 @@ TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl,
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, setOptions)(TCN_STDARGS, jlong ssl,
+                                                 jint opt)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ssl);
+    UNREFERENCED(opt);
+    tcn_ThrowException(e, "Not implemented");
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, clearOptions)(TCN_STDARGS, jlong ssl,
                                                  jint opt)
 {
     UNREFERENCED_STDARGS;

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -670,6 +670,13 @@ public final class SSL {
     public static native void setOptions(long ssl, int options);
 
     /**
+     * Clear OpenSSL Option.
+     * @param ssl the SSL instance (SSL *)
+     * @param options  See SSL.SSL_OP_* for option flags.
+     */
+    public static native void clearOptions(long ssl, int options);
+
+    /**
      * Get OpenSSL Option.
      * @param ssl the SSL instance (SSL *)
      * @return options  See SSL.SSL_OP_* for option flags.


### PR DESCRIPTION
Motivation:

We currently provide a way to set SSL options via ```SSL_set_options``` but we do not provide a way to clear out those options. Related to https://github.com/netty/netty/issues/4736

Modifications:

Add clearOptions function which executes ```SSL_clear_options```

Result:

Allow users to clear out options which were set using ```SSL_set_options```