### PR TITLE
Fix boringssl static linking on windows

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -160,7 +160,7 @@
                         <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=-Wa,- -noexecstack" />
+                          <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
                           <arg value="-GNinja" />
                           <arg value=".." />
                         </exec>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -132,14 +132,40 @@
                 </goals>
                 <configuration>
                   <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
                     <mkdir dir="${boringsslBuildDir}" />
-                    <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                      <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
-                      <arg value="-GNinja" />
-                      <arg value=".." />
-                    </exec>
+
+                    <!-- Determine if we're on windows -->
+                    <condition property="isWindows" else="false">
+                      <os family="windows" />
+                    </condition>
+
+                    <if>
+                      <equals arg1="${isWindows}" arg2="true" />
+                      <then>
+                        <!-- On Windows, build with /MT for static linking -->
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=/MT" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=/MT" />
+                          <arg value="-GNinja" />
+                          <arg value=".." />
+                        </exec>
+                      </then>
+                      <else>
+                        <!-- On *nix, add ASM flags to disable executable stack -->
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=-Wa,- -noexecstack" />
+                          <arg value="-GNinja" />
+                          <arg value=".." />
+                        </exec>
+                      </else>
+                    </if>
                     <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
                   </target>
                 </configuration>
@@ -188,6 +214,7 @@
                   <forceAutogen>${forceAutogen}</forceAutogen>
                   <forceConfigure>${forceConfigure}</forceConfigure>
                   <windowsBuildTool>msbuild</windowsBuildTool>
+                  <!-- <verbose>true</verbose> -->
                   <configureArgs>
                     <configureArg>--with-ssl=no</configureArg>
                     <configureArg>--with-apr=${aprHome}</configureArg>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,10 @@
                       <equals arg1="${archBits}" arg2="32" />
                     </condition>
                     <echo message="archBits=${archBits}. Using windowsRelease=${windowsRelease}" />
-                    <!-- Using retry since nmake fails occasionally when creating tempfile.bat -->
+                    <!-- On Windows, force building APR with /MT for static linking -->
+                    <replace dir="${aprBuildDir}" token="/MD" value="/MT">
+                      <include name="*.mak"/>
+                    </replace>
                     <retry retrycount="3">
                       <exec executable="nmake" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
                         <arg line="/f Makefile.win ARCH=&quot;${windowsRelease}&quot; PREFIX=..\apr buildall install" />

--- a/vs2010.vcxproj.static.template
+++ b/vs2010.vcxproj.static.template
@@ -86,7 +86,7 @@
       <PreprocessorDefinitions>APR_DECLARE_STATIC;WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;_WINDOWS;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>
       </ExceptionHandling>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -96,13 +96,14 @@
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>mswsock.lib;Rpcrt4.lib;Psapi.lib;Shlwapi.lib;Ws2_32.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>oldnames.lib;libcmt.lib;mswsock.lib;ws2_32.lib;rpcrt4.lib;shlwapi.lib;psapi.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>@SSL_LIB_DIR@;@APR_LIB_DIR@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'">
@@ -114,7 +115,7 @@
       <PreprocessorDefinitions>APR_DECLARE_STATIC;WIN32_LEAN_AND_MEAN;WIN64;NDEBUG;_WINDOWS;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>
       </ExceptionHandling>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -124,13 +125,14 @@
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>mswsock.lib;Rpcrt4.lib;Psapi.lib;Shlwapi.lib;Ws2_32.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>oldnames.lib;libcmt.lib;mswsock.lib;ws2_32.lib;rpcrt4.lib;shlwapi.lib;psapi.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>@SSL_LIB_DIR@;@APR_LIB_DIR@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX64</TargetMachine>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -143,7 +145,7 @@
       <ExceptionHandling>
       </ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -152,11 +154,12 @@
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>mswsock.lib;Rpcrt4.lib;Psapi.lib;Shlwapi.lib;Ws2_32.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>oldnames.lib;libcmt.lib;mswsock.lib;ws2_32.lib;rpcrt4.lib;shlwapi.lib;psapi.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>@SSL_LIB_DIR@;@APR_LIB_DIR@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'">
@@ -169,7 +172,7 @@
       <ExceptionHandling>
       </ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -178,11 +181,12 @@
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>mswsock.lib;Rpcrt4.lib;Psapi.lib;Shlwapi.lib;Ws2_32.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>oldnames.lib;libcmt.lib;mswsock.lib;ws2_32.lib;rpcrt4.lib;shlwapi.lib;psapi.lib;apr-1.lib;@SSL_LIBS@;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>@SSL_LIB_DIR@;@APR_LIB_DIR@;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Motivation:

Running netty-tcnative-boringssl-static on a windows machine that does not have the Windows SDK installed will fail to load netty-tcnative.dll.

Modifications:

The windows build is currently linking against the dynamic runtime libraries (via /MD). Changing the entire build (netty-tcnative, boringssl, and apr) to use /MT instead to force statically linking against the runtime.

Result:
Fixes #141