### PR TITLE
Fixes the OS alias miss spelling in Bundle-NativeCode header.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -373,9 +373,11 @@
                   </supportedProjectTypes>
                   <instructions>
                     <Export-Package>org.apache.tomcat.jni.*</Export-Package>
-                    <Bundle-NativeCode>META-INF/native/libnetty-tcnative-osx-x86_64.jnilib;osname=osx;processor=x86_64,
-                                       META-INF/native/libnetty-tcnative-linux-x86_64.so;osname=linux;processor=x86_64,
-                                       META-INF/native/netty-tcnative-windows-x86_64.dll;osname=windows;processor=x86_64</Bundle-NativeCode>
+                    <Bundle-NativeCode>
+                      META-INF/native/libnetty-tcnative-osx-x86_64.jnilib;osname=macos;osname=macosx;processor=x86_64,
+                      META-INF/native/libnetty-tcnative-linux-x86_64.so;osname=linux;processor=x86_64,
+                      META-INF/native/netty-tcnative-windows-x86_64.dll;osname=win32;processor=x86_64
+                    </Bundle-NativeCode>
                   </instructions>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -211,16 +211,18 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <condition property="tcnative.lib" value="libnetty-tcnative.so">
+                <condition property="tcnative.snippet" value="libnetty-tcnative.so;osname=linux">
                   <equals arg1="${os.detected.name}" arg2="linux" />
                 </condition>
-                <condition property="tcnative.lib" value="netty-tcnative.dll">
+                <!-- In OSGi specification, the alias of Windows family is win32, case insensitive -->
+                <condition property="tcnative.snippet" value="netty-tcnative.dll;osname=win32">
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
-                <condition property="tcnative.lib" value="libnetty-tcnative.jnilib">
+                <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
+                <condition property="tcnative.snippet" value="libnetty-tcnative.jnilib;osname=macos;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
-                <property name="tcnativeManifest" value="META-INF/native/${tcnative.lib}; osname=${os.detected.name}; processor=x86_64" />
+                <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=x86_64" />
                 <echo message="Bundle-NativeCode: ${tcnativeManifest}" />
               </target>
             </configuration>


### PR DESCRIPTION
Motivation:

The commit #169 contains a bug: the `osname` value in Bundle-NativeCode header does NOT follow the OSGi specification. For example, the Windows family should use the alias `win32` or the name such as `Windows7`, `Windows8`, etc. Otherwise, the netty-tcnative bundle will encounter the "unresolve native library" runtime problem.
This patch trying to fix the OS name and alias miss match problem according to the OSGi specification.

Modifications:

Using the OS alias as `osname`, instead of the detected OS name.

Result:

The Bundle-NativeCode header generated by ant script will work as design. For example, the bundle build  on Windows, the generated header would be like:
`Bundle-NativeCode: META-INF/native/netty-tcnative.dll;osname=win32;processor=x86_64`

Reference:
[The OSGi specification Reference](https://www.osgi.org/developer/specifications/reference/)

Signed-off-by: XU JINCHUAN <xsir@msn.com>