### PR TITLE
Fix 'SSL3_SEND_SERVER_KEY_EXCHANGE:missing tmp dh key' when using lib…

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -223,12 +223,8 @@ static const jint supported_ssl_opts = 0
 
 static int ssl_tmp_key_init_dh(int bits, int idx)
 {
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED)
-    if (!(SSL_temp_keys[idx] =
-          SSL_dh_get_tmp_param(bits)))
-        return 1;
-    else
-        return 0;
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED) || defined(LIBRESSL_VERSION_NUMBER)
+    return (SSL_temp_keys[idx] = SSL_dh_get_tmp_param(bits)) ? 0 : 1;
 #else
     return 0;
 #endif


### PR DESCRIPTION
…ressl

Motivation:

We need to ensure we correctly call SSL_dh_get_tmp_param(...) when using libressl.

Modifications:

Call SSL_dh_get_tmp_param(...) when libressl is used.

Result:

No more failures du missing tmp dh key.