### PR TITLE
Support wrapping/unwrapping of multiple packets

### DIFF
--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -137,6 +137,10 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslErrorWantAccep
     return SSL_ERROR_WANT_ACCEPT;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslMaxPlaintextLength)(TCN_STDARGS) {
+    return SSL3_RT_MAX_PLAIN_LENGTH;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, x509CheckFlagAlwaysCheckSubject)(TCN_STDARGS) {
 #ifdef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
     return X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT;

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -124,6 +124,11 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define HAVE_ECC              1
 #endif
 
+// TODO(scott): remove this as OpenSSL supports it in older version, or we drop support for older versions.
+#ifndef TLS1_3_VERSION
+#define TLS1_3_VERSION 0x0304
+#endif
+
 /* OpenSSL 1.0.2 compatibility */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #define TLS_method SSLv23_method

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -70,6 +70,8 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslErrorWantConnect();
     static native int sslErrorWantAccept();
 
+    static native int sslMaxPlaintextLength();
+
     static native int x509CheckFlagAlwaysCheckSubject();
     static native int x509CheckFlagDisableWildCards();
     static native int x509CheckFlagNoPartialWildCards();

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -90,6 +90,8 @@ public final class SSL {
     public static final int SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER     = sslModeAcceptMovingWriteBuffer();
     public static final int SSL_MODE_RELEASE_BUFFERS                = sslModeReleaseBuffers();
 
+    public static final int SSL_MAX_PLAINTEXT_LENGTH = sslMaxPlaintextLength();
+
     // https://www.openssl.org/docs/man1.0.2/crypto/X509_check_host.html
     public static final int X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT = x509CheckFlagAlwaysCheckSubject();
     public static final int X509_CHECK_FLAG_NO_WILD_CARDS = x509CheckFlagDisableWildCards();
@@ -233,6 +235,14 @@ public final class SSL {
      * @return the amount of data pending in buffer used for non-application writes.
      */
     public static native int bioLengthNonApplication(long bio);
+
+    /**
+     * The number of bytes pending in SSL which can be read immediately.
+     * See <a href="https://www.openssl.org/docs/man1.0.1/ssl/SSL_pending.html">SSL_pending</a>.
+     * @param ssl the SSL instance (SSL *)
+     * @return The number of bytes pending in SSL which can be read immediately.
+     */
+    public static native int sslPending(long ssl);
 
     /**
      * SSL_write
@@ -435,6 +445,31 @@ public final class SSL {
      * @return options  See SSL.SSL_OP_* for option flags.
      */
     public static native int getOptions(long ssl);
+
+    /**
+     * Call SSL_set_mode
+     *
+     * @param ssl the SSL instance (SSL *).
+     * @param mode the mode
+     * @return the set mode.
+     */
+    public static native int setMode(long ssl, int mode);
+
+    /**
+     * Call SSL_get_mode
+     *
+     * @param ssl the SSL instance (SSL *).
+     * @return the mode.
+     */
+    public static native int getMode(long ssl);
+
+    /**
+     * Get the maximum overhead, in bytes, of wrapping (a.k.a sealing) a record with ssl.
+     * See <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_max_seal_overhead">SSL_max_seal_overhead</a>.
+     * @param ssl the SSL instance (SSL *).
+     * @return Maximum overhead, in bytes, of wrapping (a.k.a sealing) a record with ssl.
+     */
+    public static native int getMaxWrapOverhead(long ssl);
 
     /**
      * Returns all Returns the cipher suites that are available for negotiation in an SSL handshake.


### PR DESCRIPTION
Motivation:
The JDK SSLEngine documentation says that a call to wrap/unwrap "will attempt to consume one complete SSL/TLS network packet" [1]. This limitation can result in thrashing in the pipeline to decode and encode data that may be spread amongst multiple SSL/TLS network packets.

Modifications:
- Add methods for SSL_set_mode and SSL_get_mode and SSL_MODE_ENABLE_PARTIAL_WRITE.
- Use OpenSSL to derive the limits for plaintext and ciphertext length.

Result:
SSL_set_mode and SSL_get_mode are supported and we get limits directly from OpenSSL.