### PR TITLE
setVerify issues and updates

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -854,8 +854,8 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
     }
 #endif
 
-    /* For SSL_get_app_data2() and SSL_get_app_data3() at request time */
-    SSL_init_app_data2_3_idx();
+    // For SSL_get_app_data*() at request time
+    SSL_init_app_data_idx();
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
     init_bio_methods();
@@ -947,8 +947,22 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
         return 0;
     }
 
+    // Set the app_data2 before all the others because it may be used in SSL_free.
+    SSL_set_app_data2(ssl, c);
+
+    // Initially we will share the configuration from the SSLContext.
+    // Set this before other app_data because there is no chance of failure, and if other app_data initialization fails
+    // SSL_free maybe called and the state of this variable is assumed to be initalized.
+    SSL_set_app_data4(ssl, &c->verify_config);
+
     // Store the handshakeCount in the SSL instance.
-    handshakeCount = malloc(sizeof(int));
+    handshakeCount = (int*) OPENSSL_malloc(sizeof(int));
+    if (handshakeCount == NULL) {
+        SSL_free(ssl);
+        tcn_ThrowException(e, "cannot create handshakeCount user data");
+        return 0;
+    }
+
     *handshakeCount = 0;
     SSL_set_app_data3(ssl, handshakeCount);
 
@@ -961,8 +975,6 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
         SSL_set_connect_state(ssl);
     }
 
-    // Store for later usage in SSL_callback_SSL_verify
-    SSL_set_app_data2(ssl, c);
     return P2J(ssl);
 }
 
@@ -1125,17 +1137,29 @@ TCN_IMPLEMENT_CALL(void, SSL, setShutdown)(TCN_STDARGS,
 TCN_IMPLEMENT_CALL(void, SSL, freeSSL)(TCN_STDARGS,
                                        jlong ssl /* SSL * */) {
     int *handshakeCount = NULL;
+    tcn_ssl_ctxt_t* c = NULL;
+    tcn_ssl_verify_config_t* verify_config = NULL;
     SSL *ssl_ = J2P(ssl, SSL *);
     if (ssl_ == NULL) {
         tcn_ThrowException(e, "ssl is null");
         return;
     }
+    c = SSL_get_app_data2(ssl_);
     handshakeCount = SSL_get_app_data3(ssl_);
+    verify_config = SSL_get_app_data4(ssl_);
 
     UNREFERENCED_STDARGS;
+    TCN_ASSERT(c != NULL);
 
     if (handshakeCount != NULL) {
-        free(handshakeCount);
+        OPENSSL_free(handshakeCount);
+        SSL_set_app_data3(ssl_, NULL);
+    }
+
+    // Only free the verify_config if it is not shared with the SSLContext.
+    if (verify_config != NULL && verify_config != &c->verify_config) {
+        OPENSSL_free(verify_config);
+        SSL_set_app_data4(ssl_, &c->verify_config);
     }
     SSL_free(ssl_);
 }
@@ -1500,11 +1524,10 @@ TCN_IMPLEMENT_CALL(jlong, SSL, setTimeout)(TCN_STDARGS, jlong ssl, jlong seconds
 }
 
 
-TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl,
-                                                jint level, jint depth)
+TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl, jint level, jint depth)
 {
-    tcn_ssl_ctxt_t *c;
-    int verify;
+    tcn_ssl_verify_config_t* verify_config;
+    tcn_ssl_ctxt_t* c;
     SSL *ssl_ = J2P(ssl, SSL *);
 
     if (ssl_ == NULL) {
@@ -1513,36 +1536,25 @@ TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl,
     }
 
     c = SSL_get_app_data2(ssl_);
-
-    verify = SSL_VERIFY_NONE;
+    verify_config = SSL_get_app_data4(ssl_);
 
     UNREFERENCED(o);
-    TCN_ASSERT(ctx != 0);
-    c->verify_mode = level;
+    TCN_ASSERT(c != NULL);
+    TCN_ASSERT(verify_config != NULL);
 
-    if (c->verify_mode == SSL_CVERIFY_UNSET)
-        c->verify_mode = SSL_CVERIFY_NONE;
-    if (depth > 0)
-        c->verify_depth = depth;
-    /*
-     *  Configure callbacks for SSL context
-     */
-    if (c->verify_mode == SSL_CVERIFY_REQUIRE)
-        verify |= SSL_VERIFY_PEER_STRICT;
-    if ((c->verify_mode == SSL_CVERIFY_OPTIONAL) ||
-        (c->verify_mode == SSL_CVERIFY_OPTIONAL_NO_CA))
-        verify |= SSL_VERIFY_PEER;
-    if (!c->store) {
-        if (SSL_CTX_set_default_verify_paths(c->ctx)) {
-            c->store = SSL_CTX_get_cert_store(c->ctx);
-            X509_STORE_set_flags(c->store, 0);
-        }
-        else {
-            /* XXX: See if this is fatal */
-        }
+    // If we are sharing the configuration from the SSLContext we now need to create a new configuration just for this SSL.
+    if (verify_config == &c->verify_config) {
+       verify_config = (tcn_ssl_verify_config_t*) OPENSSL_malloc(sizeof(tcn_ssl_verify_config_t));
+       if (verify_config == NULL) {
+           tcn_ThrowException(e, "failed to allocate tcn_ssl_verify_config_t");
+           return;
+       }
+       SSL_set_app_data4(ssl_, verify_config);
     }
 
-    SSL_set_verify(ssl_, verify, SSL_callback_SSL_verify);
+    // No need to specify a callback for SSL_set_verify because we override the default certificate verification via SSL_CTX_set_cert_verify_callback.
+    SSL_set_verify(ssl_, tcn_set_verify_config(verify_config, level, depth), NULL);
+    SSL_set_verify_depth(ssl_, verify_config->verify_depth);
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, setOptions)(TCN_STDARGS, jlong ssl,
@@ -1707,10 +1719,7 @@ TCN_IMPLEMENT_CALL(jint, SSL, getHandshakeCount)(TCN_STDARGS, jlong ssl)
     UNREFERENCED(o);
 
     handshakeCount = SSL_get_app_data3(ssl_);
-    if (handshakeCount != NULL) {
-        return *handshakeCount;
-    }
-    return 0;
+    return handshakeCount != NULL ? *handshakeCount : 0;
 }
 
 

--- a/openssl-dynamic/src/main/java/io/netty/tcnative/jni/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/tcnative/jni/SSL.java
@@ -38,11 +38,6 @@ public final class SSL {
     private SSL() { }
 
     /*
-     * Type definitions mostly from mod_ssl
-     */
-    public static final int UNSET            = -1;
-
-    /*
      * Define the SSL Protocol options
      */
     public static final int SSL_PROTOCOL_NONE  = 0;
@@ -58,20 +53,10 @@ public final class SSL {
     /*
      * Define the SSL verify levels
      */
-    public static final int SSL_CVERIFY_UNSET          = UNSET;
-    public static final int SSL_CVERIFY_NONE           = 0;
-    public static final int SSL_CVERIFY_OPTIONAL       = 1;
-    public static final int SSL_CVERIFY_REQUIRE        = 2;
-    public static final int SSL_CVERIFY_OPTIONAL_NO_CA = 3;
-
-    /* Use either SSL_VERIFY_NONE or SSL_VERIFY_PEER, the last 2 options
-     * are 'ored' with SSL_VERIFY_PEER if they are desired
-     */
-    public static final int SSL_VERIFY_NONE                 = 0;
-    public static final int SSL_VERIFY_PEER                 = 1;
-    public static final int SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 2;
-    public static final int SSL_VERIFY_CLIENT_ONCE          = 4;
-    public static final int SSL_VERIFY_PEER_STRICT          = (SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
+    public static final int SSL_CVERIFY_IGNORED            = -1;
+    public static final int SSL_CVERIFY_NONE               = 0;
+    public static final int SSL_CVERIFY_OPTIONAL           = 1;
+    public static final int SSL_CVERIFY_REQUIRED           = 2;
 
     public static final int SSL_OP_MICROSOFT_SESS_ID_BUG            = 0x00000001;
     public static final int SSL_OP_NETSCAPE_CHALLENGE_BUG           = 0x00000002;
@@ -457,14 +442,12 @@ public final class SSL {
      * but before the HTTP response is sent.
      * <br />
      * The following levels are available for level:
-     * <pre>
-     * SSL_CVERIFY_NONE           - No client Certificate is required at all
-     * SSL_CVERIFY_OPTIONAL       - The client may present a valid Certificate
-     * SSL_CVERIFY_REQUIRE        - The client has to present a valid Certificate
-     * SSL_CVERIFY_OPTIONAL_NO_CA - The client may present a valid Certificate
-     *                              but it need not to be (successfully) verifiable
-     * </pre>
-     * <br />
+     * <ul>
+     * <li>{@link #SSL_CVERIFY_IGNORED} - The level is ignored. Only depth will change.</li>
+     * <li>{@link #SSL_CVERIFY_NONE} - No client Certificate is required at all</li>
+     * <li>{@link #SSL_CVERIFY_OPTIONAL} - The client may present a valid Certificate</li>
+     * <li>{@link #SSL_CVERIFY_REQUIRED} - The client has to present a valid Certificate</li>
+     * </ul>
      * The depth actually is the maximum number of intermediate certificate issuers,
      * i.e. the number of CA certificates which are max allowed to be followed while
      * verifying the client certificate. A depth of 0 means that self-signed client

--- a/openssl-dynamic/src/main/java/io/netty/tcnative/jni/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/tcnative/jni/SSLContext.java
@@ -378,14 +378,12 @@ public final class SSLContext {
      * but before the HTTP response is sent.
      * <br>
      * The following levels are available for level:
-     * <PRE>
-     * SSL_CVERIFY_NONE           - No client Certificate is required at all
-     * SSL_CVERIFY_OPTIONAL       - The client may present a valid Certificate
-     * SSL_CVERIFY_REQUIRE        - The client has to present a valid Certificate
-     * SSL_CVERIFY_OPTIONAL_NO_CA - The client may present a valid Certificate
-     *                              but it need not to be (successfully) verifiable
-     * </PRE>
-     * <br>
+     * <ul>
+     * <li>{@link SSL#SSL_CVERIFY_IGNORED} - The level is ignored. Only depth will change.</li>
+     * <li>{@link SSL#SSL_CVERIFY_NONE} - No client Certificate is required at all</li>
+     * <li>{@link SSL#SSL_CVERIFY_OPTIONAL} - The client may present a valid Certificate</li>
+     * <li>{@link SSL#SSL_CVERIFY_REQUIRED} - The client has to present a valid Certificate</li>
+     * </ul>
      * The depth actually is the maximum number of intermediate certificate issuers,
      * i.e. the number of CA certificates which are max allowed to be followed while
      * verifying the client certificate. A depth of 0 means that self-signed client


### PR DESCRIPTION
Motivation:
SSL#setVerify and SSLContext#setVerify both attempt to initialize a default trust store which can be derived from the file system and configured with environment variables. This may result in unintentional certificates being trusted, and we should instead only trust the certificates that are programmatically set. The verification callback also supports an unused mode SSL_CVERIFY_OPTIONAL_NO_CA which is not used. Calling SSL#setVerify can also manpulate the state for the entire SSLContext which is not desired.

Motivation:
- setVerify should not initialize a trust store based upon file or environment
- Remove SSL_CVERIFY_OPTIONAL_NO_CA
- We should not specify a callback for SSL_set_verify and SSL_CTX_set_verify because they will not be called because we override the default verification mechanism via SSL_CTX_set_cert_verify_callback
- Decouple the state for SSL#setVerify and SSLContext#setVerify

Result:
setVerify doesn't have unexpected side effects.