### PR TITLE
SSLContext initialization regression

### DIFF
--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -72,7 +72,9 @@ public final class SSL {
     public static final int SSL_PROTOCOL_TLSV1 = (1<<2);
     public static final int SSL_PROTOCOL_TLSV1_1 = (1<<3);
     public static final int SSL_PROTOCOL_TLSV1_2 = (1<<4);
-    public static final int SSL_PROTOCOL_ALL   = (SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2);
+    /** TLS_*method according to https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_new.html */
+    public static final int SSL_PROTOCOL_TLS   = (SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2);
+    public static final int SSL_PROTOCOL_ALL   = (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_TLS);
 
     /*
      * Define the SSL verify levels


### PR DESCRIPTION
Motivation:
Commit c9e7cde8d5bd52e338637a08c76ac284aff44683 change the way the SSLContext.make method worked. However there are duplicate defines for SSL_PROTOCOL_ALL (one in ssl_private.h, one in SSL.java) and only one was updated. These defines should be consistent.

Modifications:
- Update the defines in SSL.java to be consistent with ssl_private.h

Result:
SSL_CTX_new is called with the correct method.