### PR TITLE
Expose SSL_set_tlsext_host_name so SNI (client-side) can be supported

### DIFF
--- a/src/main/c/ssl.c
+++ b/src/main/c/ssl.c
@@ -2060,6 +2060,24 @@ TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS,
     SSL_set_state(ssl_, state);
 }
 
+TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring hostname) {
+    TCN_ALLOC_CSTRING(hostname);
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+    } else {
+        UNREFERENCED(o);
+
+        if (SSL_set_tlsext_host_name(ssl_, J2S(hostname)) != 1) {
+            char err[256];
+            ERR_error_string(ERR_get_error(), err);
+            tcn_Throw(e, "Unable to set TLS servername extension (%s)", err);
+        }
+    }
+
+    TCN_FREE_CSTRING(hostname);
+}
 
 /*** End Apple API Additions ***/
 
@@ -2484,5 +2502,13 @@ TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS, jlong ssl, jint state) {
   UNREFERENCED(state);
   tcn_ThrowException(e, "Not implemented");
 }
+
+TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring hostname) {
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  UNREFERENCED(hostname);
+  tcn_ThrowException(e, "Not implemented");
+}
+
 /*** End Apple API Additions ***/
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -742,4 +742,12 @@ public final class SSL {
      * @param ssl the SSL instance (SSL *)
      */
     public static native void setState(long ssl, int state);
+
+    /**
+     * Call SSL_set_tlsext_host_name
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @param hostname the hostname
+     */
+    public static native void setTlsExtHostName(long ssl, String hostname);
 }


### PR DESCRIPTION
Motivation:

We need to expose SSL_set_tlsext_host_name so we can support SNI on the client-sie. Related to https://github.com/netty/netty/issues/4746.

Modifications:

Expose SSL_set_tlsext_host_name.

Result:

SSL_set_tlsext_host_name can be called from the Java layer and so SNI can be used o nthe client-side