### PR TITLE
Add option to build BoringSSL uber jar

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -30,165 +30,321 @@
     to BoringSSL and Apache APR.
   </description>
 
-  <properties>
-    <boringsslCheckoutDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslCheckoutDir>
-    <boringsslBuildDir>${boringsslCheckoutDir}/build</boringsslBuildDir>
-    <linkStatic>true</linkStatic>
-    <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
-    <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
-    <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
-  </properties>
+  <profiles>
+    <!-- Default profile that builds a platform-specific jar -->
+    <profile>
+      <id>boringssl-static-default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
 
-  <build>
-    <plugins>
-      <!-- Download the BoringSSL source -->
-      <plugin>
-        <artifactId>maven-scm-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>get-boringssl</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>checkout</goal>
-            </goals>
+      <properties>
+        <boringsslCheckoutDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslCheckoutDir>
+        <boringsslBuildDir>${boringsslCheckoutDir}/build</boringsslBuildDir>
+        <linkStatic>true</linkStatic>
+        <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
+        <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
+        <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
+      </properties>
+
+      <build>
+        <plugins>
+          <!-- Download the BoringSSL source -->
+          <plugin>
+            <artifactId>maven-scm-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>get-boringssl</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>checkout</goal>
+                </goals>
+                <configuration>
+                  <checkoutDirectory>${boringsslCheckoutDir}</checkoutDirectory>
+                  <connectionType>developerConnection</connectionType>
+                  <developerConnectionUrl>scm:git:https://boringssl.googlesource.com/boringssl</developerConnectionUrl>
+                  <scmVersion>${boringsslBranch}</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
+                  <skipCheckoutIfExists>true</skipCheckoutIfExists>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Determine the commit ID of the source code. -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>create</goal>
+                </goals>
+                <configuration>
+                  <scmDirectory>${boringsslCheckoutDir}</scmDirectory>
+                  <buildNumberPropertyName>boringsslBuildNumber</buildNumberPropertyName>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Add the commit ID and branch to the manifest. -->
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
             <configuration>
-              <checkoutDirectory>${boringsslCheckoutDir}</checkoutDirectory>
-              <connectionType>developerConnection</connectionType>
-              <developerConnectionUrl>scm:git:https://boringssl.googlesource.com/boringssl</developerConnectionUrl>
-              <scmVersion>${boringsslBranch}</scmVersion>
-              <scmVersionType>branch</scmVersionType>
-              <skipCheckoutIfExists>true</skipCheckoutIfExists>
+              <instructions>
+                <Apr-Version>${aprVersion}</Apr-Version>
+                <BoringSSL-Revision>${boringsslBuildNumber}</BoringSSL-Revision>
+                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+              </instructions>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
+          </plugin>
 
-      <!-- Determine the commit ID of the source code. -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <configuration>
-              <scmDirectory>${boringsslCheckoutDir}</scmDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
 
-      <!-- Add the commit ID and branch to the manifest. -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Apr-Version>${aprVersion}</Apr-Version>
-            <BoringSSL-Revision>${buildNumber}</BoringSSL-Revision>
-            <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
-          </instructions>
-        </configuration>
-      </plugin>
+              <!-- Only deploy to Maven Central if on centos (fedora). -->
+              <execution>
+                <id>skip-deploy</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="maven.deploy.skip" value="false" else="true">
+                      <isset property="os.detected.release.like.fedora" />
+                    </condition>
+                  </target>
+                </configuration>
+              </execution>
 
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
+              <!-- Build the BoringSSL static libs -->
+              <execution>
+                <id>build-boringssl</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${boringsslBuildDir}" />
+                    <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                      <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
+                      <arg value="-GNinja" />
+                      <arg value=".." />
+                    </exec>
+                    <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                  </target>
+                </configuration>
+              </execution>
 
-          <!-- Only deploy to Maven Central if on centos (fedora). -->
-          <execution>
-            <id>skip-deploy</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target>
-                <condition property="maven.deploy.skip" value="false" else="true">
-                  <isset property="os.detected.release.like.fedora" />
-                </condition>
-              </target>
-            </configuration>
-          </execution>
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                    </copy>
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
 
-          <!-- Build the BoringSSL static libs -->
-          <execution>
-            <id>build-boringssl</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <mkdir dir="${boringsslBuildDir}" />
-                <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                  <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                  <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                  <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
-                  <arg value="-GNinja" />
-                  <arg value=".." />
-                </exec>
-                <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
-              </target>
-            </configuration>
-          </execution>
+          <!-- Configure the distribution statically linked against OpenSSL and APR -->
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <name>netty-tcnative</name>
+                  <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+                  <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                  <forceAutogen>${forceAutogen}</forceAutogen>
+                  <forceConfigure>${forceConfigure}</forceConfigure>
+                  <windowsBuildTool>msbuild</windowsBuildTool>
+                  <configureArgs>
+                    <configureArg>--with-ssl=no</configureArg>
+                    <configureArg>--with-apr=${aprHome}</configureArg>
+                    <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
+                    <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
+                  </configureArgs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
-          <!-- Build the additional JAR that contains the native library. -->
-          <execution>
-            <id>native-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <copy todir="${nativeJarWorkdir}">
-                  <zipfileset src="${defaultJarFile}" />
-                </copy>
-                <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
-                  <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
-                  <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
-                </copy>
-                <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+    <!--
+      Profile that builds the uber-jar containing native libraries for all platforms. When this
+      is active, it will automatically disable the default profile. This should only be used
+      once the jars for all platforms are available on Maven Central. Installing/deploying this
+      artifact will overwrite the default netty-tcnative-boringssl-static.jar (i.e. the jar
+      without a classifier).
 
-      <!-- Configure the distribution statically linked against OpenSSL and APR -->
-      <plugin>
-        <groupId>org.fusesource.hawtjni</groupId>
-        <artifactId>maven-hawtjni-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>build-native-lib</id>
-            <goals>
-              <goal>generate</goal>
-              <goal>build</goal>
-            </goals>
-            <phase>compile</phase>
-            <configuration>
-              <name>netty-tcnative</name>
-              <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
-              <libDirectory>${nativeLibOnlyDir}</libDirectory>
-              <forceAutogen>${forceAutogen}</forceAutogen>
-              <forceConfigure>${forceConfigure}</forceConfigure>
-              <windowsBuildTool>msbuild</windowsBuildTool>
-              <configureArgs>
-                <configureArg>--with-ssl=no</configureArg>
-                <configureArg>--with-apr=${aprHome}</configureArg>
-                <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
-                <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
-              </configureArgs>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+      To build from the top level, run:
+      mvn clean deploy -pl boringssl-static -P uber -DstagingRepositoryId={repoId}
+
+      The repoId is necessary to allow the build to download the platform-specific jars from
+      the nexus staging repository.
+    -->
+    <profile>
+      <id>uber</id>
+      <activation>
+        <property>
+          <name>moduleSelector</name>
+          <value>uber</value>
+        </property>
+      </activation>
+
+      <properties>
+        <unpackDir>${project.build.directory}/unpack</unpackDir>
+        <libDir>${project.build.directory}/lib</libDir>
+        <nativeDir>${project.build.outputDirectory}/META-INF/native</nativeDir>
+      </properties>
+
+      <repositories>
+        <repository>
+          <id>staged-releases</id>
+          <name>Staged Releases</name>
+          <url>https://oss.sonatype.org/service/local/repositories/${stagingRepositoryId}/content/</url>
+        </repository>
+      </repositories>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <!-- Unpack just the native libraries -->
+                    <artifactItem>
+                      <groupId>io.netty</groupId>
+                      <artifactId>netty-tcnative-boringssl-static</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>osx-x86_64</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${unpackDir}/osx-x86_64</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>io.netty</groupId>
+                      <artifactId>netty-tcnative-boringssl-static</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>linux-x86_64</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${unpackDir}/linux-x86_64</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>io.netty</groupId>
+                      <artifactId>netty-tcnative-boringssl-static</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>windows-x86_64</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${unpackDir}/windows-x86_64</outputDirectory>
+                    </artifactItem>
+
+                    <!-- Now unpack all of the Java classes and the original MANIFEST.MF -->
+                    <artifactItem>
+                      <groupId>io.netty</groupId>
+                      <artifactId>netty-tcnative-boringssl-static</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                      <includes>**/*.class,**/MANIFEST.MF</includes>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-jni-libs</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target name="copy-jni-libs">
+                    <mkdir dir="${nativeDir}" />
+                    <copy todir="${nativeDir}" flatten="true">
+                      <fileset dir="${unpackDir}/osx-x86_64/META-INF/native" />
+                      <globmapper from="libnetty-tcnative.*" to="libnetty-tcnative-osx-x86_64.*"/>
+                    </copy>
+                    <copy todir="${nativeDir}" flatten="true">
+                      <fileset dir="${unpackDir}/linux-x86_64/META-INF/native" />
+                      <globmapper from="libnetty-tcnative.*" to="libnetty-tcnative-linux-x86_64.*"/>
+                    </copy>
+                    <copy todir="${nativeDir}" flatten="true">
+                      <fileset dir="${unpackDir}/windows-x86_64/META-INF/native" />
+                      <globmapper from="netty-tcnative.*" to="netty-tcnative-windows-x86_64.*"/>
+                    </copy>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-manifest</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>manifest</goal>
+                </goals>
+                <configuration>
+                  <supportedProjectTypes>
+                    <supportedProjectType>jar</supportedProjectType>
+                  </supportedProjectTypes>
+                  <instructions>
+                    <Export-Package>org.apache.tomcat.jni.*</Export-Package>
+                  </instructions>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,10 @@
           <version>1.4</version>
         </plugin>
         <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.10</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.8</version>
           <dependencies>
@@ -212,7 +216,8 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
-          <arguments>-P restricted-release,sonatype-oss-release -DskipAll=true</arguments>
+          <!-- Specifying a profile here will disable the all profile, since it's activeByDefault -->
+          <arguments>-Prestricted-release,sonatype-oss-release -DmoduleSelector=none</arguments>
           <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
@@ -407,12 +412,16 @@
         <module>boringssl-static</module>
       </modules>
     </profile>
+
+    <!--
+      Profile for building all modules. This is enabled by default so if any profile is manually specified,
+      this will be disabled automatically.
+    -->
     <profile>
-      <!-- This profile will bild all modules -->
       <id>all</id>
       <activation>
         <property>
-          <name>!skipAll</name>
+          <name>!moduleSelector</name>
         </property>
       </activation>
       <modules>
@@ -422,6 +431,22 @@
 
         <!-- Re-enable this once we get LibreSSL buiding on windows -->
         <!-- <module>libressl-static</module> -->
+      </modules>
+    </profile>
+
+    <!--
+      Profile for building uber jars for all platforms.
+    -->
+    <profile>
+      <id>uber</id>
+      <activation>
+        <property>
+          <name>moduleSelector</name>
+          <value>uber</value>
+        </property>
+      </activation>
+      <modules>
+        <module>boringssl-static</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
Motivation:

It would be useful to have a single uber jar that contains the native libraries for all the platforms. This would simplify the user's "getting started" process.

Modifications:

Added an uber profile to boringssl-static.

Result:

We can build a uber jar that is statically linked to BoringSSL and APR for osx-64, linux-64, and windows-64.