### PR TITLE
[#100] Allow to call SSL_CTX_set_mode and SSL_CTX_get_mode

### DIFF
--- a/src/main/c/sslcontext.c
+++ b/src/main/c/sslcontext.c
@@ -1591,6 +1591,27 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong
     }
     return JNI_FALSE;
 }
+
+TCN_IMPLEMENT_CALL(jint, SSLContext, setMode)(TCN_STDARGS, jlong ctx, jint mode)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    UNREFERENCED(o);
+    TCN_ASSERT(ctx != 0);
+
+    return (jint) SSL_CTX_set_mode(c->ctx, mode);
+}
+
+
+TCN_IMPLEMENT_CALL(jint, SSLContext, getMode)(TCN_STDARGS, jlong ctx)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    UNREFERENCED(o);
+    TCN_ASSERT(ctx != 0);
+
+    return (jint) SSL_CTX_get_mode(c->ctx);
+}
 #else
 /* OpenSSL is not supported.
  * Create empty stubs.
@@ -1924,11 +1945,27 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
     UNREFERENCED(ctx);
     UNREFERENCED(verifier);
 }
+
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong ctx, jbyteArray sidCtx)
 {
     UNREFERENCED_STDARGS;
     UNREFERENCED(ctx);
     UNREFERENCED(sidCtx);
     return JNI_FALSE;
+}
+
+TCN_IMPLEMENT_CALL(jint, SSLContext, setMode)(TCN_STDARGS, jlong ctx, jint mode)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    UNREFERENCED(mode);
+    return 0;
+}
+
+TCN_IMPLEMENT_CALL(jint, SSLContext, getMode)(TCN_STDARGS, jlong ctx)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    return 0;
 }
 #endif

--- a/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -237,6 +237,15 @@ public final class SSL {
     public static final int SSL_ST_CONNECT = 0x1000;
     public static final int SSL_ST_ACCEPT =  0x2000;
 
+    public static final int SSL_MODE_ENABLE_PARTIAL_WRITE           = 0x00000001;
+    public static final int SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER     = 0x00000002;
+    public static final int SSL_MODE_AUTO_RETRY                     = 0x00000004;
+    public static final int SSL_MODE_NO_AUTO_CHAIN                  = 0x00000008;
+    public static final int SSL_MODE_RELEASE_BUFFERS                = 0x00000010;
+    public static final int SSL_MODE_SEND_CLIENTHELLO_TIME          = 0x00000020;
+    public static final int SSL_MODE_SEND_SERVERHELLO_TIME          = 0x00000040;
+    public static final int SSL_MODE_SEND_FALLBACK_SCSV             = 0x00000080;
+
     /* Return OpenSSL version number */
     public static native int version();
 

--- a/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -494,4 +494,22 @@ public final class SSLContext {
      * @return {@code true} if success, {@code false} otherwise.
      */
     public static native boolean setSessionIdContext(long ctx, byte[] sidCtx);
+
+    /**
+     * Call SSL_CTX_set_mode
+     *
+     * @param ctx context to use
+     * @param mode the mode
+     * @return the set mode.
+     */
+    public static native int setMode(long ctx, int mode);
+
+    /**
+     * Call SSL_CTX_get_mode
+     *
+     * @param ctx context to use
+     * @return the mode.
+     */
+    public static native int getMode(long ctx);
+
 }


### PR DESCRIPTION
Motivation:

SSL_CTX_set_mode and SSL_CTX_get_mode may need to be called from the Java layer to adjust various mode options.

Modifications:

Expose native methods.

Result:

It's noew possible to call SSL_CTX_set_mode and SSL_CTX_get_mode.