### PR TITLE
Allow to specify the length of the DH parameters to use.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -362,6 +362,12 @@ DH         *SSL_dh_get_tmp_param(int);
 DH         *SSL_dh_get_param_from_file(const char *);
 RSA        *SSL_callback_tmp_RSA(SSL *, int, int);
 DH         *SSL_callback_tmp_DH(SSL *, int, int);
+// The following provided callbacks will always return DH of a given length.
+// See https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_tmp_dh_callback.html
+DH         *SSL_callback_tmp_DH_512(SSL *, int, int);
+DH         *SSL_callback_tmp_DH_1024(SSL *, int, int);
+DH         *SSL_callback_tmp_DH_2048(SSL *, int, int);
+DH         *SSL_callback_tmp_DH_4096(SSL *, int, int);
 void        SSL_callback_handshake(const SSL *, int, int);
 int         SSL_CTX_use_certificate_chain(SSL_CTX *, const char *, int);
 int         SSL_CTX_use_certificate_chain_bio(SSL_CTX *, BIO *, int);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -654,6 +654,30 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDH)(TCN_STDARGS, jlong ctx,
     TCN_FREE_CSTRING(file);
 }
 
+TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDHLength)(TCN_STDARGS, jlong ctx, jint length)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+    UNREFERENCED(o);
+    TCN_ASSERT(ctx != 0);
+    switch (length) {
+        case 512:
+            SSL_CTX_set_tmp_dh_callback(c->ctx,  SSL_callback_tmp_DH_512);
+            return;
+        case 1024:
+            SSL_CTX_set_tmp_dh_callback(c->ctx,  SSL_callback_tmp_DH_1024);
+            return;
+        case 2048:
+            SSL_CTX_set_tmp_dh_callback(c->ctx,  SSL_callback_tmp_DH_2048);
+            return;
+        case 4096:
+            SSL_CTX_set_tmp_dh_callback(c->ctx,  SSL_callback_tmp_DH_4096);
+            return;
+        default:
+            tcn_Throw(e, "Unsupported length %s", length);
+            return;
+    }
+}
+
 TCN_IMPLEMENT_CALL(void, SSLContext, setTmpECDHByCurveName)(TCN_STDARGS, jlong ctx,
                                                                   jstring curveName)
 {

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -427,6 +427,26 @@ DH *SSL_callback_tmp_DH(SSL *ssl, int export, int keylen)
     return (DH *)SSL_temp_keys[idx];
 }
 
+DH *SSL_callback_tmp_DH_512(SSL *ssl, int export, int keylen)
+{
+    return (DH *)SSL_temp_keys[SSL_TMP_KEY_DH_512];
+}
+
+DH *SSL_callback_tmp_DH_1024(SSL *ssl, int export, int keylen)
+{
+    return (DH *)SSL_temp_keys[SSL_TMP_KEY_DH_1024];
+}
+
+DH *SSL_callback_tmp_DH_2048(SSL *ssl, int export, int keylen)
+{
+    return (DH *)SSL_temp_keys[SSL_TMP_KEY_DH_2048];
+}
+
+DH *SSL_callback_tmp_DH_4096(SSL *ssl, int export, int keylen)
+{
+    return (DH *)SSL_temp_keys[SSL_TMP_KEY_DH_4096];
+}
+
 /*
  * Read a file that optionally contains the server certificate in PEM
  * format, possibly followed by a sequence of CA certificates that

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -490,7 +490,15 @@ public final class SSLContext {
      */
     public static native void setTmpDH(long ctx, String cert)
             throws Exception;
-    
+
+    /**
+     * Set length of the DH to use.
+     *
+     * @param ctx Server context to use.
+     * @param length the length.
+     */
+    public static native void setTmpDHLength(long ctx, int length);
+
     /**
      * Set ECDH elliptic curve by name
      * @param ctx Server context to use.
@@ -527,5 +535,4 @@ public final class SSLContext {
      * @return the mode.
      */
     public static native int getMode(long ctx);
-
 }


### PR DESCRIPTION
Motivation:

Java8 allows to set a custom length for the DH paramaters. We should provide a way to do the same when using OpenSSL.

Modifications:

Add new method which allows to set the length.

Result:

Its now possible to set the length.