### PR TITLE
JNI should load NativeStaticallyReferencedJniMethods before other cla…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -82,6 +82,11 @@ JNIEXPORT jint JNICALL JNI_OnLoad_netty_tcnative(JavaVM *vm, void *reserved)
     TCN_GET_METHOD(env, jString_class, jString_getBytes,
                    "getBytes", "()[B", JNI_ERR);
 
+    // Load the class which makes JNI references available in a static scope before loading any other classes.
+    if ((*env)->FindClass(env, "io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods") == NULL) {
+        return JNI_ERR;
+    }
+
     TCN_LOAD_CLASS(env, byteArrayClass, "[B", JNI_ERR);
     TCN_LOAD_CLASS(env, keyMaterialClass, "io/netty/internal/tcnative/CertificateRequestedCallback$KeyMaterial", JNI_ERR);
 


### PR DESCRIPTION
…sses

Motivation:
The point of NativeStaticallyReferencedJniMethods is to make JNI values usable in a static context in Java and not worry about cyclic class loading issues. However if we don't explicitly load the NativeStaticallyReferencedJniMethods class from JNI there is a chance another class which statically references a value in NativeStaticallyReferencedJniMethods is loaded first, and creates a circular class loading issue.

Modifications:
- JNI OnLoad should ensure NativeStaticallyReferencedJniMethods is loaded before other tcnative classes

Result:
Methods from NativeStaticallyReferencedJniMethods can be used in a static context from Java without cyclic class loading issues.