### PR TITLE
Only deploy static jar on centos

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -97,6 +97,24 @@
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
+
+          <!-- Only deploy to Maven Central if on centos (fedora). -->
+          <execution>
+            <id>skip-deploy</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <condition property="maven.deploy.skip" value="false" else="true">
+                  <isset property="os.detected.release.like.fedora" />
+                </condition>
+              </target>
+            </configuration>
+          </execution>
+
           <execution>
             <id>build-boringssl</id>
             <phase>generate-sources</phase>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -35,6 +35,8 @@
     <libresslBuildDir>${libresslCheckoutDir}/build-ninja</libresslBuildDir>
     <libresslArchive>libressl-${libresslVersion}.tar.gz</libresslArchive>
     <linkStatic>true</linkStatic>
+    <!-- Don't deploy this artifact to Maven Central -->
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <build>
@@ -76,14 +78,6 @@
             <Apr-Version>${aprVersion}</Apr-Version>
             <LibreSSL-Version>${libresslVersion}</LibreSSL-Version>
           </instructions>
-        </configuration>
-      </plugin>
-
-      <!-- Don't deploy to Maven central -->
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -33,6 +33,8 @@
   <properties>
     <opensslBuildDir>${project.build.directory}/openssl-${opensslVersion}</opensslBuildDir>
     <linkStatic>true</linkStatic>
+    <!-- Don't deploy this artifact to Maven Central -->
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <build>
@@ -75,14 +77,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-
-      <!-- Don't deploy to Maven central -->
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Motivation:

Our current deploy process requires that we start on centos first. Since we only generate one boring-static jar for linux, this means that it will be overwritten when we get to debian. Debian has a higher glibc version, which will release a jar that ultimately won't work on old versions of centos.

Modifications:

Modified the boringssl module to only deploy if on centos.

Result:

Our deploy process works :)