### PR TITLE
Fix openssl-static build on macOS

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -179,10 +179,10 @@
       </build>
     </profile>
     <profile>
-      <id>build-openssl-linux-mac</id>
+      <id>build-openssl-linux</id>
       <activation>
         <os>
-          <family>!windows</family>
+          <family>unix</family>
         </os>
       </activation>
       <build>
@@ -212,6 +212,56 @@
                     <mkdir dir="${sslHome}" />
                     <exec executable="config" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
                       <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
+                    </exec>
+                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                      <arg value="depend" />
+                    </exec>
+                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
+                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                      <arg value="install" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>build-openssl-mac</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-openssl</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Download the openssl source. -->
+                    <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
+                      <fileset dir="${project.build.directory}">
+                        <include name="**/openssl-${opensslVersion}.tar.gz" />
+                      </fileset>
+                    </ftp>
+                    <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
+                    <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                      <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
+                    </exec>
+
+                    <mkdir dir="${sslHome}" />
+                    <exec executable="Configure" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                      <arg line="darwin64-x86_64-cc -O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
                     </exec>
                     <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
                       <arg value="depend" />


### PR DESCRIPTION
Motivation:

Previous the openssl-static build was broken and so an exception was thrown when tried to using it.

Modifications:

Use proper Config command which is needed on macOS. See also https://github.com/rbsec/sslscan/issues/59 .

Result:

openssl-static build works on macOS as well.