### PR TITLE
[172] Java 6 Support

### DIFF
--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/Library.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/Library.java
@@ -41,7 +41,9 @@ public final class Library {
             try {
                 System.loadLibrary(NAMES[i]);
                 loaded = true;
-            } catch (ThreadDeath | VirtualMachineError t) {
+            } catch (ThreadDeath t) {
+                throw t;
+            } catch (VirtualMachineError t) {
                 throw t;
             } catch (Throwable t) {
                 String name = System.mapLibraryName(NAMES[i]);
@@ -49,7 +51,7 @@ public final class Library {
                     java.io.File fd = new java.io.File(paths[j] , name);
                     if (fd.exists()) {
                         // File exists but failed to load
-                        throw t;
+                        throw new RuntimeException(t);
                     }
                 }
                 if (i > 0) {

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/socket/AprSocketContext.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/socket/AprSocketContext.java
@@ -108,7 +108,7 @@ public class AprSocketContext {
     /**
      * Pollers.
      */
-    private final List<AprPoller> pollers = new ArrayList<>();
+    private final List<AprPoller> pollers = new ArrayList<AprPoller>();
 
     // Set on all accepted or connected sockets.
     // TODO: add the other properties
@@ -123,7 +123,7 @@ public class AprSocketContext {
     private boolean nonBlockingAccept = false;
 
     private final BlockingQueue<AprSocket> acceptedQueue =
-            new LinkedBlockingQueue<>();
+            new LinkedBlockingQueue<AprSocket>();
 
     /**
      * Root APR memory pool.
@@ -157,7 +157,7 @@ public class AprSocketContext {
     final RawDataHandler rawDataHandler = null;
 
     // TODO: do we need this here ?
-    private final Map<String, HostInfo> hosts = new HashMap<>();
+    private final Map<String, HostInfo> hosts = new HashMap<String, HostInfo>();
 
     private String certFile;
     private String keyFile;
@@ -797,10 +797,16 @@ public class AprSocketContext {
         }
 
         void unblock() {
-            try (java.net.Socket sock = new java.net.Socket()) {
-                // Easiest ( maybe safest ) way to interrupt accept
-                // we could have it in non-blocking mode, etc
-                sock.connect(new InetSocketAddress("127.0.0.1", port));
+            java.net.Socket sock = new java.net.Socket();
+
+            try {
+                try {
+                    // Easiest ( maybe safest ) way to interrupt accept
+                    // we could have it in non-blocking mode, etc
+                    sock.connect(new InetSocketAddress("127.0.0.1", port));
+                } finally {
+                    sock.close();
+                }
             } catch (Exception ex) {
                 // ignore - the acceptor may have shut down by itself.
             }
@@ -942,7 +948,7 @@ public class AprSocketContext {
 
         // Should be replaced with socket data.
         // used only to lookup by socket
-        private final Map<Long, AprSocket> channels = new HashMap<>();
+        private final Map<Long, AprSocket> channels = new HashMap<Long, AprSocket>();
 
         // Active + pending, must be < desc.length / 2
         // The channel will also have poller=this when active or pending
@@ -953,7 +959,7 @@ public class AprSocketContext {
 
         private final AtomicInteger pollCount = new AtomicInteger();
 
-        private final List<AprSocket> updates = new ArrayList<>();
+        private final List<AprSocket> updates = new ArrayList<AprSocket>();
 
         @Override
         public void run() {

--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Motivation

Add support for Java 6 for #172.

Modifications

Other than the pom.xml, Java 7 and 8 constructs have been removed.

Result

Usable from Java 6 now.