### PR TITLE
Revert commit 33caa6bb239b56d85d48111730bd0c14786bdf97 due to memory …

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -186,6 +186,7 @@ typedef struct {
 } tcn_ssl_verify_config_t;
 
 struct tcn_ssl_ctxt_t {
+    apr_pool_t*              pool;
     SSL_CTX*                 ctx;
 
     /* Holds the alpn protocols, each of them prefixed with the len of the protocol */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -254,7 +254,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     c->protocol = protocol;
     c->mode     = mode;
     c->ctx      = ctx;
-
+    c->pool     = p;
     if (!(protocol & SSL_PROTOCOL_SSLV2))
         SSL_CTX_set_options(c->ctx, SSL_OP_NO_SSLv2);
     if (!(protocol & SSL_PROTOCOL_SSLV3))
@@ -323,6 +323,12 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     SSL_CTX_set_default_passwd_cb_userdata(c->ctx, (void *) c->password);
 
     apr_thread_rwlock_create(&c->mutex, p);
+    /*
+     * Let us cleanup the ssl context when the pool is destroyed
+     */
+    apr_pool_cleanup_register(p, (const void *)c,
+                              ssl_context_cleanup,
+                              apr_pool_cleanup_null);
 
     return P2J(c);
 cleanup:
@@ -338,8 +344,10 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, free)(TCN_STDARGS, jlong ctx)
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
     UNREFERENCED_STDARGS;
     TCN_ASSERT(ctx != 0);
-
-    return ssl_context_cleanup(c);
+    /* Run and destroy the cleanup callback */
+    int result = apr_pool_cleanup_run(c->pool, c, ssl_context_cleanup);
+    apr_pool_destroy(c->pool);
+    return result;
 }
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setContextId)(TCN_STDARGS, jlong ctx,


### PR DESCRIPTION
…leak

Motivation:
Commit 33caa6bb239b56d85d48111730bd0c14786bdf97 removed the reference to the APR pool, but this reference was necessary to ensure all memory was properly freed.

Modifications:
- Revert 33caa6bb239b56d85d48111730bd0c14786bdf97

Result:
No more memory leak related to APR pool cleanup.