### PR TITLE
Remove the apr pool from the context

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -175,7 +175,6 @@ typedef struct {
 } tcn_ssl_verify_config_t;
 
 struct tcn_ssl_ctxt_t {
-    apr_pool_t*              pool;
     SSL_CTX*                 ctx;
 
     /* Holds the alpn protocols, each of them prefixed with the len of the protocol */


### PR DESCRIPTION
Motiviation:

We created and stored an apr pool in the context that we use per SSLContext. This pool is not used anymore and so not needed.

Modification:

Remove the pool creation and remove it from the struct

Result:

Less memory used for the struct and less resource creation.