### PR TITLE
Adding ssl/apr version to manifest

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -63,6 +63,36 @@
         </executions>
       </plugin>
 
+      <!-- Determine the commit ID of the source code. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+            <configuration>
+              <scmDirectory>${boringsslCheckoutDir}</scmDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Add the commit ID and branch to the manifest. -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Apr-Version>${aprVersion}</Apr-Version>
+            <BoringSSL-Revision>${buildNumber}</BoringSSL-Revision>
+            <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+          </instructions>
+        </configuration>
+      </plugin>
+
       <!-- Build the BoringSSL static libs -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -67,6 +67,18 @@
         </executions>
       </plugin>
 
+      <!-- Add the LibreSSL version to the manifest. -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Apr-Version>${aprVersion}</Apr-Version>
+            <LibreSSL-Version>${libresslVersion}</LibreSSL-Version>
+          </instructions>
+        </configuration>
+      </plugin>
+
       <!-- Don't deploy to Maven central -->
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -74,6 +74,18 @@
         </executions>
       </plugin>
 
+      <!-- Add the OpenSSL version to the manifest. -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Apr-Version>${aprVersion}</Apr-Version>
+            <OpenSSL-Version>${opensslVersion}</OpenSSL-Version>
+          </instructions>
+        </configuration>
+      </plugin>
+
       <!-- Configure the distribution statically linked against OpenSSL and APR -->
       <plugin>
         <groupId>org.fusesource.hawtjni</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
           <version>2.8.2</version>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>1.4</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.8</version>
           <dependencies>


### PR DESCRIPTION
Motivation:

It would be helpful to be able to inspect the statically-linked jars to determine exactly which version of APR/SSL they were built against.

Modifications:

Adding additional entries via the maven-bundle-plugin for the statically linked jars.

Result:

The jars provide version information for APR and SSL