### PR TITLE
Correctly handle dh key generation when using libressl

### DIFF
--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -205,7 +205,7 @@ int SSL_password_callback(char *buf, int bufsiz, int verify,
     return (int)strlen(buf);
 }
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED) || defined(LIBRESSL_VERSION_NUMBER)
 
 static unsigned char dh0512_p[]={
     0xD9,0xBA,0xBF,0xFD,0x69,0x38,0xC9,0x51,0x2D,0x19,0x37,0x39,


### PR DESCRIPTION
Motivation:

Commit f070b9167ac6e2dced746193838000dd6e99a122 changed an ifdef when using libressl to enable generation of temporary dh keys. Unfortunally I missed to also update another ifdef and so SSL.initialize() fails when using libressl now.

Modifications:

Update other ifdef as well.

Result:

netty-tcnative is usable again with libressl.