### PR TITLE
OCSP support for netty-tcnative

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -101,7 +101,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad_netty_tcnative(JavaVM *vm, void *reserved)
 /* Called by the JVM when APR_JAVA is loaded */
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 {
-  return JNI_OnLoad_netty_tcnative(vm, reserved);
+    return JNI_OnLoad_netty_tcnative(vm, reserved);
 }
 
 /* Called by the JVM before the APR_JAVA is unloaded */
@@ -114,6 +114,7 @@ JNIEXPORT void JNICALL JNI_OnUnload_netty_tcnative(JavaVM *vm, void *reserved)
     if ((*vm)->GetEnv(vm, (void **)&env, TCN_JNI_VERSION)) {
         return;
     }
+
     if (tcn_global_pool) {
         TCN_UNLOAD_CLASS(env, jString_class);
         apr_terminate();

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -161,6 +161,12 @@ extern void *SSL_temp_keys[SSL_TMP_KEY_MAX];
 #define TCN_X509_V_ERR_UNSPECIFIED (X509_V_ERR_UNSPECIFIED)
 #endif /*X509_V_ERR_UNSPECIFIED*/
 
+// OCSP stapling should be present in OpenSSL as of version 1.0.0 but we've
+// only tested 1.0.2 are therefore limiting us to that version or newer.
+#if OPENSSL_VERSION_NUMBER < 0x10002000L
+#define TCN_OCSP_NOT_SUPPORTED
+#endif
+
 typedef struct tcn_ssl_ctxt_t tcn_ssl_ctxt_t;
 
 typedef struct {

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -33,6 +33,8 @@ package io.netty.internal.tcnative;
 
 import java.nio.ByteBuffer;
 
+import javax.net.ssl.SSLEngine;
+
 import static io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods.*;
 
 public final class SSL {
@@ -625,4 +627,41 @@ public final class SSL {
      * @param x509Chain {@code STACK_OF(X509)} pointer
      */
     public static native void freeX509Chain(long x509Chain);
+    
+    /**
+     * Enables OCSP stapling for the given {@link SSLEngine} or throws an
+     * exception if OCSP stapling is not supported.
+     * 
+     * <p>NOTE: This needs to happen before the SSL handshake.
+     * 
+     * <p><a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_tlsext_status_type.html">SSL_set_tlsext_status_type</a>
+     * <p><a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html">Search for OCSP</a>
+     */
+    public static native void enableOcsp(long ssl);
+
+    /**
+     * Sets the OCSP response for the given {@link SSLEngine} or throws an
+     * exception in case of an error.
+     *
+     * <p>NOTE: This is only meant to be called for server {@link SSLEngine}s.
+     *
+     * <p><a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_tlsext_status_type.html">SSL_set_tlsext_status_type</a>
+     * <p><a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html">Search for OCSP</a>
+     *
+     * @param ssl the SSL instance (SSL *)
+     */
+    public static native void setOcspResponse(long ssl, byte[] response);
+
+    /**
+     * Returns the OCSP response for the given {@link SSLEngine} or {@code null}
+     * if the server didn't provide a stapled OCSP response.
+     *
+     * <p>NOTE: This is only meant to be called for client {@link SSLEngine}s.
+     *
+     * <p><a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_tlsext_status_type.html">SSL_set_tlsext_status_type</a>
+     * <p><a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html">Search for OCSP</a>
+     *
+     * @param ssl the SSL instance (SSL *)
+     */
+    public static native byte[] getOcspResponse(long ssl);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -539,4 +539,21 @@ public final class SSLContext {
      * @return the mode.
      */
     public static native int getMode(long ctx);
+    
+    /**
+     * Enables OCSP stapling for the given {@link SSLContext} or throws an
+     * exception if OCSP stapling is not supported.
+     * 
+     * <p><a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_tlsext_status_type.html">SSL_set_tlsext_status_type</a>
+     * <p><a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html">Search for OCSP</a>
+     */
+    public static native void enableOcsp(long ctx, boolean client);
+
+    /**
+     * Disables OCSP stapling on the given {@link SSLContext}.
+     * 
+     * <p><a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_tlsext_status_type.html">SSL_set_tlsext_status_type</a>
+     * <p><a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html">Search for OCSP</a>
+     */
+    public static native void disableOcsp(long ctx);
 }


### PR DESCRIPTION
OCSP stapling support for netty-tcnative using OpenSSL's tlsext_status API. This is a low-level API and not meant to be used directly. There will be a saparate PR for Netty.

Motivation

OCSP stapling (formally known as TLS Certificate Status Request extension) is alternative approach for checking the revocation status of X.509 Certificates. Servers can preemptively fetch the OCSP response from the CA's responder, cache it for some period of time, and pass it along during (a.k.a. staple) the TLS handshake. The client no longer has to reach out on its own to the CA to check the validity of a cetitficate. Some of the key benefits are:

1) Speed. The client doesn't have to crosscheck the certificate.
2) Efficiency. The Internet is no longer DDoS'ing the CA's OCSP responder servers.
3) Safety. Less operational dependence on the CA. Certificate owners can sustain short CA outages.
4) Privacy. The CA can lo longer track the users of a certificate.

https://en.wikipedia.org/wiki/OCSP_stapling
https://letsencrypt.org/2016/10/24/squarespace-ocsp-impl.html

Modifications

https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_tlsext_status_type.html

Result

Low-level API to enable OCSP stapling