### PR TITLE
Fix memory leak when a previous set verifier / cert callback is replaced

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1281,7 +1281,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
         }
         // Delete the reference to the previous specified verifier if needed.
         if (c->verifier != NULL) {
-            (*e)->DeleteLocalRef(e, c->verifier);
+            (*e)->DeleteGlobalRef(e, c->verifier);
         }
         c->verifier = (*e)->NewGlobalRef(e, verifier);
         c->verifier_method = method;
@@ -1471,7 +1471,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
         }
         // Delete the reference to the previous specified verifier if needed.
         if (c->cert_requested_callback != NULL) {
-            (*e)->DeleteLocalRef(e, c->cert_requested_callback);
+            (*e)->DeleteGlobalRef(e, c->cert_requested_callback);
         }
         c->cert_requested_callback = (*e)->NewGlobalRef(e, callback);
         c->cert_requested_callback_method = method;


### PR DESCRIPTION
Motivation:

When a previous set verifier / cert callback is replaced we need to ensure the previous created global reference is deleted as well. Due a bug we not did this.

Modifications:

Replace DeleteLocalRef with DeleteGlobalRef

Result:

No more native leak when replacing verifier / cert callback