### PR TITLE
Allow to use different sizes for both BIO buffers.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1543,7 +1543,7 @@ TCN_IMPLEMENT_CALL(void, SSL, freeSSL)(TCN_STDARGS,
 // The value max_bio_size = 0 can be supplied to use the default BIO size.
 TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO0)(TCN_STDARGS,
                                                jlong ssl /* SSL * */,
-                                               jint max_bio_size) {
+                                               jint maxInternalBIOSize, jint maxNetworkBIOSize) {
     SSL *ssl_ = J2P(ssl, SSL *);
     BIO *internal_bio;
     BIO *network_bio;
@@ -1553,16 +1553,21 @@ TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO0)(TCN_STDARGS,
         return 0;
     }
 
-    if (max_bio_size < 0) {
-        tcn_ThrowException(e, "max_bio_size < 0");
+    if (maxInternalBIOSize < 0) {
+        tcn_ThrowException(e, "maxInternalBIOSize < 0");
+        return 0;
+    }
+
+    if (maxNetworkBIOSize < 0) {
+        tcn_ThrowException(e, "maxNetworkBIOSize < 0");
         return 0;
     }
 
     if (BIO_new_bio_pair(
             &internal_bio,
-            (size_t) max_bio_size,
+            (size_t) maxInternalBIOSize,
             &network_bio,
-            (size_t) max_bio_size) != 1) {
+            (size_t) maxNetworkBIOSize) != 1) {
         tcn_ThrowException(e, "BIO_new_bio_pair failed");
         return 0;
     }
@@ -2600,9 +2605,12 @@ TCN_IMPLEMENT_CALL(void, SSL, freeSSL)(TCN_STDARGS, jlong ssl) {
   tcn_ThrowException(e, "Not implemented");
 }
 
-TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO)(TCN_STDARGS, jlong ssl) {
+TCN_IMPLEMENT_CALL(jlong, SSL, makeNetworkBIO)(TCN_STDARGS, jlong ssl, jint maxInternalBIOSize, jint maxNetworkBIOSize) {
   UNREFERENCED(o);
   UNREFERENCED(ssl);
+  UNREFERENCED(maxInternalBIOSize);
+  UNREFERENCED(maxNetworkBIOSize);
+
   tcn_ThrowException(e, "Not implemented");
   return 0;
 }

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -535,7 +535,16 @@ public final class SSL {
      * @see #makeNetworkBIO(long, int)
      */
     public static long makeNetworkBIO(long ssl) {
-        return makeNetworkBIO0(ssl, 0);
+        return makeNetworkBIO(ssl, 0);
+    }
+
+    /**
+     * Creates a BIO with the given max BIO size.
+     *
+     * @see #makeNetworkBIO(long, int, int)
+     */
+    public static long makeNetworkBIO(long ssl, int maxBioSize) {
+        return makeNetworkBIO0(ssl, maxBioSize, maxBioSize);
     }
 
     /**
@@ -546,15 +555,19 @@ public final class SSL {
      * While the SSL's internal/application data BIO will be freed when freeSSL is called on
      * the provided SSL instance, you must call freeBIO on the returned network BIO.
      *
+     * Please see <a href="https://www.openssl.org/docs/man1.0.1/crypto/BIO_s_bio.html">man BIO_s_bio (example section)</a>
+     * for more details.
+     *
      * @param ssl the SSL instance (SSL *)
-     * @param maxBioSize The maximum size of the BIO. Pass 0 to use the default max size.
+     * @param maxInternalBIOSize The maximum size of the application side BIO. Pass 0 to use the default max size.
+     * @param maxNetworkBIOSize The maximum size of the network side BIO. Pass 0 to use the default max size.
      * @return pointer to the Network BIO (BIO *)
      */
-    public static long makeNetworkBIO(long ssl, int maxBioSize) {
-        return makeNetworkBIO0(ssl, maxBioSize);
+    public static long makeNetworkBIO(long ssl, int maxInternalBIOSize, int maxNetworkBIOSize) {
+        return makeNetworkBIO0(ssl, maxInternalBIOSize, maxNetworkBIOSize);
     }
 
-    private static native long makeNetworkBIO0(long ssl, int maxBioSize);
+    private static native long makeNetworkBIO0(long ssl, int maxInternalBIOSize, int maxNetworkBIOSize);
 
     /**
      * BIO_free


### PR DESCRIPTION
Motivation:

e691680c4caaf6873ce457b11c67bed2b11ebc74 introduced a new method that allowed to set the BIO buffer size but this size is used for both buffers while sometimes different sizes can make sense.

Modifications:

Add new method that take two different buffer sizes.

Result:

More flexible way of creating network BIOs.