### PR TITLE
Support shading of netty-tcnative  

### DIFF
--- a/openssl-dynamic/src/main/c/bb.c
+++ b/openssl-dynamic/src/main/c/bb.c
@@ -30,6 +30,7 @@
  */
 
 #include "tcn.h"
+#include "bb.h"
 
 TCN_IMPLEMENT_CALL(jlong, Buffer, address)(TCN_STDARGS, jobject bb)
 {
@@ -42,3 +43,21 @@ TCN_IMPLEMENT_CALL(jlong, Buffer, size)(TCN_STDARGS, jobject bb)
     UNREFERENCED(o);
     return (*e)->GetDirectBufferCapacity(e, bb);
 }
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod method_table[] = {
+  { TCN_METHOD_TABLE_ENTRY(address, (Ljava/nio/ByteBuffer;)J, Buffer) },
+  { TCN_METHOD_TABLE_ENTRY(size, (Ljava/nio/ByteBuffer;)J, Buffer) }
+};
+
+static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
+// JNI Method Registration Table End
+
+jint netty_internal_tcnative_Buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    if (netty_internal_tcnative_util_register_natives(env, packagePrefix, "io/netty/internal/tcnative/Buffer", method_table, method_table_size) != 0) {
+        return JNI_ERR;
+    }
+    return TCN_JNI_VERSION;
+}
+
+void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env) { }

--- a/openssl-dynamic/src/main/c/bb.h
+++ b/openssl-dynamic/src/main/c/bb.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_TCNATIVE_BB_H_
+#define NETTY_TCNATIVE_BB_H_
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_internal_tcnative_Buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env);
+#endif /* NETTY_TCNATIVE_BB_H_ */

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -208,12 +208,24 @@ static char* netty_internal_tcnative_util_strndup(const char *s, size_t n) {
 #endif
 }
 
+static char* netty_internal_tcnative_util_strstr_last(const char* haystack, const char* needle) {
+    char* prevptr = NULL;
+    char* ptr = (char*) haystack;
+
+    while ((ptr = strstr(ptr, needle)) != NULL) {
+        // Just store the ptr and continue searching.
+        prevptr = ptr;
+        ++ptr;
+    }
+    return prevptr;
+}
+
 /**
  * The expected format of the library name is "lib<>netty-tcnative" on non windows platforms and "<>netty-tcnative" on windows,
  *  where the <> portion is what we will return.
  */
 static char* parsePackagePrefix(const char* libraryPathName, jint* status) {
-    char* packageNameEnd = strstr(libraryPathName, "netty-tcnative");
+    char* packageNameEnd = netty_internal_tcnative_util_strstr_last(libraryPathName, "netty-tcnative");
     if (packageNameEnd == NULL) {
         *status = JNI_ERR;
         return NULL;

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -16,22 +16,7 @@
 
 #include "tcn.h"
 #include "ssl_private.h"
-
-TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyNone)(TCN_STDARGS) {
-    return SSL_VERIFY_NONE;
-}
-
-TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyPeer)(TCN_STDARGS) {
-    return SSL_VERIFY_PEER;
-}
-
-TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyFailIfNoPeerCert)(TCN_STDARGS) {
-    return SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-}
-
-TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyClientOnce)(TCN_STDARGS) {
-    return SSL_VERIFY_CLIENT_ONCE;
-}
+#include "native_constants.h"
 
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpCipherServerPreference)(TCN_STDARGS) {
     return SSL_OP_CIPHER_SERVER_PREFERENCE;
@@ -484,3 +469,120 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, x509vErrDaneNoMat
     return TCN_X509_V_ERR_UNSPECIFIED;
 #endif
 }
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod method_table[] = {
+  { TCN_METHOD_TABLE_ENTRY(sslOpCipherServerPreference, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoSSLv2, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoSSLv3, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv1, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv11, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv12, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoTicket, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoCompression, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSessCacheOff, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSessCacheServer, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslStConnect, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslStAccept, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslModeEnablePartialWrite, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslModeAcceptMovingWriteBuffer, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslModeReleaseBuffers, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSendShutdown, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslReceivedShutdown, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorNone, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorSSL, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantRead, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantWrite, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantX509Lookup, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorSyscall, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorZeroReturn, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantConnect, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantAccept, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslMaxPlaintextLength, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslMaxPlaintextLength, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509CheckFlagAlwaysCheckSubject, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509CheckFlagDisableWildCards, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509CheckFlagNoPartialWildCards, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509CheckFlagMultiLabelWildCards, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vOK, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnspecified, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToGetIssuerCert, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToGetCrl, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToDecryptCertSignature, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToDecryptCrlSignature, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToDecodeIssuerPublicKey, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertSignatureFailure, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCrlSignatureFailure, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertNotYetValid, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertHasExpired, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCrlNotYetValid, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCrlHasExpired, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrErrorInCertNotBeforeField, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrErrorInCertNotAfterField, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrErrorInCrlLastUpdateField, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrErrorInCrlNextUpdateField, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrOutOfMem, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrDepthZeroSelfSignedCert, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSelfSignedCertInChain, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToGetIssuerCertLocally, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToVerifyLeafSignature, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertChainTooLong, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertRevoked, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrInvalidCa, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrPathLengthExceeded, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrInvalidPurpose, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertUntrusted, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCertRejected, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSubjectIssuerMismatch, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrAkidSkidMismatch, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrAkidIssuerSerialMismatch, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrKeyUsageNoCertSign, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnableToGetCrlIssuer, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnhandledCriticalExtension, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrKeyUsageNoCrlSign, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnhandledCriticalCrlExtension, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrInvalidNonCa, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrProxyPathLengthExceeded, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrKeyUsageNoDigitalSignature, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrProxyCertificatesNotAllowed, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrInvalidExtension, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrInvalidPolicyExtension, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrNoExplicitPolicy, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrDifferntCrlScope, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnsupportedExtensionFeature, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnnestedResource, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrPermittedViolation, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrExcludedViolation, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSubtreeMinMax, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrApplicationVerification, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnsupportedConstraintType, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnsupportedConstraintSyntax, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrUnsupportedNameSyntax, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrCrlPathValidationError, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrPathLoop, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSuiteBInvalidVersion, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSuiteBInvalidAlgorithm, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSuiteBInvalidCurve, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSuiteBInvalidSignatureAlgorithm, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSuiteBLosNotAllowed, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrSuiteBCannotSignP384WithP256, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrHostnameMismatch, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrEmailMismatch, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrIpAddressMismatch, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(x509vErrDaneNoMatch, ()I, NativeStaticallyReferencedJniMethods) }
+};
+
+static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
+// JNI Method Registration Table End
+
+jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    if (netty_internal_tcnative_util_register_natives(env,
+             packagePrefix,
+             "io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods",
+             method_table, method_table_size) != 0) {
+        return JNI_ERR;
+    }
+    return TCN_JNI_VERSION;
+}
+
+void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env) { }

--- a/openssl-dynamic/src/main/c/native_constants.h
+++ b/openssl-dynamic/src/main/c/native_constants.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_TCNATIVE_NATIVE_CONSTANTS_H_
+#define NETTY_TCNATIVE_NATIVE_CONSTANTS_H_
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env);
+#endif /* NETTY_TCNATIVE_NATIVE_CONSTANTS_H_ */

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -38,6 +38,7 @@
 #include "apr_strings.h"
 #include "apr_portable.h"
 #include "ssl_private.h"
+#include "ssl.h"
 
 static int ssl_initialized = 0;
 extern apr_pool_t *tcn_global_pool;
@@ -1823,7 +1824,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
     }
 }
 
-TCN_IMPLEMENT_CALL(long, SSL, parsePrivateKey)(TCN_STDARGS, jlong privateKeyBio, jstring password)
+TCN_IMPLEMENT_CALL(jlong, SSL, parsePrivateKey)(TCN_STDARGS, jlong privateKeyBio, jstring password)
 {
     EVP_PKEY* pkey = NULL;
     BIO *bio = J2P(privateKeyBio, BIO *);
@@ -1856,7 +1857,7 @@ TCN_IMPLEMENT_CALL(void, SSL, freePrivateKey)(TCN_STDARGS, jlong privateKey)
     EVP_PKEY_free(key); // Safe to call with NULL as well.
 }
 
-TCN_IMPLEMENT_CALL(long, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
+TCN_IMPLEMENT_CALL(jlong, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
 {
     BIO *cert_bio = J2P(x509ChainBio, BIO *);
     X509* cert = NULL;
@@ -2036,3 +2037,85 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getOcspResponse)(TCN_STDARGS, jlong ssl) {
     return value;
 #endif
 }
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod method_table[] = {
+  { TCN_METHOD_TABLE_ENTRY(bioLengthByteBuffer, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioLengthNonApplication, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(version, ()I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(versionString, ()Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(initialize, (Ljava/lang/String;)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(newMemBIO, ()J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getLastError, ()Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getLastErrorNumber, ()I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(newSSL, (JZ)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getError, (JI)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioWrite, (JJI)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioSetByteBuffer, (JJIZ)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioClearByteBuffer, (J)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioFlushByteBuffer, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(sslPending, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(writeToSSL, (JJI)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(readFromSSL, (JJI)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getShutdown, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setShutdown, (JI)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(freeSSL, (J)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioNewByteBuffer, (JI)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioNewByteBuffer, (JI)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(freeBIO, (J)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(shutdownSSL, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getCipherForSSL, (J)Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getVersion, (J)Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(isInInit, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(doHandshake, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getNextProtoNegotiated, (J)Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getAlpnSelected, (J)Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getPeerCertChain, (J)[[B, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getPeerCertificate, (J)[B, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getErrorString, (J)Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getTime, (J)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getTimeout, (J)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setTimeout, (JJ)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setVerify, (JII)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setOptions, (JI)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(clearOptions, (JI)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getOptions, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setMode, (JI)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getMode, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getMaxWrapOverhead, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getCiphers, (J)[Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setCipherSuites, (JLjava/lang/String;)Z, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getSessionId, (J)[B, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getHandshakeCount, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(clearError, ()V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(renegotiate, (J)I, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setState, (JI)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setTlsExtHostName, (JLjava/lang/String;)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setHostNameValidation, (JILjava/lang/String;)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(authenticationMethods, (J)[Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setCertificateBio, (JJJLjava/lang/String;)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setCertificateChainBio, (JJZ)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(parsePrivateKey, (JLjava/lang/String;)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(freePrivateKey, (J)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(parseX509Chain, (J)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(freeX509Chain, (J)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(enableOcsp, (J)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setOcspResponse, (J[B)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getOcspResponse, (J)[B, SSL) }
+};
+
+static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
+
+// JNI Method Registration Table End
+
+jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    if (netty_internal_tcnative_util_register_natives(env,
+             packagePrefix,
+             "io/netty/internal/tcnative/SSL",
+             method_table, method_table_size) != 0) {
+        return JNI_ERR;
+    }
+    return TCN_JNI_VERSION;
+}
+
+void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env) { }

--- a/openssl-dynamic/src/main/c/ssl.h
+++ b/openssl-dynamic/src/main/c/ssl.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_TCNATIVE_SSL_H_
+#define NETTY_TCNATIVE_SSL_H_
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env);
+#endif /* NETTY_TCNATIVE_SSL_H_ */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -36,8 +36,11 @@
 
 #include "ssl_private.h"
 #include <stdint.h>
+#include "sslcontext.h"
 
 extern apr_pool_t *tcn_global_pool;
+
+static char *keyMaterialRequestedMethodSignature;
 
 static apr_status_t ssl_context_cleanup(void *data)
 {
@@ -1462,7 +1465,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
         SSL_CTX_set_client_cert_cb(c->ctx, NULL);
     } else {
         jclass callback_class = (*e)->GetObjectClass(e, callback);
-        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", "(J[B[[B)Lio/netty/internal/tcnative/CertificateRequestedCallback$KeyMaterial;");
+        jmethodID method = (*e)->GetMethodID(e, callback_class, "requested", keyMaterialRequestedMethodSignature);
         if (method == NULL) {
             return;
         }
@@ -1651,4 +1654,123 @@ TCN_IMPLEMENT_CALL(void, SSLContext, disableOcsp)(TCN_STDARGS, jlong ctx) {
     SSL_CTX_set_tlsext_status_cb(c->ctx, NULL);
     SSL_CTX_set_tlsext_status_arg(c->ctx, NULL);
 #endif
+}
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod fixed_method_table[] = {
+  { TCN_METHOD_TABLE_ENTRY(make, (II)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(free, (J)I, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setContextId, (JLjava/lang/String;)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setOptions, (JI)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getOptions, (J)I, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(clearOptions, (JI)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCipherSuite, (JLjava/lang/String;)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCertificateChainFile, (JLjava/lang/String;Z)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCertificateChainBio, (JJZ)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCACertificateBio, (JJ)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setTmpDHLength, (JI)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setVerify, (JII)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCertificate, (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCertificateBio, (JJJLjava/lang/String;)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setNpnProtos, (J[Ljava/lang/String;I)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setAlpnProtos, (J[Ljava/lang/String;I)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setSessionCacheMode, (JJ)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getSessionCacheMode, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setSessionCacheTimeout, (JJ)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getSessionCacheTimeout, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setSessionCacheSize, (JJ)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getSessionCacheSize, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionNumber, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionConnect, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionConnectGood, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionConnectRenegotiate, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionAccept, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionAcceptGood, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionAcceptRenegotiate, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionHits, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionCbHits, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionMisses, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionTimeouts, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionCacheFull, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionTicketKeyNew, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionTicketKeyResume, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionTicketKeyRenew, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(sessionTicketKeyFail, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setSessionTicketKeys0, (J[B)V, SSLContext) },
+
+  // setCertVerifyCallback -> needs dynamic method table
+  // setCertRequestedCallback -> needs dynamic method table
+  // setSniHostnameMatcher -> needs dynamic method table
+
+  { TCN_METHOD_TABLE_ENTRY(setSessionIdContext, (J[B)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setMode, (JI)I, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getMode, (J)I, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(enableOcsp, (JZ)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(disableOcsp, (J)V, SSLContext) }
+};
+
+static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
+
+static jint dynamicMethodsTableSize() {
+    return fixed_method_table_size + 3;
+}
+
+static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
+    JNINativeMethod* dynamicMethods = malloc(sizeof(JNINativeMethod) * dynamicMethodsTableSize());
+    memcpy(dynamicMethods, fixed_method_table, sizeof(fixed_method_table));
+    char* dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateVerifier;)V");
+    JNINativeMethod* dynamicMethod = &dynamicMethods[fixed_method_table_size];
+    dynamicMethod->name = "setCertVerifyCallback";
+    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
+    dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setCertVerifyCallback);
+    free(dynamicTypeName);
+
+    dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateRequestedCallback;)V");
+    dynamicMethod = &dynamicMethods[fixed_method_table_size + 1];
+    dynamicMethod->name = "setCertRequestedCallback";
+    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
+    dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setCertRequestedCallback);
+    free(dynamicTypeName);
+
+    dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SniHostNameMatcher;)V");
+    dynamicMethod = &dynamicMethods[fixed_method_table_size + 2];
+    dynamicMethod->name = "setSniHostnameMatcher";
+    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
+    dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setSniHostnameMatcher);
+    free(dynamicTypeName);
+    return dynamicMethods;
+}
+
+static void freeDynamicMethodsTable(JNINativeMethod* dynamicMethods) {
+    jint fullMethodTableSize = dynamicMethodsTableSize();
+    jint i = fixed_method_table_size;
+    for (; i < fullMethodTableSize; ++i) {
+        free(dynamicMethods[i].signature);
+    }
+    free(dynamicMethods);
+}
+// JNI Method Registration Table End
+
+jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
+    if (netty_internal_tcnative_util_register_natives(env,
+            packagePrefix,
+            "io/netty/internal/tcnative/SSLContext",
+            dynamicMethods,
+            dynamicMethodsTableSize()) != 0) {
+        freeDynamicMethodsTable(dynamicMethods);
+        return JNI_ERR;
+    }
+    freeDynamicMethodsTable(dynamicMethods);
+
+    char* tmpSignature = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateRequestedCallback$KeyMaterial;");
+    keyMaterialRequestedMethodSignature = netty_internal_tcnative_util_prepend("(J[B[[B)L", tmpSignature);
+    free(tmpSignature);
+
+    return TCN_JNI_VERSION;
+}
+
+void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env) {
+    free(keyMaterialRequestedMethodSignature);
+    keyMaterialRequestedMethodSignature = NULL;
 }

--- a/openssl-dynamic/src/main/c/sslcontext.h
+++ b/openssl-dynamic/src/main/c/sslcontext.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_TCNATIVE_SSLCONTEXT_H_
+#define NETTY_TCNATIVE_SSLCONTEXT_H_
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env);
+#endif /* NETTY_TCNATIVE_SSLCONTEXT_H_ */

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -71,8 +71,16 @@
 #define TCN_BUFFER_SZ   8192
 #define TCN_STDARGS     JNIEnv *e, jobject o
 
+#define STR(V) #V
+
+#define TCN_FUNCTION_NAME(CL, FN)  \
+    netty_internal_tcnative_##CL##_##FN
+
 #define TCN_IMPLEMENT_CALL(RT, CL, FN)  \
-    JNIEXPORT RT JNICALL Java_io_netty_internal_tcnative_##CL##_##FN
+    static RT TCN_FUNCTION_NAME(CL, FN)
+
+#define TCN_METHOD_TABLE_ENTRY(ME, SI, CL) \
+    STR(ME), STR(SI), (void *) TCN_FUNCTION_NAME(CL, ME)
 
 /* Private helper functions */
 void            tcn_Throw(JNIEnv *, const char *, ...);
@@ -143,6 +151,10 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
 
 #define TCN_MIN(a, b) ((a) < (b) ? (a) : (b))
 
+#ifndef TCN_JNI_VERSION
+#define TCN_JNI_VERSION JNI_VERSION_1_6
+#endif
+
 /* Return global String class
  */
 jclass tcn_get_string_class(void);
@@ -154,5 +166,19 @@ jfieldID tcn_get_key_material_private_key_field();
 /* Get current thread JNIEnv
  */
 jint tcn_get_java_env(JNIEnv **);
+
+/**
+ * Return a new string (caller must free this string) which is equivalent to <pre>prefix + str</pre>.
+ *
+ * Caller must free the return value!
+ */
+char* netty_internal_tcnative_util_prepend(const char* prefix, const char* str);
+
+char* netty_internal_tcnative_util_rstrstr(char* s1rbegin, const char* s1rend, const char* s2);
+
+/**
+ * Return type is as defined in http://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#wp5833.
+ */
+jint netty_internal_tcnative_util_register_natives(JNIEnv* env, const char* packagePrefix, const char* className, const JNINativeMethod* methods, jint numMethods);
 
 #endif /* TCN_H */


### PR DESCRIPTION
Motivation:

If netty-tcnative's class files are renamed and the type references are updated (shaded) the native libraries will not function. netty-tcnative uses implicit JNI bindings which requires the fully qualified java type names to match the method signatures of the native methods. This means netty-tcnative can not be shaded atm.

Modifications:

- Dynamic register JNI methods
- Based on the library name a different package can now be used

Result:

- netty-tcnative can now be shaded.