### PR TITLE
Use latest 6.x centos release for enforcing rule.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
                       <files>
                         <file>/etc/redhat-release</file>
                       </files>
-                      <content>release 6.6</content>
+                      <content>release 6.7</content>
                     </requireFilesContent>
                   </rules>
                 </configuration>


### PR DESCRIPTION
Motivation:

We currently use centos 6.6 when enforcing the linux version during release. We should use 6.7 which is the latest centos release out of the 6 series.

Modifications:

Enforce centos 6.7

Result:

Be able to release on latest centos version out of the 6 series.