### PR TITLE
Update libressl and be able to compile on windows libressl-static

### DIFF
--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-tcnative-parent</artifactId>
-    <version>1.1.33.Fork19-SNAPSHOT</version>
+    <version>1.1.33.Fork20-SNAPSHOT</version>
   </parent>
   <artifactId>netty-tcnative-libressl-static</artifactId>
   <packaging>jar</packaging>
@@ -116,7 +116,6 @@
   </build>
 
   <profiles>
-    <!-- TODO: Build currently doesn't work on Windows. -->
     <profile>
       <id>build-libressl-windows</id>
       <activation>
@@ -124,28 +123,15 @@
           <family>windows</family>
         </os>
       </activation>
+      <properties>
+        <msvcSslLibs>libssl-39.lib; libcrypto-38.lib; libtls-1.1</msvcSslLibs>
+        <msvcSslLibDirs>${sslHome}/x${archBits}</msvcSslLibDirs>
+        <libresslWindows>libressl-${libresslVersion}-windows</libresslWindows>
+        <libresslWindowsZip>${libresslWindows}.zip</libresslWindowsZip>
+      </properties>
       <build>
         <plugins>
           <!-- Download the LibreSSL source -->
-          <plugin>
-            <artifactId>maven-scm-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>get-libressl-windows</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>checkout</goal>
-                </goals>
-                <configuration>
-                  <checkoutDirectory>${libresslCheckoutDir}</checkoutDirectory>
-                  <connectionType>developerConnection</connectionType>
-                  <developerConnectionUrl>scm:git:https://github.com/libressl-portable/portable.git</developerConnectionUrl>
-                  <scmVersion>v${libresslVersion}</scmVersion>
-                  <scmVersionType>tag</scmVersionType>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
@@ -157,13 +143,11 @@
                 </goals>
                 <configuration>
                   <target>
-                    <mkdir dir="${libresslBuildDir}"/>
-                    <exec executable="cmake" failonerror="true" dir="${libresslBuildDir}" resolveexecutable="true">
-                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                      <arg value="-GNinja" />
-                      <arg value=".." />
-                    </exec>
+                    <get src="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${libresslWindowsZip}"
+                         dest="${project.build.directory}/${libresslWindowsZip}"
+                         verbose="on"/>
+                    <unzip src="${project.build.directory}/${libresslWindowsZip}" dest="${project.build.directory}/" />
+                    <move file="${project.build.directory}/${libresslWindows}" tofile="${sslHome}"/>
                   </target>
                 </configuration>
               </execution>

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -678,7 +678,7 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
 #endif
 
 #ifndef OPENSSL_IS_BORINGSSL
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20400000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
     /* We must register the library in full, to ensure our configuration
      * code can successfully test the SSL environment.

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1625,7 +1625,7 @@ static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     *x509Out = NULL;
     *pkeyOut = NULL;
 
-#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x1000200fL || LIBRESSL_VERSION_NUMBER < 0x20400000L)
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER))
     char ssl2_ctype = SSL3_CT_RSA_SIGN;
     switch (ssl->version) {
         case SSL2_VERSION:

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -596,7 +596,7 @@ int SSL_CTX_use_certificate_chain_bio(SSL_CTX *ctx, BIO *bio,
 int SSL_use_certificate_chain_bio(SSL *ssl, BIO *bio,
                                   int skipfirst)
 {
-#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x1000200fL || LIBRESSL_VERSION_NUMBER < 0x20400000L)
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER))
     // Only supported on boringssl or openssl 1.0.2+
     return -1;
 #else
@@ -802,7 +802,7 @@ static int ssl_verify_CRL(int ok, X509_STORE_CTX *ctx, tcn_ssl_ctxt_t *c)
             X509_REVOKED *revoked =
                 sk_X509_REVOKED_value(X509_CRL_get_REVOKED(crl), i);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20400000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
             ASN1_INTEGER *sn = revoked->serialNumber;
 #else
             ASN1_INTEGER *sn = X509_REVOKED_get0_serialNumber(revoked);
@@ -937,7 +937,7 @@ void SSL_callback_handshake(const SSL *ssl, int where, int rc)
         int state = SSL_get_state(ssl);
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER < 0x20400000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
         if (state == SSL3_ST_SR_CLNT_HELLO_A
 #ifndef OPENSSL_IS_BORINGSSL
                 || state == SSL23_ST_SR_CLNT_HELLO_A

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.5.2</aprVersion>
     <aprMd5>98492e965963f852ab29f9e61b2ad700</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.4.1</libresslVersion>
+    <libresslVersion>2.4.2</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>121922b13169cd47a85e3e77f0bc129f8d04247193b42491cb1fab9074e80477</libresslSha256>
+    <libresslSha256>5f87d778e5d62822d60e38fa9621c1c5648fc559d198ba314bd9d89cbf67d9e3</libresslSha256>
     <opensslVersion>1.0.2h</opensslVersion>
     <opensslSha256>1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
@@ -474,9 +474,7 @@
         <module>openssl-dynamic</module>
         <module>openssl-static</module>
         <module>boringssl-static</module>
-
-        <!-- Re-enable this once we get LibreSSL buiding on windows -->
-        <!-- <module>libressl-static</module> -->
+        <module>libressl-static</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
Motiviation:

Libressl 2.4.2.Final was released. Also libressl-static did not build on windows.

Modifications:

- Update libressl version
- Fix build on windows of libressl-static

Result:

Using latest libressl version and be able to build libressl-static on windows.