### PR TITLE
Rename package to internal to make it clear its for netty use only.

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -68,7 +68,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad_netty_tcnative(JavaVM *vm, void *reserved)
     apr_version(&apv);
     apvn = apv.major * 1000 + apv.minor * 100 + apv.patch;
     if (apvn < 1201) {
-        tcn_Throw(env, "Unupported APR version (%s)",
+        tcn_Throw(env, "Unsupported APR version (%s)",
                   apr_version_string());
         return JNI_ERR;
     }
@@ -83,7 +83,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad_netty_tcnative(JavaVM *vm, void *reserved)
                    "getBytes", "()[B", JNI_ERR);
 
     TCN_LOAD_CLASS(env, byteArrayClass, "[B", JNI_ERR);
-    TCN_LOAD_CLASS(env, keyMaterialClass, "io/netty/tcnative/jni/CertificateRequestedCallback$KeyMaterial", JNI_ERR);
+    TCN_LOAD_CLASS(env, keyMaterialClass, "io/netty/internal/tcnative/CertificateRequestedCallback$KeyMaterial", JNI_ERR);
 
     TCN_GET_FIELD(env, keyMaterialClass, keyMaterialCertificateChainFieldId,
                    "certificateChain", "J", JNI_ERR);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1465,7 +1465,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
         SSL_CTX_set_client_cert_cb(c->ctx, NULL);
     } else {
         jclass callback_class = (*e)->GetObjectClass(e, callback);
-        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", "(J[B[[B)Lio/netty/tcnative/jni/CertificateRequestedCallback$KeyMaterial;");
+        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", "(J[B[[B)Lio/netty/internal/tcnative/CertificateRequestedCallback$KeyMaterial;");
         if (method == NULL) {
             return;
         }

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -72,8 +72,7 @@
 #define TCN_STDARGS     JNIEnv *e, jobject o
 
 #define TCN_IMPLEMENT_CALL(RT, CL, FN)  \
-    JNIEXPORT RT JNICALL Java_io_netty_tcnative_jni_##CL##_##FN
-
+    JNIEXPORT RT JNICALL Java_io_netty_internal_tcnative_##CL##_##FN
 
 /* Private helper functions */
 void            tcn_Throw(JNIEnv *, const char *, ...);

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Buffer.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Buffer.java
@@ -30,7 +30,7 @@
  *  limitations under the License.
  */
 
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 import java.nio.ByteBuffer;
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 /**
  * Is called during handshake and hooked into openssl via {@code SSL_CTX_set_client_cert_cb}.

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateVerifier.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateVerifier.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 /**
  * Is called during handshake and hooked into openssl via {@code SSL_CTX_set_cert_verify_callback}.

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
@@ -30,7 +30,7 @@
  *  limitations under the License.
  */
 
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 import java.io.File;
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -29,7 +29,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 import java.nio.ByteBuffer;
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -30,7 +30,7 @@
  *  limitations under the License.
  */
 
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 public final class SSLContext {
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SessionTicketKey.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SessionTicketKey.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package io.netty.tcnative.jni;
+package io.netty.internal.tcnative;
 
 /**
  * Session Ticket Key

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
                 <supportedProjectType>jar</supportedProjectType>
               </supportedProjectTypes>
               <instructions>
-                <Export-Package>io.netty.tcnative.jni.*</Export-Package>
+                <Export-Package>io.netty.internal.tcnative.*</Export-Package>
                 <Bundle-NativeCode>${tcnativeManifest}</Bundle-NativeCode>
               </instructions>
             </configuration>


### PR DESCRIPTION
Motivation:

We should put everything in an internal package to make it clear its for netty usage only and so we are free to break it at any time.

Modifications:

Move everything to an internal package.

Result:

Ensure peple are aware its an internal project.