### PR TITLE
Allow to set CA list for SSLContext via BIO

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -41,6 +41,7 @@
 
 #include "apr_thread_rwlock.h"
 #include "apr_atomic.h"
+#include <stdbool.h>
 
 /* OpenSSL headers */
 #include <openssl/opensslv.h>
@@ -387,9 +388,10 @@ DH         *SSL_callback_tmp_DH_1024(SSL *, int, int);
 DH         *SSL_callback_tmp_DH_2048(SSL *, int, int);
 DH         *SSL_callback_tmp_DH_4096(SSL *, int, int);
 void        SSL_callback_handshake(const SSL *, int, int);
-int         SSL_CTX_use_certificate_chain(SSL_CTX *, const char *, int);
-int         SSL_CTX_use_certificate_chain_bio(SSL_CTX *, BIO *, int);
-int         SSL_use_certificate_chain_bio(SSL *, BIO *, int);
+int         SSL_CTX_use_certificate_chain(SSL_CTX *, const char *, bool);
+int         SSL_CTX_use_certificate_chain_bio(SSL_CTX *, BIO *, bool);
+int         SSL_CTX_use_client_CA_bio(SSL_CTX *, BIO *);
+int         SSL_use_certificate_chain_bio(SSL *, BIO *, bool);
 X509        *load_pem_cert_bio(tcn_pass_cb_t *, const BIO *);
 EVP_PKEY    *load_pem_key_bio(tcn_pass_cb_t *, const BIO *);
 int         tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -593,6 +593,17 @@ cleanup:
     return rv;
 }
 
+TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCACertificateBio)(TCN_STDARGS, jlong ctx, jlong certs)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+    BIO *b = J2P(certs, BIO *);
+
+    UNREFERENCED(o);
+    TCN_ASSERT(c != NULL);
+
+    return b != NULL && c->mode != SSL_MODE_CLIENT && SSL_CTX_use_client_CA_bio(c->ctx, b) > 0 ? JNI_TRUE : JNI_FALSE;
+}
+
 TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDH)(TCN_STDARGS, jlong ctx,
                                                                   jstring file)
 {
@@ -1899,6 +1910,16 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCACertificate)(TCN_STDARGS,
     return JNI_FALSE;
 }
 
+TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCACertificateBio)(TCN_STDARGS,
+                                                           jlong ctx,
+                                                           jlong certs)
+{
+    UNREFERENCED_STDARGS;
+    UNREFERENCED(ctx);
+    UNREFERENCED(certs);
+    return JNI_FALSE;
+}
+
 TCN_IMPLEMENT_CALL(void, SSLContext, setShutdownType)(TCN_STDARGS, jlong ctx,
                                                       jint type)
 {
@@ -1949,6 +1970,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateBio)(TCN_STDARGS, jlong c
     UNREFERENCED(idx);
     return JNI_FALSE;
 }
+
 TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray next_protos,
         jint selectorFailureBehavior)
 {
@@ -1956,7 +1978,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos)(TCN_STDARGS, jlong ctx, jobje
     UNREFERENCED(ctx);
     UNREFERENCED(next_protos);
 }
-
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobjectArray alpn_protos,
         jint selectorFailureBehavior)

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSLContext.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSLContext.java
@@ -441,6 +441,22 @@ public final class SSLContext {
         throws Exception;
 
     /**
+     * Set concatenated PEM-encoded CA Certificates for Client Auth
+     * <br>
+     * This directive sets the all-in-one BIO where you can assemble the
+     * Certificates of Certification Authorities (CA) whose clients you deal with.
+     * These are used for Client Authentication. Such a BIO is simply the
+     * concatenation of the various PEM-encoded Certificate files, in order of
+     * preference. This can be used alternatively and/or additionally to
+     * path.
+     * <br>
+     * @param ctx Server context to use.
+     * @param certBio Directory of PEM-encoded CA Certificates for Client Auth.
+     * @return {@code true} if successful, {@code false} otherwise.
+     */
+    public static native boolean setCACertificateBio(long ctx, long certBio);
+
+    /**
      * Set file for randomness
      * @param ctx Server or Client context to use.
      * @param file random file.


### PR DESCRIPTION
Motivation:

To correct announce CA list we need to allow setting it via a BIO so we can hook it up with the X509TrustManager.
This is needed to fix https://github.com/netty/netty/issues/6141 .

Modifications:

Add new SSLContext.setCACertifcateBio(...) method

Result:

Be able to set the to be announced CA list.