### PR TITLE
Remove no-op SSL_set_verify_result calls.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -658,9 +658,6 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
         SSL_set_connect_state(ssl);
     }
 
-    // Setup verify and seed
-    SSL_set_verify_result(ssl, X509_V_OK);
-
     // Store for later usage in SSL_callback_SSL_verify
     SSL_set_app_data2(ssl, c);
     return P2J(ssl);

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -565,7 +565,6 @@ int SSL_callback_SSL_verify(int ok, X509_STORE_CTX *ctx)
     if (SSL_VERIFY_ERROR_IS_OPTIONAL(errnum) &&
         (verify == SSL_CVERIFY_OPTIONAL_NO_CA)) {
         ok = 1;
-        SSL_set_verify_result(ssl, X509_V_OK);
     }
 
     if (errdepth > depth) {


### PR DESCRIPTION
Note: I haven't been able to build and test netty, so someone will probably need to double-check this to confirm these are no-ops.


Motivation:

These function calls don't do anything. The first is called right after
SSL_new, but the value is initialized to X509_V_OK anyway. There hasn't
been a certificate to report a result on:
https://git.openssl.org/gitweb/?p=openssl.git;a=blob;f=ssl/ssl_lib.c;h=65e3ba1824dbc3b8c252982582a322ddf3fe3d70;hb=HEAD#l638

The second happens in the verify_callback. This too does nothing as any
value set gets immediately clobbered:
https://git.openssl.org/gitweb/?p=openssl.git;a=blob;f=ssl/ssl_cert.c;h=f26e8760149b503c0290de36e78a65728be4ebfb;hb=HEAD#l433

The verify_callback is called as part of X509_verify_cert. Immediately
afterwards, the error is extracted from the X509_STORE_CTX and written
to s->verify_result.

netty-tcnative also does not call SSL_get_verify_result, so it does not
care what the value is. It relies on whether or not certificate errors
are configured to terminate the connection.

Modifications:

Remove the two unnecessary calls.

Result:

No behavior change.