### PR TITLE
Remove SSL_PROTOCOL_ALL

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -97,9 +97,8 @@
 #define SSL_PROTOCOL_TLSV1      (1<<2)
 #define SSL_PROTOCOL_TLSV1_1    (1<<3)
 #define SSL_PROTOCOL_TLSV1_2    (1<<4)
-/* TLS_*method according to https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_new.html */
+/* TLS_*method according to https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_new.html */
 #define SSL_PROTOCOL_TLS        (SSL_PROTOCOL_SSLV3|SSL_PROTOCOL_TLSV1|SSL_PROTOCOL_TLSV1_1|SSL_PROTOCOL_TLSV1_2)
-#define SSL_PROTOCOL_ALL        (SSL_PROTOCOL_SSLV2|SSL_PROTOCOL_TLS)
 
 #define SSL_MODE_CLIENT         (0)
 #define SSL_MODE_SERVER         (1)

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -120,7 +120,6 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
 #else
     switch (protocol) {
     case SSL_PROTOCOL_TLS:
-    case SSL_PROTOCOL_ALL:
         if (mode == SSL_MODE_CLIENT)
             ctx = SSL_CTX_new(SSLv23_client_method());
         else if (mode == SSL_MODE_SERVER)


### PR DESCRIPTION
Motivation:
SSL_PROTOCOL_ALL includes SSLv2 which has long been deprecated. We should no longer support this definition and instead use SSL_PROTOCOL_TLS.

Modifications:
- Remove SSL_PROTOCOL_ALL

Result:
SSLv2 is not coupled with the default definition SSL_PROTOCOL_ALL.