### PR TITLE
Remove Unused Variables

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -657,8 +657,6 @@ static int ssl_rand_make(const char *file, int len, int base64)
 TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
 {
     int r = 0;
-    jclass clazz;
-    jclass sClazz;
 
     TCN_ALLOC_CSTRING(engine);
 

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -38,7 +38,6 @@ static apr_status_t ssl_context_cleanup(void *data)
     JNIEnv *e;
 
     if (c) {
-        int i;
         if (c->crl != NULL)
             X509_STORE_free(c->crl);
         c->crl = NULL;


### PR DESCRIPTION
Motivation:
Some compilers complain if variables are not used

Modifications:
Remove an unused variables.

Result:
Easier compilation time.

cc @Scottmitch 