### PR TITLE
Replacing deprecated method on windows

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -195,7 +195,11 @@ char *tcn_strdup(JNIEnv *env, jstring jstr)
 
     cjstr = (const char *)((*env)->GetStringUTFChars(env, jstr, 0));
     if (cjstr) {
+#ifdef WIN32
+        result = _strdup(cjstr);
+#else
         result = strdup(cjstr);
+#endif
         (*env)->ReleaseStringUTFChars(env, jstr, cjstr);
     }
     return result;


### PR DESCRIPTION
Motivation:

strdup is deprecated on windows in favor of _strdup. The deprecated version of the method does not seem to be available when attempting to link with against libcmt.lib.

Modifications:

Changed jnilib.c to use _strdup instead.

Result:
Windows now resolves _strdup when linking against libcmt.lib.