### PR TITLE
Update libressl to 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.5.2</aprVersion>
     <aprMd5>98492e965963f852ab29f9e61b2ad700</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.4.2</libresslVersion>
+    <libresslVersion>2.4.4</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>5f87d778e5d62822d60e38fa9621c1c5648fc559d198ba314bd9d89cbf67d9e3</libresslSha256>
+    <libresslSha256>6fcfaf6934733ea1dcb2f6a4d459d9600e2f488793e51c2daf49b70518eebfd1</libresslSha256>
     <opensslVersion>1.0.2j</opensslVersion>
     <opensslSha256>e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>


### PR DESCRIPTION
Motivation:

New version of libressl was released

Modifications:

Update version.

Result:

Use up to date version