### PR TITLE
Fail build when unused c code is detected

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -38,7 +38,6 @@
 #include "ssl_private.h"
 
 static int ssl_initialized = 0;
-static char *ssl_global_rand_file = NULL;
 extern apr_pool_t *tcn_global_pool;
 
 ENGINE *tcn_ssl_engine = NULL;

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -125,7 +125,7 @@
 
 #define MAX_ALPN_NPN_PROTO_SIZE 65535
 
-static const char* UNKNOWN_AUTH_METHOD = "UNKNOWN";
+extern const char* TCN_UNKNOWN_AUTH_METHOD;
 
 /* ECC: make sure we have at least 1.0.0 */
 #if !defined(OPENSSL_NO_EC) && defined(TLSEXT_ECPOINTFORMAT_uncompressed)

--- a/openssl-dynamic/src/main/native-package/configure.ac
+++ b/openssl-dynamic/src/main/native-package/configure.ac
@@ -28,7 +28,7 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
-${CFLAGS="-O3 -Werror -fno-omit-frame-pointer"}
+${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -Wunused-variable"}
 
 ## -----------------------------------------------
 ## Application Checks


### PR DESCRIPTION
Motivation:

To keep our code clean we should fail the build when unused c code is detected.

Modifications:

- Add '-Wunused-variable' to build flags
- Removed some unused code, added ifdefs

Result:

Cleaner code.