### PR TITLE
Use -fno-omit-frame-pointer to ensure frame pointers are intact

### DIFF
--- a/openssl-dynamic/src/main/native-package/configure.ac
+++ b/openssl-dynamic/src/main/native-package/configure.ac
@@ -28,7 +28,7 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
-${CFLAGS="-O3 -Werror"}
+${CFLAGS="-O3 -Werror -fno-omit-frame-pointer"}
 
 ## -----------------------------------------------
 ## Application Checks


### PR DESCRIPTION
Motivation:

When try to profile with tools like perf / flamegraphs its important to have correct frame pointers.

Modifications:

Use -fno-omit-frame-pointer

Result:

Frame pointers are intact.