### PR TITLE
Remove casts by using correct macros

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1671,7 +1671,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     // Get a stack of all certs in the chain.
     sk = SSL_get_peer_cert_chain(ssl_);
 
-    len = sk_num((_STACK*) sk);
+    len = sk_X509_num(sk);
     if (len <= 0) {
         // No peer certificate chain as no auth took place yet, or the auth was not successful.
         return NULL;
@@ -1680,7 +1680,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     array = (*e)->NewObjectArray(e, len, byteArrayClass, NULL);
 
     for(i = 0; i < len; i++) {
-        cert = (X509*) sk_value((_STACK*) sk, i);
+        cert = sk_X509_value(sk, i);
 
         buf = NULL;
         length = i2d_X509(cert, &buf);
@@ -1933,7 +1933,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
     UNREFERENCED_STDARGS;
 
     sk = SSL_get_ciphers(ssl_);
-    len = sk_num((_STACK*) sk);
+    len = sk_SSL_CIPHER_num(sk);
 
     if (len <= 0) {
         // No peer certificate chain as no auth took place yet, or the auth was not successful.
@@ -1944,7 +1944,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
     array = (*e)->NewObjectArray(e, len, stringClass, NULL);
 
     for (i = 0; i < len; i++) {
-        cipher = (SSL_CIPHER*) sk_value((_STACK*) sk, i);
+        cipher = sk_SSL_CIPHER_value(sk, i);
         name = SSL_CIPHER_get_name(cipher);
 
         c_name = (*e)->NewStringUTF(e, name);
@@ -2099,7 +2099,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
     UNREFERENCED(o);
 
     ciphers = SSL_get_ciphers(ssl_);
-    len = sk_num((_STACK*) ciphers);
+    len = sk_SSL_CIPHER_num(ciphers);
 
     array = (*e)->NewObjectArray(e, len, stringClass, NULL);
 

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1463,11 +1463,11 @@ static const char* authentication_method(const SSL* ssl) {
             return SSL_TXT_RSA;
         default:
             ciphers = SSL_get_ciphers(ssl);
-            if (ciphers == NULL || sk_num((_STACK*) ciphers) <= 0) {
+            if (ciphers == NULL || sk_SSL_CIPHER_num(ciphers) <= 0) {
                 // No cipher available so return UNKNOWN.
                 return UNKNOWN_AUTH_METHOD;
             }
-            return SSL_cipher_authentication_method(sk_value((_STACK*) ciphers, 0));
+            return SSL_cipher_authentication_method(sk_SSL_CIPHER_value(ciphers, 0));
         }
     }
 }
@@ -1482,7 +1482,7 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     // Get a stack of all certs in the chain
     STACK_OF(X509) *sk = ctx->untrusted;
 
-    int len = sk_num((_STACK*) sk);
+    int len = sk_X509_num(sk);
     unsigned i;
     X509 *cert;
     int length;
@@ -1499,7 +1499,7 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     array = (*e)->NewObjectArray(e, len, byteArrayClass, NULL);
 
     for(i = 0; i < len; i++) {
-        cert = (X509*) sk_value((_STACK*) sk, i);
+        cert = sk_X509_value(sk, i);
 
         buf = NULL;
         length = i2d_X509(cert, &buf);


### PR DESCRIPTION
Motivation:

We can use the correct macros and so remove manual casts.

Modifications:

Use correct macros.

Result:

Cleaner code.