### PR TITLE
Ensure we correctly handle parsing of the cert chain when multiple ce…

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2247,7 +2247,7 @@ TCN_IMPLEMENT_CALL(long, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
 
     chain = sk_X509_new_null();
     while ((cert = PEM_read_bio_X509(cert_bio, NULL, NULL, NULL)) != NULL) {
-        if (sk_X509_push(chain, cert) != 1) {
+        if (sk_X509_push(chain, cert) <= 0) {
             tcn_Throw(e, "No Certificate specified or invalid format");
             goto cleanup;
         }


### PR DESCRIPTION
…rtificates are used.

Motivation:

We incorrectly used the return value of sk_X509_push which could lead to a double-free bug when more then 1 certificate was included in the certificate chain.

Modifications:

Correctly test for sk_X509_push(...) > 0.

Result:

No more double-free can happen.