### PR TITLE
Enable frame pointers and optimization for static builds

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -156,7 +156,8 @@
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
                           <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
-                          <arg value="-DCMAKE_C_FLAGS_RELEASE=-std=c99" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=-std=c99 -O3 -fno-omit-frame-pointer" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer" />
                           <arg value="-GNinja" />
                           <arg value=".." />
                         </exec>
@@ -227,6 +228,7 @@
                   <configureArgs>
                     <configureArg>--with-ssl=no</configureArg>
                     <configureArg>--with-apr=${aprHome}</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -Wunused-variable</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
                   </configureArgs>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -178,7 +178,7 @@
                     </exec>
                     <mkdir dir="${sslHome}" />
                     <exec executable="configure" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
-                      <arg line="--disable-shared --prefix=${sslHome} CFLAGS=-fPIC" />
+                      <arg line="--disable-shared --prefix=${sslHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
                     </exec>
                     <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true" />
                     <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">

--- a/openssl-dynamic/src/main/native-package/configure.ac
+++ b/openssl-dynamic/src/main/native-package/configure.ac
@@ -29,6 +29,7 @@ AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
 ${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -Wunused-variable"}
+${CXXFLAGS="-O3 -Werror -fno-omit-frame-pointer -Wunused-variable"}
 
 ## -----------------------------------------------
 ## Application Checks

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -211,7 +211,7 @@
 
                     <mkdir dir="${sslHome}" />
                     <exec executable="config" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg line="-fPIC no-shared --prefix=${sslHome} --openssldir=${sslHome}" />
+                      <arg line="-O3 -fno-omit-frame-pointer -fPIC no-shared --prefix=${sslHome} --openssldir=${sslHome}" />
                     </exec>
                     <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
                     <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
                     </exec>
                     <mkdir dir="${aprHome}" />
                     <exec executable="configure" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
-                      <arg line="--disable-shared --prefix=${aprHome} CFLAGS=-fPIC" />
+                      <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
                     </exec>
                     <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true" />
                     <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">


### PR DESCRIPTION
Motivation:
We currently do not include frame pointers and may not consistently enable the build optimization level for our static builds.

Modifications:
- Ensure -O3 and -fno-omit-frame-pointer is used for static libraries

Result:
More consistent builds and frame pointers are preserved for debugging.