### PR TITLE
Allow to use -Dstrip.skip=true to disable stripping of boringssl stat…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -181,7 +181,10 @@
 
                     <!-- Strip on linux. See https://github.com/netty/netty-tcnative/issues/129 -->
                     <if>
-                      <equals arg1="${os.detected.name}" arg2="linux" />
+                      <and>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <equals arg1="${strip.skip}" arg2="false" />
+                      </and>
                       <then>
                         <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
                           <arg value="libnetty-tcnative.so" />

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <msvcSslIncludeDirs>${sslHome}/include</msvcSslIncludeDirs>
     <msvcSslLibDirs>${sslHome}/lib</msvcSslLibDirs>
     <msvcSslLibs>ssleay32.lib;libeay32.lib</msvcSslLibs>
+    <strip.skip>false</strip.skip>
   </properties>
 
   <build>


### PR DESCRIPTION
…ic lib

Motivation:

Sometimes it makes sense to build the library and ensure its not stripped.

Modifications:

Allow to use -Dstrip.skip=true to skip stripping.

Result:

Easier to build artifact that is not stripped.