### PR TITLE
Cleanup from 563307abc5955194d93d5f9c71caa1c5a3346388

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1508,10 +1508,11 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSniHostnameMatcher)(TCN_STDARGS, jlong c
     // Delete the reference to the previous specified matcher if needed.
     if (c->sni_hostname_matcher != NULL) {
         (*e)->DeleteGlobalRef(e, c->sni_hostname_matcher);
+        c->sni_hostname_matcher = NULL;
     }
 
     if (matcher == NULL) {
-        c->sni_hostname_matcher = NULL;
+        c->sni_hostname_matcher_method = NULL;
 
         SSL_CTX_set_tlsext_servername_callback(c->ctx, NULL);
         SSL_CTX_set_tlsext_servername_arg(c->ctx, NULL);
@@ -1519,6 +1520,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSniHostnameMatcher)(TCN_STDARGS, jlong c
         jclass matcher_class = (*e)->GetObjectClass(e, matcher);
         jmethodID method = (*e)->GetMethodID(e, matcher_class, "match", "(JLjava/lang/String;)Z");
         if (method == NULL) {
+            c->sni_hostname_matcher_method = NULL;
             return;
         }
 


### PR DESCRIPTION
Motivation:
563307abc5955194d93d5f9c71caa1c5a3346388 introduced some code which may lead to a double delete of memory. c->sni_hostname_matcher was not always set to NULL which could lead to ssl_context_cleanup double freeing the memory.

Modifications:
- setSniHostnameMatcher should always set c->sni_hostname_matcher and c->sni_hostname_matcher_method

Result:
No more double free.