### PR TITLE
Expose BIO_should_retry(...) method.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1430,6 +1430,20 @@ TCN_IMPLEMENT_CALL(jint /* status */, SSL, readFromBIO)(TCN_STDARGS,
     return BIO_read(b, r, rlen);
 }
 
+TCN_IMPLEMENT_CALL(jboolean, SSL, shouldRetryBIO)(TCN_STDARGS,
+                                                        jlong bio /* BIO * */) {
+    BIO *b = J2P(bio, BIO *);
+
+    if (b == NULL) {
+        tcn_ThrowException(e, "bio is null");
+        return 0;
+    }
+
+    UNREFERENCED_STDARGS;
+
+    return BIO_should_retry(b) ? JNI_TRUE : JNI_FALSE;
+}
+
 // Write up to wlen bytes of application data to the ssl BIO (encrypt)
 TCN_IMPLEMENT_CALL(jint /* status */, SSL, writeToSSL)(TCN_STDARGS,
                                                        jlong ssl /* SSL * */,
@@ -2539,6 +2553,13 @@ TCN_IMPLEMENT_CALL(jint, SSL, readFromBIO)(TCN_STDARGS, jlong bio, jlong rbuf, j
   UNREFERENCED(rlen);
   tcn_ThrowException(e, "Not implemented");
   return 0;
+}
+
+TCN_IMPLEMENT_CALL(jboolean, SSL, shouldRetryBIO)(TCN_STDARGS, jlong bio) {
+  UNREFERENCED(o);
+  UNREFERENCED(bio);
+  tcn_ThrowException(e, "Not implemented");
+  return JNI_FALSE;
 }
 
 TCN_IMPLEMENT_CALL(jint, SSL, writeToSSL)(TCN_STDARGS, jlong ssl, jlong wbuf, jint wlen) {

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -485,6 +485,13 @@ public final class SSL {
     public static native int readFromBIO(long bio, long rbuf, int rlen);
 
     /**
+     * BIO_should_retry
+     * @param bio the BIO.
+     * @return {@code true} if the failed BIO operation should be retried later.
+     */
+    public static native boolean shouldRetryBIO(long bio);
+
+    /**
      * SSL_write
      * @param ssl the SSL instance (SSL *)
      * @param wbuf


### PR DESCRIPTION
Motivation:

When a BIO operation fails we need to call BIO_should_retry(...) to find out if we should retry the same operation later or not.

Modifications:

Expose BIO_should_retry(...).

Result:

Its now possible to check if BIO operation should be retried later.