### PR TITLE
Static OpenSSL Configuration Options

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -211,7 +211,10 @@
 
                     <mkdir dir="${sslHome}" />
                     <exec executable="config" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg line="-O3 -fno-omit-frame-pointer -fPIC no-shared --prefix=${sslHome} --openssldir=${sslHome}" />
+                      <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
+                    </exec>
+                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                      <arg value="depend" />
                     </exec>
                     <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
                     <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">


### PR DESCRIPTION
Motivation:
Some configuration options maybe enabled by default which are dangerous or not supported by Netty. We should be more explicit with configuration options of the static OpenSSL build.

Modifications:
- disable sslv2, sslv3, compression, and heartbeats

Result:
Statically built OpenSSL leaner and excludes stuff we don't need.