### PR TITLE
Fixing invalid character in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <opensslDynamicDir>../openssl-dynamic</opensslDynamicDir>
     <vsStaticTemplateFile>../vs2010.vcxproj.static.template</vsStaticTemplateFile>
     <defaultJarFile>${project.build.directory}/${project.build.finalName}.jar</defaultJarFile>
-    <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.classifier}}.jar</nativeJarFile>
+    <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.classifier}.jar</nativeJarFile>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <nativeJarWorkdir>${project.build.directory}/native-jar-work</nativeJarWorkdir>
     <aprVersion>1.5.2</aprVersion>


### PR DESCRIPTION
Motivation:

The nativeJarFile property value contains a doulbe "}"

Modifications:

Removed the extra "}"

Result:

Fixes the pom.