### PR TITLE
Add support for setting callback via SSL_CTX_set_client_cert_cb

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -50,7 +50,6 @@ struct CRYPTO_dynlock_value {
     apr_thread_mutex_t *mutex;
 };
 
-
 /*
  * Handle the Temporary RSA Keys and DH Params
  */
@@ -835,11 +834,11 @@ TCN_IMPLEMENT_CALL(jint, SSL, fipsModeSet)(TCN_STDARGS, jint mode)
     if(1 != (r = (jint)FIPS_mode_set((int)mode))) {
       /* arrange to get a human-readable error message */
       unsigned long err = ERR_get_error();
-      char msg[256];
+      char msg[ERR_LEN];
 
       /* ERR_load_crypto_strings() already called in initialize() */
 
-      ERR_error_string_n(err, msg, 256);
+      ERR_error_string_n(err, msg, ERR_LEN);
 
       tcn_ThrowException(e, msg);
     }
@@ -1205,7 +1204,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, loadDSATempKey)(TCN_STDARGS, jint idx,
 
 TCN_IMPLEMENT_CALL(jstring, SSL, getLastError)(TCN_STDARGS)
 {
-    char buf[256];
+    char buf[ERR_LEN];
     UNREFERENCED(o);
     ERR_error_string(ERR_get_error(), buf);
     return tcn_new_string(e, buf);
@@ -1686,7 +1685,9 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
         buf = NULL;
         length = i2d_X509(cert, &buf);
         if (length < 0) {
-            OPENSSL_free(buf);
+            if (buf != NULL) {
+                OPENSSL_free(buf);
+            }
             // In case of error just return an empty byte[][]
             return (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
         }
@@ -1743,7 +1744,7 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
 
 TCN_IMPLEMENT_CALL(jstring, SSL, getErrorString)(TCN_STDARGS, jlong number)
 {
-    char buf[256];
+    char buf[ERR_LEN];
     UNREFERENCED(o);
     ERR_error_string(number, buf);
     return tcn_new_string(e, buf);
@@ -1971,7 +1972,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     }
 
     if (!SSL_set_cipher_list(ssl_, J2S(ciphers))) {
-        char err[256];
+        char err[ERR_LEN];
         ERR_error_string(ERR_get_error(), err);
         tcn_Throw(e, "Unable to configure permitted SSL ciphers (%s)", err);
         rv = JNI_FALSE;
@@ -2077,13 +2078,123 @@ TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring
         UNREFERENCED(o);
 
         if (SSL_set_tlsext_host_name(ssl_, J2S(hostname)) != 1) {
-            char err[256];
+            char err[ERR_LEN];
             ERR_error_string(ERR_get_error(), err);
             tcn_Throw(e, "Unable to set TLS servername extension (%s)", err);
         }
     }
 
     TCN_FREE_CSTRING(hostname);
+}
+
+TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong ssl) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+    const STACK_OF(SSL_CIPHER) *ciphers = NULL;
+    int len;
+    int i;
+    jobjectArray array;
+
+    TCN_ASSERT(ssl_ != NULL);
+
+    UNREFERENCED(o);
+
+    ciphers = SSL_get_ciphers(ssl_);
+    len = sk_num((_STACK*) ciphers);
+
+    array = (*e)->NewObjectArray(e, len, stringClass, NULL);
+
+    for (i = 0; i < len; i++) {
+        (*e)->SetObjectArrayElement(e, array, i,
+        (*e)->NewStringUTF(e, SSL_cipher_authentication_method((SSL_CIPHER*) sk_value((_STACK*) ciphers, i))));
+    }
+    return array;
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, setCertificateBio)(TCN_STDARGS, jlong ssl,
+                                                         jlong cert, jlong key,
+                                                         jstring password)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+    BIO *cert_bio = J2P(cert, BIO *);
+    BIO *key_bio = J2P(key, BIO *);
+    EVP_PKEY* pkey;
+    X509* xcert;
+    tcn_pass_cb_t* cb_data;
+    TCN_ALLOC_CSTRING(password);
+    char err[ERR_LEN];
+
+    UNREFERENCED(o);
+    TCN_ASSERT(ssl != NULL);
+
+    cb_data = &tcn_password_callback;
+    cb_data->password[0] = '\0';
+    if (J2S(password) != NULL) {
+        strncat(cb_data->password, J2S(password), SSL_MAX_PASSWORD_LEN - 1);
+    }
+
+    if (key <= 0) {
+        key = cert;
+    }
+
+    if (cert <= 0 || key <= 0) {
+        tcn_Throw(e, "No Certificate file specified or invalid file format");
+        goto cleanup;
+    }
+
+    if ((pkey = load_pem_key_bio(cb_data, key_bio)) == NULL) {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+        tcn_Throw(e, "Unable to load certificate key (%s)",err);
+        goto cleanup;
+    }
+    if ((xcert = load_pem_cert_bio(cb_data, cert_bio)) == NULL) {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+        tcn_Throw(e, "Unable to load certificate (%s) ", err);
+        goto cleanup;
+    }
+
+    if (SSL_use_certificate(ssl_, xcert) <= 0) {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+        tcn_Throw(e, "Error setting certificate (%s)", err);
+        goto cleanup;
+    }
+    if (SSL_use_PrivateKey(ssl_, pkey) <= 0) {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+        tcn_Throw(e, "Error setting private key (%s)", err);
+        goto cleanup;
+    }
+    if (SSL_check_private_key(ssl_) <= 0) {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+
+        tcn_Throw(e, "Private key does not match the certificate public key (%s)",
+                  err);
+        goto cleanup;
+    }
+cleanup:
+    TCN_FREE_CSTRING(password);
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
+                                                                  jlong chain,
+                                                                  jboolean skipfirst)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+    BIO *b = J2P(chain, BIO *);
+    char err[ERR_LEN];
+
+    UNREFERENCED(o);
+    TCN_ASSERT(ssl_ != NULL);
+    TCN_ASSERT(b != NULL);
+
+    if (SSL_use_certificate_chain_bio(ssl_, b, skipfirst) < 0)  {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+        tcn_Throw(e, "Error setting certificate chain (%s)", err);
+    }
 }
 
 /*** End Apple API Additions ***/
@@ -2517,5 +2628,10 @@ TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring
   tcn_ThrowException(e, "Not implemented");
 }
 
+TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong ssl) {
+  UNREFERENCED(o);
+  UNREFERENCED(ssl);
+  tcn_ThrowException(e, "Not implemented");
+}
 /*** End Apple API Additions ***/
 #endif

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -53,6 +53,9 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
+
+#define ERR_LEN 256
+
 /* Avoid tripping over an engine build installed globally and detected
  * when the user points at an explicit non-engine flavor of OpenSSL
  */
@@ -217,6 +220,8 @@
 
 #define MAX_ALPN_NPN_PROTO_SIZE 65535
 
+static const char* UNKNOWN_AUTH_METHOD = "UNKNOWN";
+
 /* ECC: make sure we have at least 1.0.0 */
 #if !defined(OPENSSL_NO_EC) && defined(TLSEXT_ECPOINTFORMAT_uncompressed)
 #define HAVE_ECC              1
@@ -290,6 +295,9 @@ struct tcn_ssl_ctxt_t {
     /* certificate verifier callback */
     jobject verifier;
     jmethodID verifier_method;
+
+    jobject cert_requested_callback;
+    jmethodID cert_requested_callback_method;
 
     unsigned char           *next_proto_data;
     unsigned int            next_proto_len;
@@ -365,12 +373,17 @@ DH         *SSL_callback_tmp_DH(SSL *, int, int);
 void        SSL_callback_handshake(const SSL *, int, int);
 int         SSL_CTX_use_certificate_chain(SSL_CTX *, const char *, int);
 int         SSL_CTX_use_certificate_chain_bio(SSL_CTX *, BIO *, int);
+int         SSL_use_certificate_chain_bio(SSL *, BIO *, int);
+X509        *load_pem_cert_bio(tcn_pass_cb_t *, const BIO *);
+EVP_PKEY    *load_pem_key_bio(tcn_pass_cb_t *, const BIO *);
+
 int         SSL_callback_SSL_verify(int, X509_STORE_CTX *);
 int         SSL_rand_seed(const char *file);
 int         SSL_callback_next_protos(SSL *, const unsigned char **, unsigned int *, void *);
 int         SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int,void *);
 int         SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
-
+void        SSL_init_app_data2_3_idx(void);
+const char *SSL_cipher_authentication_method(const SSL_CIPHER *);
 
 #if defined(__GNUC__) || defined(__GNUG__)
     // only supported with GCC, this will be used to support different openssl versions at the same time.

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -31,8 +31,6 @@
 #ifdef HAVE_OPENSSL
 #include "ssl_private.h"
 
-static const char* UNKNOWN_AUTH_METHOD = "UNKNOWN";
-
 static jclass byteArrayClass;
 
 static apr_status_t ssl_context_cleanup(void *data)
@@ -42,45 +40,52 @@ static apr_status_t ssl_context_cleanup(void *data)
 
     if (c) {
         int i;
-        if (c->crl)
+        if (c->crl != NULL)
             X509_STORE_free(c->crl);
         c->crl = NULL;
-        if (c->ctx)
+        if (c->ctx != NULL)
             SSL_CTX_free(c->ctx);
         c->ctx = NULL;
         for (i = 0; i < SSL_AIDX_MAX; i++) {
-            if (c->certs[i]) {
+            if (c->certs[i] != NULL) {
                 X509_free(c->certs[i]);
                 c->certs[i] = NULL;
             }
-            if (c->keys[i]) {
+            if (c->keys[i] != NULL) {
                 EVP_PKEY_free(c->keys[i]);
                 c->keys[i] = NULL;
             }
         }
-        if (c->bio_is) {
+        if (c->bio_is != NULL ) {
             SSL_BIO_close(c->bio_is);
             c->bio_is = NULL;
         }
-        if (c->bio_os) {
+        if (c->bio_os != NULL ) {
             SSL_BIO_close(c->bio_os);
             c->bio_os = NULL;
         }
 
-        if (c->verifier) {
+        if (c->verifier != NULL) {
             tcn_get_java_env(&e);
             (*e)->DeleteGlobalRef(e, c->verifier);
             c->verifier = NULL;
         }
         c->verifier_method = NULL;
 
-        if (c->next_proto_data) {
+        if (c->cert_requested_callback != NULL) {
+            tcn_get_java_env(&e);
+            (*e)->DeleteGlobalRef(e, c->cert_requested_callback);
+            c->cert_requested_callback = NULL;
+        }
+        c->cert_requested_callback_method = NULL;
+
+        if (c->next_proto_data != NULL) {
             free(c->next_proto_data);
             c->next_proto_data = NULL;
         }
         c->next_proto_len = 0;
 
-        if (c->alpn_proto_data) {
+        if (c->alpn_proto_data != NULL) {
             free(c->alpn_proto_data);
             c->alpn_proto_data = NULL;
         }
@@ -88,7 +93,7 @@ static apr_status_t ssl_context_cleanup(void *data)
 
         apr_thread_rwlock_destroy(c->mutex);
 
-        if (c->ticket_keys) {
+        if (c->ticket_keys != NULL) {
             free(c->ticket_keys);
             c->ticket_keys = NULL;
         }
@@ -772,26 +777,6 @@ static EVP_PKEY *load_pem_key(tcn_ssl_ctxt_t *c, const char *file)
     return key;
 }
 
-static EVP_PKEY *load_pem_key_bio(tcn_ssl_ctxt_t *c, const BIO *bio)
-{
-    EVP_PKEY *key = NULL;
-    tcn_pass_cb_t *cb_data = c->cb_data;
-    int i;
-
-    if (cb_data == NULL)
-        cb_data = &tcn_password_callback;
-    for (i = 0; i < 3; i++) {
-        key = PEM_read_bio_PrivateKey((BIO*) bio, NULL,
-                    (pem_password_cb *)SSL_password_callback,
-                    (void *)cb_data);
-        if (key)
-            break;
-        cb_data->password[0] = '\0';
-        BIO_ctrl((BIO*) bio, BIO_CTRL_RESET, 0, NULL);
-    }
-    return key;
-}
-
 static X509 *load_pem_cert(tcn_ssl_ctxt_t *c, const char *file)
 {
     BIO *bio = NULL;
@@ -817,25 +802,6 @@ static X509 *load_pem_cert(tcn_ssl_ctxt_t *c, const char *file)
         cert = d2i_X509_bio(bio, NULL);
     }
     BIO_free(bio);
-    return cert;
-}
-
-static X509 *load_pem_cert_bio(tcn_ssl_ctxt_t *c, const BIO *bio)
-{
-    X509 *cert = NULL;
-    tcn_pass_cb_t *cb_data = c->cb_data;
-
-    if (cb_data == NULL)
-        cb_data = &tcn_password_callback;
-    cert = PEM_read_bio_X509_AUX((BIO*) bio, NULL,
-                (pem_password_cb *)SSL_password_callback,
-                (void *)cb_data);
-    if (cert == NULL &&
-       (ERR_GET_REASON(ERR_peek_last_error()) == PEM_R_NO_START_LINE)) {
-        ERR_clear_error();
-        BIO_ctrl((BIO*) bio, BIO_CTRL_RESET, 0, NULL);
-        cert = d2i_X509_bio((BIO*) bio, NULL);
-    }
     return cert;
 }
 
@@ -1020,14 +986,14 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateBio)(TCN_STDARGS, jlong c
         goto cleanup;
     }
 
-    if ((c->keys[idx] = load_pem_key_bio(c, key_bio)) == NULL) {
+    if ((c->keys[idx] = load_pem_key_bio(c->cb_data, key_bio)) == NULL) {
         ERR_error_string(ERR_get_error(), err);
         ERR_clear_error();
         tcn_Throw(e, "Unable to load certificate key (%s)",err);
         rv = JNI_FALSE;
         goto cleanup;
     }
-    if ((c->certs[idx] = load_pem_cert_bio(c, cert_bio)) == NULL) {
+    if ((c->certs[idx] = load_pem_cert_bio(c->cb_data, cert_bio)) == NULL) {
         ERR_error_string(ERR_get_error(), err);
         ERR_clear_error();
         tcn_Throw(e, "Unable to load certificate (%s) ", err);
@@ -1462,92 +1428,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys0)(TCN_STDARGS, jlong c
     SSL_CTX_set_tlsext_ticket_key_cb(c->ctx, ssl_tlsext_ticket_key_cb);
 }
 
-
-/*
- * Adapted from OpenSSL:
- * http://osxr.org/openssl/source/ssl/ssl_locl.h#0291
- */
-/* Bits for algorithm_mkey (key exchange algorithm) */
-#define SSL_kRSA        0x00000001L /* RSA key exchange */
-#define SSL_kDHr        0x00000002L /* DH cert, RSA CA cert */ /* no such ciphersuites supported! */
-#define SSL_kDHd        0x00000004L /* DH cert, DSA CA cert */ /* no such ciphersuite supported! */
-#define SSL_kEDH        0x00000008L /* tmp DH key no DH cert */
-#define SSL_kKRB5       0x00000010L /* Kerberos5 key exchange */
-#define SSL_kECDHr      0x00000020L /* ECDH cert, RSA CA cert */
-#define SSL_kECDHe      0x00000040L /* ECDH cert, ECDSA CA cert */
-#define SSL_kEECDH      0x00000080L /* ephemeral ECDH */
-#define SSL_kPSK        0x00000100L /* PSK */
-#define SSL_kGOST       0x00000200L /* GOST key exchange */
-#define SSL_kSRP        0x00000400L /* SRP */
-
-/* Bits for algorithm_auth (server authentication) */
-#define SSL_aRSA        0x00000001L /* RSA auth */
-#define SSL_aDSS        0x00000002L /* DSS auth */
-#define SSL_aNULL       0x00000004L /* no auth (i.e. use ADH or AECDH) */
-#define SSL_aDH         0x00000008L /* Fixed DH auth (kDHd or kDHr) */ /* no such ciphersuites supported! */
-#define SSL_aECDH       0x00000010L /* Fixed ECDH auth (kECDHe or kECDHr) */
-#define SSL_aKRB5       0x00000020L /* KRB5 auth */
-#define SSL_aECDSA      0x00000040L /* ECDSA auth*/
-#define SSL_aPSK        0x00000080L /* PSK auth */
-#define SSL_aGOST94     0x00000100L /* GOST R 34.10-94 signature auth */
-#define SSL_aGOST01     0x00000200L /* GOST R 34.10-2001 signature auth */
-
-/* OpenSSL end */
-
-/*
- * Adapted from Android:
- * https://android.googlesource.com/platform/external/openssl/+/master/patches/0003-jsse.patch
- */
-const char* cipher_authentication_method(const SSL_CIPHER* cipher){
-#ifndef OPENSSL_IS_BORINGSSL
-    switch (cipher->algorithm_mkey)
-        {
-    case SSL_kRSA:
-        return SSL_TXT_RSA;
-    case SSL_kDHr:
-        return SSL_TXT_DH "_" SSL_TXT_RSA;
-
-    case SSL_kDHd:
-        return SSL_TXT_DH "_" SSL_TXT_DSS;
-    case SSL_kEDH:
-        switch (cipher->algorithm_auth)
-            {
-        case SSL_aDSS:
-            return "DHE_" SSL_TXT_DSS;
-        case SSL_aRSA:
-            return "DHE_" SSL_TXT_RSA;
-        case SSL_aNULL:
-            return SSL_TXT_DH "_anon";
-        default:
-            return UNKNOWN_AUTH_METHOD;
-            }
-    case SSL_kKRB5:
-        return SSL_TXT_KRB5;
-    case SSL_kECDHr:
-        return SSL_TXT_ECDH "_" SSL_TXT_RSA;
-    case SSL_kECDHe:
-        return SSL_TXT_ECDH "_" SSL_TXT_ECDSA;
-    case SSL_kEECDH:
-        switch (cipher->algorithm_auth)
-            {
-        case SSL_aECDSA:
-            return "ECDHE_" SSL_TXT_ECDSA;
-        case SSL_aRSA:
-            return "ECDHE_" SSL_TXT_RSA;
-        case SSL_aNULL:
-            return SSL_TXT_ECDH "_anon";
-        default:
-            return UNKNOWN_AUTH_METHOD;
-            }
-    default:
-        return UNKNOWN_AUTH_METHOD;
-    }
-#else
-    return SSL_CIPHER_get_kx_name(cipher);
-#endif
-
-}
-
 static const char* authentication_method(const SSL* ssl) {
 {
     const STACK_OF(SSL_CIPHER) *ciphers = NULL;
@@ -1562,7 +1442,7 @@ static const char* authentication_method(const SSL* ssl) {
                 // No cipher available so return UNKNOWN.
                 return UNKNOWN_AUTH_METHOD;
             }
-            return cipher_authentication_method(sk_value((_STACK*) ciphers, 0));
+            return SSL_cipher_authentication_method(sk_value((_STACK*) ciphers, 0));
         }
     }
 }
@@ -1601,8 +1481,10 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
         if (length < 0) {
             // In case of error just return an empty byte[][]
             array = (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
-            // We need to delete the local references so we not leak memory as this method is called via callback.
-            OPENSSL_free(buf);
+            if (buf != NULL) {
+                // We need to delete the local references so we not leak memory as this method is called via callback.
+                OPENSSL_free(buf);
+            }
             break;
         }
         bArray = (*e)->NewByteArray(e, length);
@@ -1631,7 +1513,6 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     return result == X509_V_OK ? 1 : 0;
 }
 
-
 TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong ctx, jobject verifier)
 {
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
@@ -1656,6 +1537,153 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
         c->verifier_method = method;
 
         SSL_CTX_set_cert_verify_callback(c->ctx, SSL_cert_verify, NULL);
+    }
+}
+
+/**
+ * Returns an array containing all the X500 principal's bytes.
+ *
+ * Partly based on code from conscrypt:
+ * https://android.googlesource.com/platform/external/conscrypt/+/master/src/main/native/org_conscrypt_NativeCrypto.cpp
+ */
+static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) {
+    jobjectArray array;
+    jbyteArray bArray;
+    int i;
+    int count;
+    int length;
+    unsigned char *buf;
+    X509_NAME* principal;
+
+    if (names == NULL) {
+        return NULL;
+    }
+
+    count = sk_X509_NAME_num(names);
+    if (count <= 0) {
+        return NULL;
+    }
+
+    array = (*e)->NewObjectArray(e, count, byteArrayClass, NULL);
+    if (array == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < count; i++) {
+        principal = sk_X509_NAME_value(names, i);
+        buf = NULL;
+        length = i2d_X509_NAME(principal, &buf);
+        if (length < 0) {
+            if (buf != NULL) {
+                // We need to delete the local references so we not leak memory as this method is called via callback.
+                OPENSSL_free(buf);
+            }
+            // In case of error just return an empty byte[][]
+            return (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
+        }
+        bArray = (*e)->NewByteArray(e, length);
+        (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) buf);
+        (*e)->SetObjectArrayElement(e, array, i, bArray);
+
+        // Delete the local reference as we not know how long the chain is and local references are otherwise
+        // only freed once jni method returns.
+        (*e)->DeleteLocalRef(e, bArray);
+        OPENSSL_free(buf);
+    }
+
+    return array;
+}
+
+/**
+ * Partly based on code from conscrypt:
+ * https://android.googlesource.com/platform/external/conscrypt/+/master/src/main/native/org_conscrypt_NativeCrypto.cpp
+ */
+static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
+    tcn_ssl_ctxt_t *c = SSL_get_app_data2(ssl);
+    char ssl2_ctype = SSL3_CT_RSA_SIGN;
+    int ctype_num;
+    jbyte* ctype_bytes;
+    jobjectArray issuers;
+    JNIEnv *e;
+    jbyteArray keyTypes;
+    X509* certificate;
+    EVP_PKEY* privatekey;
+    tcn_get_java_env(&e);
+
+    /* Clear output of key and certificate in case of early exit due to error. */
+    *x509Out = NULL;
+    *pkeyOut = NULL;
+
+#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_NUMBER < 0x1000200fL
+    switch (ssl->version) {
+        case SSL2_VERSION:
+            ctype_bytes = (jbyte*) &ssl2_ctype;
+            ctype_num = 1;
+            break;
+        case SSL3_VERSION:
+        case TLS1_VERSION:
+        case TLS1_1_VERSION:
+        case TLS1_2_VERSION:
+        case DTLS1_VERSION:
+            ctype_bytes = (jbyte*) ssl->s3->tmp.ctype;
+            ctype_num = ssl->s3->tmp.ctype_num;
+            break;
+    }
+#else
+    ctype_num = SSL_get0_certificate_types(ssl, (const uint8_t **) &ctype_bytes);
+#endif
+    if (ctype_num <= 0) {
+        // Use no certificate
+        return 0;
+    }
+    keyTypes = (*e)->NewByteArray(e, ctype_num);
+    if (keyTypes == NULL) {
+        // Something went seriously wrong, bail out!
+        return -1;
+    }
+    (*e)->SetByteArrayRegion(e, keyTypes, 0, ctype_num, ctype_bytes);
+
+    issuers = principalBytes(e,  SSL_get_client_CA_list(ssl));
+
+    // Execute the java callback
+    (*e)->CallVoidMethod(e, c->cert_requested_callback, c->cert_requested_callback_method, P2J(ssl), keyTypes, issuers);
+
+    // Check for values set from Java
+    certificate = SSL_get_certificate(ssl);
+    privatekey  = SSL_get_privatekey(ssl);
+
+    if (certificate != NULL && privatekey != NULL) {
+        *x509Out = certificate;
+        *pkeyOut = privatekey;
+        return 1;
+    }
+    // TODO: Would it be more correct to return 0 in this case we may not want to use any cert / private key ?
+    return -1;
+}
+
+TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlong ctx, jobject callback)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    UNREFERENCED(o);
+    TCN_ASSERT(ctx != 0);
+
+    if (callback == NULL) {
+        SSL_CTX_set_client_cert_cb(c->ctx, NULL);
+    } else {
+        jclass callback_class = (*e)->GetObjectClass(e, callback);
+        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", "(J[B[[B)V");
+        if (method == NULL) {
+            return;
+        }
+        // Delete the reference to the previous specified verifier if needed.
+        if (c->cert_requested_callback != NULL) {
+            (*e)->DeleteLocalRef(e, c->cert_requested_callback);
+        }
+        c->cert_requested_callback = (*e)->NewGlobalRef(e, callback);
+        c->cert_requested_callback_method = method;
+
+        SSL_CTX_set_client_cert_cb(c->ctx, cert_requested);
     }
 }
 

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/CertificateRequestedCallback.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/CertificateRequestedCallback.java
@@ -1,0 +1,36 @@
+package org.apache.tomcat.jni;
+
+/**
+ * Is called during handshake and hooked into openssl via {@code SSL_CTX_set_client_cert_cb}.
+ *
+ * IMPORTANT: Implementations of this interface should be static as it is stored as a global reference via JNI. This
+ *            means if you use an inner / anonymous class to implement this and also depend on the finalizer of the
+ *            class to free up the SSLContext the finalizer will never run as the object is never GC, due the hard
+ *            reference to the enclosing class. This will most likely result in a memory leak.
+ */
+public interface CertificateRequestedCallback {
+
+    /**
+     * The types contained in the {@code keyTypeBytes} array.
+     */
+    // Extracted from https://github.com/openssl/openssl/blob/master/include/openssl/tls1.h
+    byte TLS_CT_RSA_SIGN = 1;
+    byte TLS_CT_DSS_SIGN = 2;
+    byte TLS_CT_RSA_FIXED_DH = 3;
+    byte TLS_CT_DSS_FIXED_DH = 4;
+    byte TLS_CT_ECDSA_SIGN = 64;
+    byte TLS_CT_RSA_FIXED_ECDH = 65;
+    byte TLS_CT_ECDSA_FIXED_ECDH = 66;
+
+    /**
+     * Called during cert selection.
+     *
+     * Implementation should use {@link SSL#setCertificateBio(long, long, long, String)} and
+     * {@link SSL#setCertificateChainBio(long, long, boolean)} to set the certificate and private key to use.
+     *
+     * @param ssl                       the SSL instance
+     * @param keyTypeBytes              an array of the key types.
+     * @param asn1DerEncodedPrincipals  the principals
+     */
+    void requested(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals);
+}

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -761,4 +761,52 @@ public final class SSL {
      * @param hostname the hostname
      */
     public static native void setTlsExtHostName(long ssl, String hostname);
+
+    public static native String[] authenticationMethods(long ssl);
+
+    /**
+     * Set BIO of PEM-encoded Server CA Certificates
+     * <p>
+     * This directive sets the optional all-in-one file where you can assemble the
+     * certificates of Certification Authorities (CA) which form the certificate
+     * chain of the server certificate. This starts with the issuing CA certificate
+     * of of the server certificate and can range up to the root CA certificate.
+     * Such a file is simply the concatenation of the various PEM-encoded CA
+     * Certificate files, usually in certificate chain order.
+     * <p>
+     * But be careful: Providing the certificate chain works only if you are using
+     * a single (either RSA or DSA) based server certificate. If you are using a
+     * coupled RSA+DSA certificate pair, this will work only if actually both
+     * certificates use the same certificate chain. Otherwsie the browsers will be
+     * confused in this situation.
+     * @param ssl Server or Client to use.
+     * @param bio BIO of PEM-encoded Server CA Certificates.
+     * @param skipfirst Skip first certificate if chain file is inside
+     *                  certificate file.
+     */
+    public static native void setCertificateChainBio(long ssl, long bio, boolean skipfirst);
+
+    /**
+     * Set Certificate
+     * <br>
+     * Point setCertificate at a PEM encoded certificate stored in a BIO. If
+     * the certificate is encrypted, then you will be prompted for a
+     * pass phrase.  Note that a kill -HUP will prompt again. A test
+     * certificate can be generated with `make certificate' under
+     * built time. Keep in mind that if you've both a RSA and a DSA
+     * certificate you can configure both in parallel (to also allow
+     * the use of DSA ciphers, etc.)
+     * <br>
+     * If the key is not combined with the certificate, use key param
+     * to point at the key file.  Keep in mind that if
+     * you've both a RSA and a DSA private key you can configure
+     * both in parallel (to also allow the use of DSA ciphers, etc.)
+     * @param ssl Server or Client to use.
+     * @param certBio Certificate BIO.
+     * @param keyBio Private Key BIO to use if not in cert.
+     * @param password Certificate password. If null and certificate
+     *                 is encrypted.
+     */
+    public static native void setCertificateBio(
+            long ssl, long certBio, long keyBio, String password) throws Exception;
 }

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -453,6 +453,15 @@ public final class SSLContext {
     public static native void setCertVerifyCallback(long ctx, CertificateVerifier verifier);
 
     /**
+     * Allow to hook {@link CertificateRequestedCallback} into the certificate choosing process.
+     * This will call {@code SSL_CTX_set_client_cert_cb} and so replace the default verification
+     * callback used by openssl
+     * @param ctx Server or Client context to use.
+     * @param callback the callback to call during certificate selection.
+     */
+    public static native void setCertRequestedCallback(long ctx, CertificateRequestedCallback callback);
+
+    /**
      * Set next protocol for next protocol negotiation extension
      * @param ctx Server context to use.
      * @param nextProtos comma delimited list of protocols in priority order


### PR DESCRIPTION
Motivation:

To be able to hook in X509KeyManager we need to allow setting a callback via SSL_CTX_set_client_cert_cb.

Modification:

Add CertificateRequestedCallback and needed SSL methods to set the cert / privatekey so we can hook in X509KeyManager from within netty.

Result:

Be able to hook in X509KeyManager