### PR TITLE
Refactor CertificateRequestedCallback to fix possible segfault.

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -46,6 +46,10 @@ static jclass    jFinfo_class;
 static jclass    jAinfo_class;
 static jmethodID jString_init;
 static jmethodID jString_getBytes;
+static jclass    byteArrayClass;
+static jclass    keyMaterialClass;
+static jfieldID  keyMaterialCertificateChainFieldId;
+static jfieldID  keyMaterialPrivateKeyFieldId;
 
 int tcn_parent_pid = 0;
 
@@ -98,7 +102,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad_netty_tcnative(JavaVM *vm, void *reserved)
     tcn_parent_pid = getppid();
 #endif
 
-    return  TCN_JNI_VERSION;  
+    TCN_LOAD_CLASS(env, byteArrayClass, "[B", JNI_ERR);
+    TCN_LOAD_CLASS(env, keyMaterialClass, "org/apache/tomcat/jni/CertificateRequestedCallback$KeyMaterial", JNI_ERR);
+
+    TCN_GET_FIELD(env, keyMaterialClass, keyMaterialCertificateChainFieldId,
+                   "certificateChain", "J", JNI_ERR);
+    TCN_GET_FIELD(env, keyMaterialClass, keyMaterialPrivateKeyFieldId,
+                   "privateKey", "J", JNI_ERR);
+
+    return TCN_JNI_VERSION;
 }
 
 /* Called by the JVM when APR_JAVA is loaded */
@@ -123,6 +135,9 @@ JNIEXPORT void JNICALL JNI_OnUnload_netty_tcnative(JavaVM *vm, void *reserved)
         TCN_UNLOAD_CLASS(env, jAinfo_class);
         apr_terminate();
     }
+
+    TCN_UNLOAD_CLASS(env, byteArrayClass);
+    TCN_UNLOAD_CLASS(env, keyMaterialClass);
 }
 
 /* Called by the JVM before the APR_JAVA is unloaded */
@@ -483,6 +498,21 @@ apr_pool_t *tcn_get_global_pool()
 jclass tcn_get_string_class()
 {
     return jString_class;
+}
+
+jclass tcn_get_byte_array_class()
+{
+    return byteArrayClass;
+}
+
+jfieldID tcn_get_key_material_certificate_chain_field()
+{
+    return keyMaterialCertificateChainFieldId;
+}
+
+jfieldID tcn_get_key_material_private_key_field()
+{
+    return keyMaterialPrivateKeyFieldId;
 }
 
 JavaVM * tcn_get_java_vm()

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -39,9 +39,6 @@ tcn_pass_cb_t tcn_password_callback;
 /* Global reference to the pool used by the dynamic mutexes */
 static apr_pool_t *dynlockpool = NULL;
 
-static jclass byteArrayClass;
-static jclass stringClass;
-
 /* Dynamic lock structure */
 struct CRYPTO_dynlock_value {
     apr_pool_t *pool;
@@ -759,14 +756,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
                               ssl_init_cleanup,
                               apr_pool_cleanup_null);
     TCN_FREE_CSTRING(engine);
-
-    // Cache the byte[].class for performance reasons
-    clazz = (*e)->FindClass(e, "[B");
-    byteArrayClass = (jclass) (*e)->NewGlobalRef(e, clazz);
-
-    // Cache the String.class for performance reasons
-    sClazz = (*e)->FindClass(e, "java/lang/String");
-    stringClass = (jclass) (*e)->NewGlobalRef(e, sClazz);
 
     return (jint)APR_SUCCESS;
 }
@@ -1659,6 +1648,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     unsigned char *buf;
     jobjectArray array;
     jbyteArray bArray;
+    jclass byteArrayClass = tcn_get_byte_array_class();
 
     SSL *ssl_ = J2P(ssl, SSL *);
 
@@ -1942,7 +1932,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
     }
 
     // Create the byte[][] array that holds all the certs
-    array = (*e)->NewObjectArray(e, len, stringClass, NULL);
+    array = (*e)->NewObjectArray(e, len, tcn_get_string_class(), NULL);
 
     for (i = 0; i < len; i++) {
         cipher = sk_SSL_CIPHER_value(sk, i);
@@ -2102,7 +2092,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
     ciphers = SSL_get_ciphers(ssl_);
     len = sk_SSL_CIPHER_num(ciphers);
 
-    array = (*e)->NewObjectArray(e, len, stringClass, NULL);
+    array = (*e)->NewObjectArray(e, len, tcn_get_string_class(), NULL);
 
     for (i = 0; i < len; i++) {
         (*e)->SetObjectArrayElement(e, array, i,
@@ -2198,6 +2188,99 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
         ERR_clear_error();
         tcn_Throw(e, "Error setting certificate chain (%s)", err);
     }
+}
+
+TCN_IMPLEMENT_CALL(long, SSL, parsePrivateKey)(TCN_STDARGS, jlong privateKeyBio, jstring password)
+{
+    EVP_PKEY* pkey = NULL;
+    BIO *bio = J2P(privateKeyBio, BIO *);
+    tcn_pass_cb_t* cb_data = &tcn_password_callback;
+    TCN_ALLOC_CSTRING(password);
+    char err[ERR_LEN];
+
+    UNREFERENCED(o);
+
+    if (bio == NULL) {
+        tcn_Throw(e, "Unable to load certificate key");
+        goto cleanup;
+    }
+
+    cb_data->password[0] = '\0';
+    if (J2S(password) != NULL) {
+        strncat(cb_data->password, J2S(password), SSL_MAX_PASSWORD_LEN - 1);
+    }
+
+    if ((pkey = load_pem_key_bio(cb_data, bio)) == NULL) {
+        ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+        ERR_clear_error();
+        tcn_Throw(e, "Unable to load certificate key (%s)",err);
+        goto cleanup;
+    }
+
+cleanup:
+    TCN_FREE_CSTRING(password);
+    return P2J(pkey);
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, freePrivateKey)(TCN_STDARGS, jlong privateKey)
+{
+    EVP_PKEY *key = J2P(privateKey, EVP_PKEY *);
+    UNREFERENCED(o);
+    EVP_PKEY_free(key); // Safe to call with NULL as well.
+}
+
+TCN_IMPLEMENT_CALL(long, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
+{
+    BIO *cert_bio = J2P(x509ChainBio, BIO *);
+    X509* cert = NULL;
+    STACK_OF(X509) *chain = NULL;
+    char err[ERR_LEN];
+    unsigned long error;
+    int n = 0;
+
+    UNREFERENCED(o);
+
+    if (cert_bio == NULL) {
+        tcn_Throw(e, "No Certificate specified or invalid format");
+        goto cleanup;
+    }
+
+    chain = sk_X509_new_null();
+    while ((cert = PEM_read_bio_X509(cert_bio, NULL, NULL, NULL)) != NULL) {
+        if (sk_X509_push(chain, cert) != 1) {
+            tcn_Throw(e, "No Certificate specified or invalid format");
+            goto cleanup;
+        }
+        cert = NULL;
+        n++;
+    }
+
+    // ensure that if we have an error its just for EOL.
+    if ((error = ERR_peek_error()) > 0) {
+        if (!(ERR_GET_LIB(error) == ERR_LIB_PEM
+              && ERR_GET_REASON(error) == PEM_R_NO_START_LINE)) {
+
+            ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
+            tcn_Throw(e, "Invalid format (%s)", err);
+            goto cleanup;
+        }
+        ERR_clear_error();
+    }
+
+    return P2J(chain);
+
+cleanup:
+    ERR_clear_error();
+    sk_X509_pop_free(chain, X509_free);
+    X509_free(cert);
+    return 0;
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, freeX509Chain)(TCN_STDARGS, jlong x509Chain)
+{
+    STACK_OF(X509) *chain = J2P(x509Chain, STACK_OF(X509) *);
+    UNREFERENCED(o);
+    sk_X509_pop_free(chain, X509_free);
 }
 
 /*** End Apple API Additions ***/
@@ -2635,6 +2718,38 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
   UNREFERENCED(o);
   UNREFERENCED(ssl);
   tcn_ThrowException(e, "Not implemented");
+}
+
+
+TCN_IMPLEMENT_CALL(long, SSL, parsePrivateKey)(TCN_STDARGS, jlong privateKeyBio, jstring password)
+{
+     UNREFERENCED(o);
+     UNREFERENCED(privateKeyBio);
+     UNREFERENCED(password);
+     tcn_ThrowException(e, "Not implemented");
+     return 0;
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, freePrivateKey)(TCN_STDARGS, jlong privateKey)
+{
+     UNREFERENCED(o);
+     UNREFERENCED(privateKey);
+     tcn_ThrowException(e, "Not implemented");
+}
+
+TCN_IMPLEMENT_CALL(long, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
+{
+     UNREFERENCED(o);
+     UNREFERENCED(x509ChainBio);
+     tcn_ThrowException(e, "Not implemented");
+     return 0;
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, freeX509Chain)(TCN_STDARGS, jlong x509Chain)
+{
+    UNREFERENCED(o);
+    UNREFERENCED(x509Chain);
+    tcn_ThrowException(e, "Not implemented");
 }
 /*** End Apple API Additions ***/
 #endif

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -374,6 +374,8 @@ int         SSL_CTX_use_certificate_chain_bio(SSL_CTX *, BIO *, int);
 int         SSL_use_certificate_chain_bio(SSL *, BIO *, int);
 X509        *load_pem_cert_bio(tcn_pass_cb_t *, const BIO *);
 EVP_PKEY    *load_pem_key_bio(tcn_pass_cb_t *, const BIO *);
+int         tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey);
+int         tcn_X509_up_ref(X509* cert);
 
 int         SSL_callback_SSL_verify(int, X509_STORE_CTX *);
 int         SSL_rand_seed(const char *file);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -32,8 +32,6 @@
 #include "ssl_private.h"
 #include <stdint.h>
 
-static jclass byteArrayClass;
-
 static apr_status_t ssl_context_cleanup(void *data)
 {
     tcn_ssl_ctxt_t *c = (tcn_ssl_ctxt_t *)data;
@@ -99,7 +97,6 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jlong pool,
     apr_pool_t *p = J2P(pool, apr_pool_t *);
     tcn_ssl_ctxt_t *c = NULL;
     SSL_CTX *ctx = NULL;
-    jclass clazz;
 
     UNREFERENCED(o);
 
@@ -325,11 +322,6 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jlong pool,
     apr_pool_cleanup_register(p, (const void *)c,
                               ssl_context_cleanup,
                               apr_pool_cleanup_null);
-
-
-    // Cache the byte[].class for performance reasons
-    clazz = (*e)->FindClass(e, "[B");
-    byteArrayClass = (jclass) (*e)->NewGlobalRef(e, clazz);
 
     return P2J(c);
 init_failed:
@@ -1465,7 +1457,6 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     SSL *ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
     tcn_ssl_ctxt_t *c = SSL_get_app_data2(ssl);
 
-
     // Get a stack of all certs in the chain
     STACK_OF(X509) *sk = ctx->untrusted;
 
@@ -1480,6 +1471,7 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     const char *authMethod;
     jstring authMethodString;
     jint result;
+    jclass byteArrayClass = tcn_get_byte_array_class();
     tcn_get_java_env(&e);
 
     // Create the byte[][] array that holds all the certs
@@ -1566,6 +1558,7 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
     int length;
     unsigned char *buf;
     X509_NAME* principal;
+    jclass byteArrayClass = tcn_get_byte_array_class();
 
     if (names == NULL) {
         return NULL;
@@ -1606,10 +1599,6 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
     return array;
 }
 
-/**
- * Partly based on code from conscrypt:
- * https://android.googlesource.com/platform/external/conscrypt/+/master/src/main/native/org_conscrypt_NativeCrypto.cpp
- */
 static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     tcn_ssl_ctxt_t *c = SSL_get_app_data2(ssl);
     int ctype_num;
@@ -1617,15 +1606,20 @@ static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     jobjectArray issuers;
     JNIEnv *e;
     jbyteArray keyTypes;
-    X509* certificate;
-    EVP_PKEY* privatekey;
+    jobject keyMaterial;
+    STACK_OF(X509) *chain = NULL;
+    X509 *cert = NULL;
+    EVP_PKEY* pkey = NULL;
+    jlong certChain;
+    jlong privateKey;
     tcn_get_java_env(&e);
 
-    /* Clear output of key and certificate in case of early exit due to error. */
-    *x509Out = NULL;
-    *pkeyOut = NULL;
 
-#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER))
+#if defined(LIBRESSL_VERSION_NUMBER)
+    return -1;
+#else
+
+#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_NUMBER < 0x10002000L
     char ssl2_ctype = SSL3_CT_RSA_SIGN;
     switch (ssl->version) {
         case SSL2_VERSION:
@@ -1658,19 +1652,46 @@ static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     issuers = principalBytes(e,  SSL_get_client_CA_list(ssl));
 
     // Execute the java callback
-    (*e)->CallVoidMethod(e, c->cert_requested_callback, c->cert_requested_callback_method, P2J(ssl), keyTypes, issuers);
-
-    // Check for values set from Java
-    certificate = SSL_get_certificate(ssl);
-    privatekey  = SSL_get_privatekey(ssl);
-
-    if (certificate != NULL && privatekey != NULL) {
-        *x509Out = certificate;
-        *pkeyOut = privatekey;
-        return 1;
+    keyMaterial = (*e)->CallObjectMethod(e, c->cert_requested_callback, c->cert_requested_callback_method, P2J(ssl), keyTypes, issuers);
+    if (keyMaterial == NULL) {
+        return 0;
     }
+
+    // Any failure after this line must cause a goto fail to cleanup things.
+    certChain = (*e)->GetLongField(e, keyMaterial, tcn_get_key_material_certificate_chain_field());
+    privateKey = (*e)->GetLongField(e, keyMaterial, tcn_get_key_material_private_key_field());
+
+    chain = J2P(certChain, STACK_OF(X509) *);
+    pkey = J2P(privateKey, EVP_PKEY *);
+
+    if (chain == NULL || pkey == NULL || sk_X509_num(chain) <= 0) {
+        goto fail;
+    }
+
+    // We need to explicit set the chain as stated in:
+    // https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_client_cert_cb.html
+    //
+    // Using SSL_set0_chain(...) here as we not want to increment the reference count.
+    if (SSL_set0_chain(ssl, chain) <= 0) {
+        goto fail;
+    }
+
+    cert = sk_X509_value(chain, 0);
+    // Increment the reference count as we already set the chain via SSL_set0_chain(...) and using a cert out of it.
+    if (tcn_X509_up_ref(cert) <= 0) {
+        goto fail;
+    }
+    *x509Out = cert;
+    *pkeyOut = pkey;
+    return 1;
+fail:
+    ERR_clear_error();
+    sk_X509_pop_free(chain, X509_free);
+    EVP_PKEY_free(pkey);
+
     // TODO: Would it be more correct to return 0 in this case we may not want to use any cert / private key ?
     return -1;
+#endif
 }
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlong ctx, jobject callback)
@@ -1684,7 +1705,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
         SSL_CTX_set_client_cert_cb(c->ctx, NULL);
     } else {
         jclass callback_class = (*e)->GetObjectClass(e, callback);
-        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", "(J[B[[B)V");
+        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", "(J[B[[B)Lorg/apache/tomcat/jni/CertificateRequestedCallback$KeyMaterial;");
         if (method == NULL) {
             return;
         }

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -267,6 +267,14 @@ apr_status_t    tcn_load_ainfo_class(JNIEnv *, jclass);
         }                                           \
     TCN_END_MACRO
 
+#define TCN_GET_FIELD(E, C, F, N, S, R)            \
+    TCN_BEGIN_MACRO                                 \
+        F = (*(E))->GetFieldID((E), C, N, S);      \
+        if (F == NULL) {                            \
+            return R;                               \
+        }                                           \
+    TCN_END_MACRO
+
 #define TCN_MAX_METHODS 8
 
 typedef struct {

--- a/openssl-dynamic/src/main/c/tcn_api.h
+++ b/openssl-dynamic/src/main/c/tcn_api.h
@@ -50,6 +50,10 @@ apr_pool_t *tcn_get_global_pool(void);
  */
 jclass tcn_get_string_class(void);
 
+jclass tcn_get_byte_array_class();
+jfieldID tcn_get_key_material_certificate_chain_field();
+jfieldID tcn_get_key_material_private_key_field();
+
 /* Return global JVM initalized on JNI_OnLoad
  */
 JavaVM *tcn_get_java_vm(void);

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -813,4 +813,38 @@ public final class SSL {
      */
     public static native void setCertificateBio(
             long ssl, long certBio, long keyBio, String password) throws Exception;
+
+    /**
+     * Parse private key from BIO and return {@code EVP_PKEY} pointer.
+     *
+     * <p>Be sure you understand how OpenSsl will behave with respect to reference counting!
+     *
+     * If the {@code EVP_PKEY} pointer is used with the client certificate callback
+     * {@link CertificateRequestedCallback} the ownership goes over to OpenSsl / Tcnative and so calling
+     * {@link #freePrivateKey(long)} should <strong>NOT</strong> be done in this case. Otherwise you may
+     * need to call {@link #freePrivateKey(long)} to decrement the reference count and free memory.
+     */
+    public static native long parsePrivateKey(long privateKeyBio, String password) throws Exception;
+
+    /**
+     * Free private key ({@code EVP_PKEY} pointer).
+     */
+    public static native void freePrivateKey(long privateKey);
+
+    /**
+     * Parse X509 chain from BIO and return ({@code STACK_OF(X509)} pointer).
+     *
+     * <p>Be sure you understand how OpenSsl will behave with respect to reference counting!
+     *
+     * If the {@code STACK_OF(X509)} pointer is used with the client certificate callback
+     * {@link CertificateRequestedCallback} the ownership goes over to OpenSsl / Tcnative and and so calling
+     * {@link #freeX509Chain(long)} should <strong>NOT</strong> be done in this case. Otherwise you may
+     * need to call {@link #freeX509Chain(long)} to decrement the reference count and free memory.
+     */
+    public static native long parseX509Chain(long x509ChainBio) throws Exception;
+
+    /**
+     * Free x509 chain ({@code STACK_OF(X509)} pointer).
+     */
+    public static native void freeX509Chain(long x509Chain);
 }


### PR DESCRIPTION
Motivation:

In the previous CertificateRequestedCallback interface the contract was that users will directly call SSL_ methods to set the key, cert and chain. This could lead to memory leaks or segfaults depending on if the key, cert and chain is freed or not.

Modification:

Change the CertificateRequestedCallback interface to return a KeyMaterial object that holds the chain, key and password. We will call the correct SSL_ methods after calling the callback and so help to prevent leaks and segfaults.

Results:

No more leaks and segfaults.