### PR TITLE
[#166] netty-tcnative fails to build for libressl < 2.4.0

### DIFF
--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-tcnative-parent</artifactId>
-    <version>1.1.33.Fork13-SNAPSHOT</version>
+    <version>1.1.33.Fork19-SNAPSHOT</version>
   </parent>
   <artifactId>netty-tcnative-libressl-static</artifactId>
   <packaging>jar</packaging>

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -678,7 +678,7 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
 #endif
 
 #ifndef OPENSSL_IS_BORINGSSL
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20400000L
 
     /* We must register the library in full, to ensure our configuration
      * code can successfully test the SSL environment.

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1639,7 +1639,7 @@ static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     *x509Out = NULL;
     *pkeyOut = NULL;
 
-#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_NUMBER < 0x1000200fL
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x1000200fL || LIBRESSL_VERSION_NUMBER < 0x20400000L)
     switch (ssl->version) {
         case SSL2_VERSION:
             ctype_bytes = (jbyte*) &ssl2_ctype;

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -596,7 +596,7 @@ int SSL_CTX_use_certificate_chain_bio(SSL_CTX *ctx, BIO *bio,
 int SSL_use_certificate_chain_bio(SSL *ssl, BIO *bio,
                                   int skipfirst)
 {
-#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_NUMBER < 0x1000200fL
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x1000200fL || LIBRESSL_VERSION_NUMBER < 0x20400000L)
     // Only supported on boringssl or openssl 1.0.2+
     return -1;
 #else
@@ -803,7 +803,7 @@ static int ssl_verify_CRL(int ok, X509_STORE_CTX *ctx, tcn_ssl_ctxt_t *c)
             X509_REVOKED *revoked =
                 sk_X509_REVOKED_value(X509_CRL_get_REVOKED(crl), i);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20400000L
             ASN1_INTEGER *sn = revoked->serialNumber;
 #else
             ASN1_INTEGER *sn = X509_REVOKED_get0_serialNumber(revoked);
@@ -938,7 +938,7 @@ void SSL_callback_handshake(const SSL *ssl, int where, int rc)
         int state = SSL_get_state(ssl);
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20400000L
         if (state == SSL3_ST_SR_CLNT_HELLO_A
 #ifndef OPENSSL_IS_BORINGSSL
                 || state == SSL23_ST_SR_CLNT_HELLO_A

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.5.2</aprVersion>
     <aprMd5>98492e965963f852ab29f9e61b2ad700</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.3.4</libresslVersion>
+    <libresslVersion>2.4.1</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>7a1135b2620f78928e89538c211a4df1d9415994001d1e7c9178c6b6d72de6a9</libresslSha256>
+    <libresslSha256>121922b13169cd47a85e3e77f0bc129f8d04247193b42491cb1fab9074e80477</libresslSha256>
     <opensslVersion>1.0.2h</opensslVersion>
     <opensslSha256>1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>


### PR DESCRIPTION
Motivation:

With the latest set of changes (in Fork18), netty-tcnative fails to build for LibreSSL. This is related to change: 444598b

Modifications:

Add ifdefs to ensure it compiles on libressl as well.

Result:

netty-tcnative compiles again on libressl.