### PR TITLE
Use SSL_version accessor.

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1436,7 +1436,7 @@ static const char* authentication_method(const SSL* ssl) {
 {
     const STACK_OF(SSL_CIPHER) *ciphers = NULL;
 
-    switch (ssl->version)
+    switch (SSL_version(ssl))
         {
         case SSL2_VERSION:
             return SSL_TXT_RSA;


### PR DESCRIPTION
This has been around since SSLeay 0.8.1b. Use it rather than reaching
into OpenSSL structs directly.