### PR TITLE
Update openssl to 1.0.2h and libressl to 2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
     <nativeJarWorkdir>${project.build.directory}/native-jar-work</nativeJarWorkdir>
     <aprVersion>1.5.2</aprVersion>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.3.2</libresslVersion>
-    <opensslVersion>1.0.2g</opensslVersion>
+    <libresslVersion>2.3.4</libresslVersion>
+    <opensslVersion>1.0.2h</opensslVersion>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

New versions of openssl and libressl were released.

Modifications:

Update versions.

Result:

Use up to date versions.