### PR TITLE
Add max bio size param

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1477,9 +1477,12 @@ TCN_IMPLEMENT_CALL(void, SSL, freeSSL)(TCN_STDARGS,
     SSL_free(ssl_);
 }
 
-// Make a BIO pair (network and internal) for the provided SSL * and return the network BIO
-TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO)(TCN_STDARGS,
-                                               jlong ssl /* SSL * */) {
+// Make a BIO pair (network and internal) for the provided SSL * which has a
+// maximum size of max_bio_size, and return the network BIO.
+// The value max_bio_size = 0 can be supplied to use the default BIO size.
+TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO0)(TCN_STDARGS,
+                                               jlong ssl /* SSL * */,
+                                               jint max_bio_size) {
     SSL *ssl_ = J2P(ssl, SSL *);
     BIO *internal_bio;
     BIO *network_bio;
@@ -1489,7 +1492,16 @@ TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO)(TCN_STDARGS,
         return 0;
     }
 
-    if (BIO_new_bio_pair(&internal_bio, 0, &network_bio, 0) != 1) {
+    if (max_bio_size < 0) {
+        tcn_ThrowException(e, "max_bio_size < 0");
+        return 0;
+    }
+
+    if (BIO_new_bio_pair(
+            &internal_bio,
+            (size_t) max_bio_size,
+            &network_bio,
+            (size_t) max_bio_size) != 1) {
         tcn_ThrowException(e, "BIO_new_bio_pair failed");
         return 0;
     }

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -523,6 +523,15 @@ public final class SSL {
     public static native void freeSSL(long ssl);
 
     /**
+     * Creates a BIO with the default max BIO size.
+     *
+     * @see #makeNetworkBIO(long, int)
+     */
+    public static long makeNetworkBIO(long ssl) {
+        return makeNetworkBIO0(ssl, 0);
+    }
+
+    /**
      * Wire up internal and network BIOs for the given SSL instance.
      *
      * <b>Warning: you must explicitly free this resource by calling freeBIO</b>
@@ -531,9 +540,14 @@ public final class SSL {
      * the provided SSL instance, you must call freeBIO on the returned network BIO.
      *
      * @param ssl the SSL instance (SSL *)
+     * @param maxBioSize The maximum size of the BIO. Pass 0 to use the default max size.
      * @return pointer to the Network BIO (BIO *)
      */
-    public static native long makeNetworkBIO(long ssl);
+    public static long makeNetworkBIO(long ssl, int maxBioSize) {
+        return makeNetworkBIO0(ssl, maxBioSize);
+    }
+
+    private static native long makeNetworkBIO0(long ssl, int maxBioSize);
 
     /**
      * BIO_free


### PR DESCRIPTION
Add max bio size param

Motivation:

We observed that when the number of connections is very large
on a service, the machines started running out of memory.
On memory analysis the major consumer of memory was found
to be the bio allocation.

Modifications:

The default max bio size is 17K. This allows the parameter to be
tunable.

Result:

We've found this extremely useful for scaling large services. On
reducing the buffer size memory usage can be reduced signficantly. The
CPU usage goes up a bit when this is reduced so everyone find their
own sweet spot.