### PR TITLE
Set SSL_CTX_set_allow_unknown_alpn_protos when using boringssl

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -322,6 +322,12 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     SSL_CTX_set_default_passwd_cb(c->ctx, (pem_password_cb *)SSL_password_callback);
     SSL_CTX_set_default_passwd_cb_userdata(c->ctx, (void *) c->password);
 
+#if defined(OPENSSL_IS_BORINGSSL)
+    if (mode != SSL_MODE_SERVER) {
+        // Set this to make the behaviour consistent with openssl / libressl
+        SSL_CTX_set_allow_unknown_alpn_protos(ctx, 1);
+    }
+#endif
     apr_thread_rwlock_create(&c->mutex, p);
     /*
      * Let us cleanup the ssl context when the pool is destroyed


### PR DESCRIPTION
Motivation:

We should set SSL_CTX_set_allow_unknown_alpn_protos when using boringssl to make its behaviour consistent with openssl and libressl.

Modifications:

Set SSL_CTX_set_allow_unknown_alpn_protos if boringssl is used and the SSLContext is created for client-side usage. This is done by a macro-guard so it needs to be linked against boringssl on compile time.

Result:

More consistent behaviour.