### PR TITLE
Use openssl 1.1.0 for openssl-static

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
     <libresslSha256>5f87d778e5d62822d60e38fa9621c1c5648fc559d198ba314bd9d89cbf67d9e3</libresslSha256>
-    <opensslVersion>1.0.2h</opensslVersion>
-    <opensslSha256>1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919</opensslSha256>
+    <opensslVersion>1.1.0</opensslVersion>
+    <opensslSha256>4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

openssl 1.1.0 was released and so we should use it when compile static against openssl.

Modifications:

Bump up openssl version.

Result:

Use latest openssl version for static compile