### PR TITLE
Fix errors when generate javadoc on Java8+

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Buffer.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Buffer.java
@@ -41,12 +41,14 @@ public final class Buffer {
     /**
      * Returns the memory address of the ByteBuffer.
      * @param buf Previously allocated ByteBuffer.
+     * @return the memory address.
      */
     public static native long address(ByteBuffer buf);
 
     /**
      * Returns the allocated memory size of the ByteBuffer.
      * @param buf Previously allocated ByteBuffer.
+     * @return the allocated memory size
      */
     public static native long size(ByteBuffer buf);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
@@ -65,13 +65,17 @@ public interface CertificateRequestedCallback {
 
         /**
          * Returns a {@code EVP_PKEY} pointer
+         *
+         * @return the {@code EVP_PKEY} pointer
          */
         public final long privateKey() {
             return privateKey;
         }
 
         /**
-         * Returns a x509 chain ({@code STACK_OF(X509)} pointer).
+         * Returns a x509 chain ({@code STACK_OF(X509)} pointer)
+         *
+         * @return thex509 chain ({@code STACK_OF(X509)} pointer)
          */
         public final long certificateChain() {
             return certificateChain;

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
@@ -101,6 +101,9 @@ public final class Library {
 
     /**
      * Calls {@link #initialize(String, String)} with {@code "provided"} and {@code null}.
+     *
+     * @return {@code true} if initialization was successful
+     * @throws Exception if an error happens during initialization
      */
     public static boolean initialize() throws Exception {
         return initialize("provided", null);
@@ -110,8 +113,9 @@ public final class Library {
      * Setup native library. This is the first method that must be called!
      *
      * @param libraryName the name of the library to load
-     * @param engine Support for external a Crypto Device ("engine"),
-     *                usually
+     * @param engine Support for external a Crypto Device ("engine"), usually
+     * @return {@code true} if initialization was successful
+     * @throws Exception if an error happens during initialization
      */
     public static boolean initialize(String libraryName, String engine) throws Exception {
         if (_instance == null) {
@@ -121,11 +125,12 @@ public final class Library {
                 _instance = new Library(libraryName);
             int aprMajor  = version(0x11);
 
-            boolean aprHasThreads = has(2);
             if (aprMajor < 1) {
                 throw new UnsatisfiedLinkError("Unsupported APR Version (" +
                                                aprVersionString() + ")");
             }
+
+            boolean aprHasThreads = has(2);
             if (!aprHasThreads) {
                 throw new UnsatisfiedLinkError("Missing APR_HAS_THREADS");
             }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -49,7 +49,7 @@ public final class SSL {
     public static final int SSL_PROTOCOL_TLSV1_1 = (1<<3);
     public static final int SSL_PROTOCOL_TLSV1_2 = (1<<4);
 
-    /** TLS_*method according to https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_new.html */
+    /** TLS_*method according to <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_new.html">SSL_CTX_new</a> */
     public static final int SSL_PROTOCOL_TLS   = (SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2);
     public static final int SSL_PROTOCOL_ALL   = (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_TLS);
 
@@ -114,12 +114,16 @@ public final class SSL {
 
     /**
      * Initialize new in-memory BIO that is located in the secure heap.
+     *
      * @return New BIO handle
+     * @throws Exception if an error happened.
      */
     public static native long newMemBIO() throws Exception;
 
     /**
      * Return last SSL error string
+     *
+     * @return the last SSL error string.
      */
     public static native String getLastError();
 
@@ -162,6 +166,7 @@ public final class SSL {
      * SSL_get_error
      * @param ssl SSL pointer (SSL *)
      * @param ret TLS/SSL I/O return value
+     * @return the error code
      */
     public static native int getError(long ssl, int ret);
 
@@ -184,7 +189,7 @@ public final class SSL {
      * @param ssl the SSL instance (SSL *)
      * @param nonApplicationBufferSize The size of the internal buffer for write operations that are not
      *                                 initiated directly by the application attempting to encrypt data.
-     *                                 Must be &gt{@code 0}.
+     *                                 Must be &gt;{@code 0}.
      * @return pointer to the Network BIO (BIO *).
      *         The memory is owned by {@code ssl} and will be cleaned up by {@link #freeSSL(long)}.
      */
@@ -239,32 +244,32 @@ public final class SSL {
     /**
      * SSL_write
      * @param ssl the SSL instance (SSL *)
-     * @param wbuf
-     * @param wlen
-     * @return
+     * @param wbuf the memory address of the buffer
+     * @param wlen the length
+     * @return the number of written bytes
      */
     public static native int writeToSSL(long ssl, long wbuf, int wlen);
 
     /**
      * SSL_read
      * @param ssl the SSL instance (SSL *)
-     * @param rbuf
-     * @param rlen
-     * @return
+     * @param rbuf the memory address of the buffer
+     * @param rlen the length
+     * @return the number of read bytes
      */
     public static native int readFromSSL(long ssl, long rbuf, int rlen);
 
     /**
      * SSL_get_shutdown
      * @param ssl the SSL instance (SSL *)
-     * @return
+     * @return the return code of {@code SSL_get_shutdown}
      */
     public static native int getShutdown(long ssl);
 
     /**
      * SSL_set_shutdown
      * @param ssl the SSL instance (SSL *)
-     * @param mode
+     * @param mode the mode to use
      */
     public static native void setShutdown(long ssl, int mode);
 
@@ -276,54 +281,55 @@ public final class SSL {
 
     /**
      * BIO_free
-     * @param bio
+     * @param bio the BIO
      */
     public static native void freeBIO(long bio);
 
     /**
      * SSL_shutdown
      * @param ssl the SSL instance (SSL *)
-     * @return
+     * @return the return code of {@code SSL_shutdown}
      */
     public static native int shutdownSSL(long ssl);
 
     /**
      * Get the error number representing the last error OpenSSL encountered on this thread.
-     * @return
+     * @return the last error code for the calling thread.
      */
     public static native int getLastErrorNumber();
 
     /**
      * SSL_get_cipher
      * @param ssl the SSL instance (SSL *)
-     * @return
+     * @return the name of the current cipher.
      */
     public static native String getCipherForSSL(long ssl);
 
     /**
      * SSL_get_version
      * @param ssl the SSL instance (SSL *)
-     * @return
+     * @return the version.
      */
     public static native String getVersion(long ssl);
 
     /**
      * SSL_do_handshake
      * @param ssl the SSL instance (SSL *)
+     * @return the return code of {@code SSL_do_handshake}.
      */
     public static native int doHandshake(long ssl);
 
     /**
      * SSL_in_init
-     * @param SSL
-     * @return
+     * @param ssl the SSL instance (SSL *)
+     * @return the return code of {@code SSL_in_init}.
      */
-    public static native int isInInit(long SSL);
+    public static native int isInInit(long ssl);
 
     /**
      * SSL_get0_next_proto_negotiated
      * @param ssl the SSL instance (SSL *)
-     * @return
+     * @return the name of the negotiated proto
      */
     public static native String getNextProtoNegotiated(long ssl);
 
@@ -334,21 +340,29 @@ public final class SSL {
     /**
      * SSL_get0_alpn_selected
      * @param ssl the SSL instance (SSL *)
-     * @return
+     * @return the name of the selected ALPN protocol
      */
     public static native String getAlpnSelected(long ssl);
 
     /**
-     * Get the peer certificate chain or {@code null} if non was send.
+     * Get the peer certificate chain or {@code null} if none was send.
+     * @param ssl the SSL instance (SSL *)
+     * @return the chain or {@code null} if none was send
      */
     public static native byte[][] getPeerCertChain(long ssl);
 
     /**
      * Get the peer certificate or {@code null} if non was send.
+     * @param ssl the SSL instance (SSL *)
+     * @return the peer certificate or {@code null} if none was send
      */
     public static native byte[] getPeerCertificate(long ssl);
-    /*
-     * Get the error number representing for the given {@code errorNumber}.
+
+    /**
+     * Get the error string representing for the given {@code errorNumber}.
+     *
+     * @param errorNumber the error number / code
+     * @return the error string
      */
     public static native String getErrorString(long errorNumber);
 
@@ -377,7 +391,7 @@ public final class SSL {
     /**
      * Set Type of Client Certificate verification and Maximum depth of CA Certificates
      * in Client Certificate verification.
-     * <br />
+     * <p>
      * This directive sets the Certificate verification level for the Client
      * Authentication. Notice that this directive can be used both in per-server
      * and per-directory context. In per-server context it applies to the client
@@ -385,7 +399,7 @@ public final class SSL {
      * is established. In per-directory context it forces a SSL renegotiation with
      * the reconfigured client verification level after the HTTP request was read
      * but before the HTTP response is sent.
-     * <br />
+     * <p>
      * The following levels are available for level:
      * <ul>
      * <li>{@link #SSL_CVERIFY_IGNORED} - The level is ignored. Only depth will change.</li>
@@ -438,7 +452,7 @@ public final class SSL {
 
     /**
      * Returns the cipher suites available for negotiation in SSL handshake.
-     * <br />
+     * <p>
      * This complex directive uses a colon-separated cipher-spec string consisting
      * of OpenSSL cipher specifications to configure the Cipher Suite the client
      * is permitted to negotiate in the SSL handshake phase. Notice that this
@@ -449,6 +463,8 @@ public final class SSL {
      * was read but before the HTTP response is sent.
      * @param ssl the SSL instance (SSL *)
      * @param ciphers an SSL cipher specification
+     * @return {@code true} if successful
+     * @throws Exception if an error happened
      */
     public static native boolean setCipherSuites(long ssl, String ciphers)
             throws Exception;
@@ -486,6 +502,7 @@ public final class SSL {
      * Call SSL_set_state.
      *
      * @param ssl the SSL instance (SSL *)
+     * @param state the state to set
      */
     public static native void setState(long ssl, int state);
 
@@ -507,6 +524,12 @@ public final class SSL {
      */
     public static native void setHostNameValidation(long ssl, int flags, String hostname);
 
+    /**
+     * Return the methods used for authentication.
+     *
+     * @param ssl the SSL instance (SSL*)
+     * @return the methods
+     */
     public static native String[] authenticationMethods(long ssl);
 
     /**
@@ -551,6 +574,7 @@ public final class SSL {
      * @param keyBio Private Key BIO to use if not in cert.
      * @param password Certificate password. If null and certificate
      *                 is encrypted.
+     * @throws Exception if an error happened
      */
     public static native void setCertificateBio(
             long ssl, long certBio, long keyBio, String password) throws Exception;
@@ -564,11 +588,18 @@ public final class SSL {
      * {@link CertificateRequestedCallback} the ownership goes over to OpenSsl / Tcnative and so calling
      * {@link #freePrivateKey(long)} should <strong>NOT</strong> be done in this case. Otherwise you may
      * need to call {@link #freePrivateKey(long)} to decrement the reference count and free memory.
+     *
+     * @param privateKeyBio the pointer to the {@code BIO} that contains the private key
+     * @param password the password or {@code null} if no password is needed
+     * @return {@code EVP_PKEY} pointer
+     * @throws Exception if an error happened
      */
     public static native long parsePrivateKey(long privateKeyBio, String password) throws Exception;
 
     /**
      * Free private key ({@code EVP_PKEY} pointer).
+     *
+     * @param privateKey {@code EVP_PKEY} pointer
      */
     public static native void freePrivateKey(long privateKey);
 
@@ -581,11 +612,17 @@ public final class SSL {
      * {@link CertificateRequestedCallback} the ownership goes over to OpenSsl / Tcnative and and so calling
      * {@link #freeX509Chain(long)} should <strong>NOT</strong> be done in this case. Otherwise you may
      * need to call {@link #freeX509Chain(long)} to decrement the reference count and free memory.
+     *
+     * @param x509ChainBio the pointer to the {@code BIO} that contains the X509 chain
+     * @return {@code STACK_OF(X509)} pointer
+     * @throws Exception if an error happened
      */
     public static native long parseX509Chain(long x509ChainBio) throws Exception;
 
     /**
      * Free x509 chain ({@code STACK_OF(X509)} pointer).
+     *
+     * @param x509Chain {@code STACK_OF(X509)} pointer
      */
     public static native void freeX509Chain(long x509Chain);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -54,6 +54,8 @@ public final class SSLContext {
      * SSL_MODE_SERVER
      * SSL_MODE_COMBINED
      * </PRE>
+     * @return the SSLContext struct
+     * @throws Exception if an error happened
      */
     public static native long make(int protocol, int mode)
         throws Exception;
@@ -106,9 +108,10 @@ public final class SSLContext {
      * was read but before the HTTP response is sent.
      * @param ctx Server or Client context to use.
      * @param ciphers An SSL cipher specification.
+     * @return {@code true} if successful
+     * @throws Exception if an error happened
      */
-    public static native boolean setCipherSuite(long ctx, String ciphers)
-        throws Exception;
+    public static native boolean setCipherSuite(long ctx, String ciphers) throws Exception;
 
     /**
      * Set File of PEM-encoded Server CA Certificates
@@ -129,9 +132,9 @@ public final class SSLContext {
      * @param file File of PEM-encoded Server CA Certificates.
      * @param skipfirst Skip first certificate if chain file is inside
      *                  certificate file.
+     * @return {@code true} if successful
      */
-    public static native boolean setCertificateChainFile(long ctx, String file,
-                                                         boolean skipfirst);
+    public static native boolean setCertificateChainFile(long ctx, String file, boolean skipfirst);
     /**
      * Set BIO of PEM-encoded Server CA Certificates
      * <p>
@@ -151,12 +154,11 @@ public final class SSLContext {
      * @param bio BIO of PEM-encoded Server CA Certificates.
      * @param skipfirst Skip first certificate if chain file is inside
      *                  certificate file.
+     * @return {@code true} if successful
      */
     public static native boolean setCertificateChainBio(long ctx, long bio, boolean skipfirst);
 
     /**
-     * @deprecated Use {@link #setCertificate(long, String, String, String)}
-     * <p>
      * Set Certificate
      * <p>
      * Point setCertificateFile at a PEM encoded certificate.  If
@@ -176,38 +178,12 @@ public final class SSLContext {
      * @param key Private Key file to use if not in cert.
      * @param password Certificate password. If null and certificate
      *                 is encrypted, password prompt will be displayed.
-     * @param idx deprecated and ignored.
-     */
-    @Deprecated
-    public static boolean setCertificate(long ctx, String cert, String key, String password, int idx) throws Exception {
-        return setCertificate(ctx, cert, key, password);
-    }
-
-    /**
-     * Set Certificate
-     * <p>
-     * Point setCertificateFile at a PEM encoded certificate.  If
-     * the certificate is encrypted, then you will be prompted for a
-     * pass phrase.  Note that a kill -HUP will prompt again. A test
-     * certificate can be generated with `make certificate' under
-     * built time. Keep in mind that if you've both a RSA and a DSA
-     * certificate you can configure both in parallel (to also allow
-     * the use of DSA ciphers, etc.)
-     * <p>
-     * If the key is not combined with the certificate, use key param
-     * to point at the key file.  Keep in mind that if
-     * you've both a RSA and a DSA private key you can configure
-     * both in parallel (to also allow the use of DSA ciphers, etc.)
-     * @param ctx Server or Client context to use.
-     * @param cert Certificate file.
-     * @param key Private Key file to use if not in cert.
-     * @param password Certificate password. If null and certificate
-     *                 is encrypted, password prompt will be displayed.
+     * @return {@code true} if successful
+     * @throws Exception if an error happened
      */
     public static native boolean setCertificate(long ctx, String cert, String key, String password) throws Exception;
 
     /**
-     * @deprecated Use {@link #setCertificateBio(long, long, long, String)}
      * Set Certificate
      * <p>
      * Point setCertificate at a PEM encoded certificate stored in a BIO. If
@@ -227,95 +203,187 @@ public final class SSLContext {
      * @param keyBio Private Key BIO to use if not in cert.
      * @param password Certificate password. If null and certificate
      *                 is encrypted, password prompt will be displayed.
-     * @param idx deprecated and ignored.
+     * @return {@code true} if successful
+     * @throws Exception if an error happened
      */
-    @Deprecated
-    public static boolean setCertificateBio(
-            long ctx, long certBio, long keyBio, String password, int idx) throws Exception {
-        return setCertificateBio(ctx, certBio, keyBio, password);
-    }
-
-    /**
-     * Set Certificate
-     * <p>
-     * Point setCertificate at a PEM encoded certificate stored in a BIO. If
-     * the certificate is encrypted, then you will be prompted for a
-     * pass phrase.  Note that a kill -HUP will prompt again. A test
-     * certificate can be generated with `make certificate' under
-     * built time. Keep in mind that if you've both a RSA and a DSA
-     * certificate you can configure both in parallel (to also allow
-     * the use of DSA ciphers, etc.)
-     * <p>
-     * If the key is not combined with the certificate, use key param
-     * to point at the key file.  Keep in mind that if
-     * you've both a RSA and a DSA private key you can configure
-     * both in parallel (to also allow the use of DSA ciphers, etc.)
-     * @param ctx Server or Client context to use.
-     * @param certBio Certificate BIO.
-     * @param keyBio Private Key BIO to use if not in cert.
-     * @param password Certificate password. If null and certificate
-     *                 is encrypted, password prompt will be displayed.
-     */
-    public static native boolean setCertificateBio(
-            long ctx, long certBio, long keyBio, String password) throws Exception;
+    public static native boolean setCertificateBio(long ctx, long certBio, long keyBio, String password) throws Exception;
 
     /**
      * Set the size of the internal session cache.
-     * http://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_set_cache_size.html">man SSL_CTX_sess_set_cache_size</a>
+     * @param ctx Server or Client context to use.
+     * @param size the size of the cache
+     * @return the previous set value
      */
     public static native long setSessionCacheSize(long ctx, long size);
 
     /**
      * Get the size of the internal session cache.
-     * http://www.openssl.org/docs/ssl/SSL_CTX_sess_get_cache_size.html
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_get_cache_size.html">man SSL_CTX_sess_get_cache_size</a>
+     * @param ctx Server or Client context to use.
+     * @return the current value
      */
     public static native long getSessionCacheSize(long ctx);
 
     /**
      * Set the timeout for the internal session cache in seconds.
-     * http://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_timeout.html">man SSL_CTX_set_timeout</a>
+     * @param ctx Server or Client context to use.
+     * @param timeoutSeconds the timeout of the cache
+     * @return the previous set value
      */
     public static native long setSessionCacheTimeout(long ctx, long timeoutSeconds);
 
     /**
      * Get the timeout for the internal session cache in seconds.
-     * http://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_get_timeout.html">man SSL_CTX_get_timeout</a>
+     * @param ctx Server or Client context to use
+     * @return the current value
      */
     public static native long getSessionCacheTimeout(long ctx);
 
     /**
      * Set the mode of the internal session cache and return the previous used mode.
+     * @param ctx Server or Client context to use
+     * @param mode the mode of the cache
+     * @return the previous set value
      */
     public static native long setSessionCacheMode(long ctx, long mode);
 
     /**
      * Get the mode of the current used internal session cache.
+     *
+     * @param ctx Server or Client context to use
+     * @return the current mode
      */
     public static native long getSessionCacheMode(long ctx);
 
     /**
      * Session resumption statistics methods.
-     * http://www.openssl.org/docs/ssl/SSL_CTX_sess_number.html
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
      */
     public static native long sessionAccept(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionAcceptGood(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionAcceptRenegotiate(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionCacheFull(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionCbHits(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionConnect(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionConnectGood(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionConnectRenegotiate(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionHits(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionMisses(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionNumber(long ctx);
+
+    /**
+     * Session resumption statistics methods.
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_sess_number.html">man SSL_CTX_sess_number</a>
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionTimeouts(long ctx);
 
     /**
      * TLS session ticket key resumption statistics.
+     *
+     * @param ctx Server or Client context to use
+     * @return the current number
      */
     public static native long sessionTicketKeyNew(long ctx);
+
+    /**
+     * TLS session ticket key resumption statistics.
+     *
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionTicketKeyResume(long ctx);
+
+    /**
+     * TLS session ticket key resumption statistics.
+     *
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionTicketKeyRenew(long ctx);
+
+    /**
+     * TLS session ticket key resumption statistics.
+     *
+     * @param ctx Server or Client context to use
+     * @return the current number
+     */
     public static native long sessionTicketKeyFail(long ctx);
 
     /**
@@ -324,8 +392,10 @@ public final class SSLContext {
      * <p> The first key in the list is the primary key. Tickets dervied from the other keys
      * in the list will be accepted but updated to a new ticket using the primary key. This
      * is useful for implementing ticket key rotation.
+     * See <a href="https://tools.ietf.org/html/rfc5077">RFC 5077</a>
      *
-     * @see <a href="https://tools.ietf.org/html/rfc5077">RFC 5077</a>
+     * @param ctx Server or Client context to use
+     * @param keys the {@link SessionTicketKey}s
      */
     public static void setSessionTicketKeys(long ctx, SessionTicketKey[] keys) {
         if (keys == null || keys.length == 0) {
@@ -443,8 +513,8 @@ public final class SSLContext {
     public static native void setTmpDHLength(long ctx, int length);
 
     /**
-     * Set the context within which session be reused (server side only)
-     * http://www.openssl.org/docs/ssl/SSL_CTX_set_session_id_context.html
+     * Set the context within which session be reused (server side only).
+     * See <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_session_id_context.html">man SSL_CTX_set_session_id_context</a>
      *
      * @param ctx Server context to use.
      * @param sidCtx can be any kind of binary data, it is therefore possible to use e.g. the name


### PR DESCRIPTION
Motivation:

Java8 is a lot stricter when it comes to javadocs.

Modifications:

- Add missing javadocs
- Remove deprecated methods

Result:

Be able to generate javadocs and so use java8 for release.