### PR TITLE
Correctly detect if we compile on windows

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -28,14 +28,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef WIN32
+#if !defined(_WIN32) && !defined (_WIN64)
 // It's important to have #define _GNU_SOURCE before any other include as otherwise it will not work.
 // See http://stackoverflow.com/questions/7296963/gnu-source-and-use-gnu
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #else
 #define MAX_DLL_PATH_LEN 2048
-#endif /* WIN32 */
+#endif
 
 #include "tcn.h"
 #include "apr_version.h"


### PR DESCRIPTION
Motivation:

a61c1a897ef13916a70ff1bd7fb676cdae447ff8 introduced some platform specific code but not correctly detected if we are on windows in all cases.

Modifications:

Correctly detect.

Result:

Be able to compile on windows as well