### PR TITLE
Add method to be able to hook in SNIMatchers that exists since java8

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -195,6 +195,9 @@ struct tcn_ssl_ctxt_t {
     jobject                  cert_requested_callback;
     jmethodID                cert_requested_callback_method;
 
+    jobject                  sni_hostname_matcher;
+    jmethodID                sni_hostname_matcher_method;
+
     tcn_ssl_verify_config_t  verify_config;
 
     int                      protocol;

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -487,6 +487,15 @@ public final class SSLContext {
     public static native void setCertRequestedCallback(long ctx, CertificateRequestedCallback callback);
 
     /**
+     * Allow to hook {@link SniHostNameMatcher} into the sni processing.
+     * This will call {@code SSL_CTX_set_tlsext_servername_callback} and so replace the default
+     * callback used by openssl
+     * @param ctx Server or Client context to use.
+     * @param matcher the matcher to call during sni hostname matching.
+     */
+    public static native void setSniHostnameMatcher(long ctx, SniHostNameMatcher matcher);
+
+    /**
      * Set next protocol for next protocol negotiation extension
      * @param ctx Server context to use.
      * @param nextProtos protocols in priority order

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SniHostNameMatcher.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SniHostNameMatcher.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+public interface SniHostNameMatcher {
+
+    /**
+     * Returns {@code true} if the hostname was matched and so SNI should be allowed.
+     * @param ssl the SSL instance
+     * @param hostname the hostname to match.
+     * @return {@code true} if the hostname was matched
+     */
+    boolean match(long ssl, String hostname);
+}


### PR DESCRIPTION
Motivation:

Java8 supports the concept of SNIMatcher, we should allow to hook these into tcnative.

Modifications:

Add new method and interface to allow using SNIMatcher in netty when using java8+

Result:

More inline with features provided by java8+