### PR TITLE
ByteBuffer BIO

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -144,8 +144,13 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define OPENSSL_malloc_init CRYPTO_malloc_init
 #define X509_REVOKED_get0_serialNumber(x) x->serialNumber
 #define OpenSSL_version_num SSLeay
+#define BIO_get_init(x)       ((x)->init)
+#define BIO_set_init(x,v)     ((x)->init=(v))
+#define BIO_get_data(x)       ((x)->ptr)
+#define BIO_set_data(x,v)     ((x)->ptr=(v))
+#define BIO_set_shutdown(x,v) ((x)->shutdown=(v))
+#define BIO_get_shutdown(x)   ((x)->shutdown)
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
-
 
 #define SSL_SELECTOR_FAILURE_NO_ADVERTISE                       0
 #define SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL            1

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -142,6 +142,7 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
         }                                           \
     TCN_END_MACRO
 
+#define TCN_MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /* Return global String class
  */


### PR DESCRIPTION
Motivation:
Currently netty-tcnative uses BIO_new_bio_pair so we can control all FD lifetime and event notification in Java but delegates to OpenSSL for encryption/decryption. The current implementation sets up a pair of BIO buffers to read/write encrypted/plaintext data. This approach requires copying of data from Java ByteBuffers to native memory BIO buffers, and also requires both BIO buffers to be sufficiently large to hold application data. If direct ByteBuffers are used we can avoid copying to/from the intermediate BIO buffer and just read/write directly from the direct ByteBuffer memory. We still need an internal buffer because OpenSSL may generate write data as a result of read calls (e.g. handshake, alerts, renegotiation, etc..), but this buffer doesn't have to be be large enough to hold application data.

Modifications:
- Implement BIO which reads/writes from/to direct ByteBuffer memory.
- The BIO must also support an intermediate storage buffer for when OpenSSL generates write data but we are reading.

Result:
Allows for less memory copying and lower memory for internal buffers when used from Java.