### PR TITLE
Disable execstack when building boringssl-static

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -127,6 +127,7 @@
                 <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
                   <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                   <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                  <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
                   <arg value="-GNinja" />
                   <arg value=".." />
                 </exec>


### PR DESCRIPTION
Motivation:

Using the boringssl-static artifact currently generates a spammy log on linux indicating that the library has disabled stack guard.

Modifications:

Updated the cmake command line for boringssl to include assembler flags disabling execstack.

Result:

Fixes #99