### PR TITLE
add some function to ssl.c for client side session resumption.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2369,6 +2369,55 @@ TCN_IMPLEMENT_CALL(void, SSL, freeX509Chain)(TCN_STDARGS, jlong x509Chain)
     sk_X509_pop_free(chain, X509_free);
 }
 
+TCN_IMPLEMENT_CALL(jlong, SSL, getSession)(TCN_STDARGS, jlong ssl)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return 0;
+    }
+
+    UNREFERENCED(o);
+
+    SSL_SESSION *sess = SSL_get1_session(ssl_);
+    return P2J(sess);
+}
+
+TCN_IMPLEMENT_CALL(jint, SSL, setSession)(TCN_STDARGS, jlong ssl, jlong sess)
+{
+    SSL *ssl_ = J2P(ssl, SSL *);
+    SSL_SESSION *sess_ = J2P(sess, SSL_SESSION *);
+
+    if (ssl_ == NULL) {
+        tcn_ThrowException(e, "ssl is null");
+        return 0;
+    }
+
+    if (sess_ == NULL) {
+        tcn_ThrowException(e, "sess is null");
+        return 0;
+    }
+
+    UNREFERENCED(o);
+
+    return (jint)SSL_set_session(ssl_, sess_);
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, freeSession)(TCN_STDARGS, jlong sess)
+{
+    SSL_SESSION *sess_ = J2P(sess, SSL_SESSION *);
+
+    if (sess_ == NULL) {
+        tcn_ThrowException(e, "sess is null");
+        return;
+    }
+
+    UNREFERENCED(o);
+
+    SSL_SESSION_free(sess_);
+}
+
 /*** End Apple API Additions ***/
 
 #else
@@ -2847,5 +2896,30 @@ TCN_IMPLEMENT_CALL(void, SSL, freeX509Chain)(TCN_STDARGS, jlong x509Chain)
     UNREFERENCED(x509Chain);
     tcn_ThrowException(e, "Not implemented");
 }
+
+TCN_IMPLEMENT_CALL(jlong, SSL, getSession)(TCN_STDARGS, jlong ssl)
+{
+    UNREFERENCED(o);
+    UNREFERENCED(ssl);
+    tcn_ThrowException(e, "Not implemented");
+    return 0;
+}
+
+TCN_IMPLEMENT_CALL(jint, SSL, setSession)(TCN_STDARGS, jlong ssl, jlong sess)
+{
+    UNREFERENCED(o);
+    UNREFERENCED(ssl);
+    UNREFERENCED(sess);
+    tcn_ThrowException(e, "Not implemented");
+    return 0;
+}
+
+TCN_IMPLEMENT_CALL(void, SSL, freeSession)(TCN_STDARGS, jlong sess)
+{
+    UNREFERENCED(o);
+    UNREFERENCED(sess);
+    tcn_ThrowException(e, "Not implemented");
+}
+
 /*** End Apple API Additions ***/
 #endif

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -881,4 +881,32 @@ public final class SSL {
      * Free x509 chain ({@code STACK_OF(X509)} pointer).
      */
     public static native void freeX509Chain(long x509Chain);
+
+    /**
+     * Call SSL_get1_session.
+     * https://www.openssl.org/docs/man1.1.0/ssl/SSL_get1_session.html
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return pointer to SSL_SESSION instance (SSL_SESSION *)
+     */
+    public static native long getSession(long ssl);
+
+    /**
+     * Call SSL_set_session.
+     * https://www.openssl.org/docs/man1.0.1/ssl/SSL_set_session.html
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @param sess the SSL_SESSION instance (SSL_SESSION *)
+     * @return return value of SSL_set_session
+     */
+    public static native int setSession(long ssl, long sess);
+
+    /**
+     * Call SSL_SESSION_free.
+     * https://www.openssl.org/docs/man1.0.1/ssl/SSL_SESSION_free.html
+     *
+     * @param sess the SSL_SESSION instance (SSL_SESSION *)
+     */
+    public static native void freeSession(long sess);
+
 }

--- a/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/org/apache/tomcat/jni/SSL.java
@@ -884,7 +884,7 @@ public final class SSL {
 
     /**
      * Call SSL_get1_session.
-     * https://www.openssl.org/docs/man1.1.0/ssl/SSL_get1_session.html
+     * @see <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get1_session.html">OpenSSL method SSL_get1_session()</a>
      *
      * @param ssl the SSL instance (SSL *)
      * @return pointer to SSL_SESSION instance (SSL_SESSION *)
@@ -893,7 +893,7 @@ public final class SSL {
 
     /**
      * Call SSL_set_session.
-     * https://www.openssl.org/docs/man1.0.1/ssl/SSL_set_session.html
+     * @see <a href="https://www.openssl.org/docs/man1.0.1/ssl/SSL_set_session.html">OpenSSL method SSL_set_session()</a>
      *
      * @param ssl the SSL instance (SSL *)
      * @param sess the SSL_SESSION instance (SSL_SESSION *)
@@ -903,7 +903,7 @@ public final class SSL {
 
     /**
      * Call SSL_SESSION_free.
-     * https://www.openssl.org/docs/man1.0.1/ssl/SSL_SESSION_free.html
+     * @see <a href="https://www.openssl.org/docs/man1.0.1/ssl/SSL_SESSION_free.html">OpenSSL method SSL_SESSION_free()</a>
      *
      * @param sess the SSL_SESSION instance (SSL_SESSION *)
      */


### PR DESCRIPTION
Motivation:
It need getSession, setSession and freeSession for client side session resumption.

Modifications:
Add getSession(SSL_get1_session), setSession(SSL_set_session), freeSession(SSL_SESSION_free) method.

Result:
Be able to handle session for client side session resumption.