### PR TITLE
Fix m4 warnings

### DIFF
--- a/src/main/native-package/m4/tcnative.m4
+++ b/src/main/native-package/m4/tcnative.m4
@@ -18,7 +18,7 @@
 dnl
 dnl TCN_FIND_APR: figure out where APR is located
 dnl
-AC_DEFUN(TCN_FIND_APR,[
+AC_DEFUN([TCN_FIND_APR],[
 
   dnl use the find_apr.m4 script to locate APR. sets apr_found and apr_config
   APR_FIND_APR(,,[1],[1])
@@ -273,7 +273,7 @@ dnl Autoconf 2.50 can not handle substr correctly.  It does have
 dnl AC_HELP_STRING, so let's try to call it if we can.
 dnl Note: this define must be on one line so that it can be properly returned
 dnl as the help string.
-AC_DEFUN(TCN_HELP_STRING,[ifelse(regexp(AC_ACVERSION, 2\.1), -1, AC_HELP_STRING($1,$2),[  ]$1 substr([                       ],len($1))$2)])dnl
+AC_DEFUN([TCN_HELP_STRING],[ifelse(regexp(AC_ACVERSION, 2\.1), -1, AC_HELP_STRING($1,$2),[  ]$1 substr([                       ],len($1))$2)])dnl
 
 dnl
 dnl TCN_CHECK_SSL_TOOLKIT
@@ -281,7 +281,7 @@ dnl
 dnl Configure for the detected openssl toolkit installation, giving
 dnl preference to "--with-ssl=<path>" if it was specified.
 dnl
-AC_DEFUN(TCN_CHECK_SSL_TOOLKIT,[
+AC_DEFUN([TCN_CHECK_SSL_TOOLKIT],[
 OPENSSL_WARNING=
 AC_MSG_CHECKING(for OpenSSL library)
 AC_ARG_WITH(ssl,


### PR DESCRIPTION
Motivation:

When running with verbose=true, there are a few warnings from the tcnative.m4 due to underquoted method definitions.

Modifications:

Adding proper quoting to method definitions in tcnative.m4.

Result:

No more warnings :)