### PR TITLE
Explicit specify the c99 should be used when compiling boringssl-static

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -156,6 +156,7 @@
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
                           <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=-std=c99" />
                           <arg value="-GNinja" />
                           <arg value=".." />
                         </exec>


### PR DESCRIPTION
Motivation:

On some linux distributions its needed to explicit specify that c99 should be used when compile boringssl-static. If this is not done the build will fail.

Modifications:

Ensure we use c99 when compile boringssl-static.

Result:

No more compile errors on some linux distributions