### PR TITLE
Not force to run autoconf and compile multiple times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
   <properties>
     <checkstyle.skip>true</checkstyle.skip>
     <animal.sniffer.skip>true</animal.sniffer.skip>
-    <forceAutogen>true</forceAutogen>
-    <forceConfigure>true</forceConfigure>
+    <forceAutogen>false</forceAutogen>
+    <forceConfigure>false</forceConfigure>
     <opensslDynamicDir>../openssl-dynamic</opensslDynamicDir>
     <vsStaticTemplateFile>../vs2010.vcxproj.static.template</vsStaticTemplateFile>
     <defaultJarFile>${project.build.directory}/${project.build.finalName}.jar</defaultJarFile>
@@ -295,11 +295,6 @@
           <family>windows</family>
         </os>
       </activation>
-      <properties>
-        <!-- On Windows, we do not use autotools -->
-        <forceAutogen>false</forceAutogen>
-        <forceConfigure>false</forceConfigure>
-      </properties>
     </profile>
 
     <!-- Build the static APR library -->


### PR DESCRIPTION
Motivation:

We should not force autoconf and compile as this will result in multiple executions and so slow down the build.

Modifications:

Not force by default.

Result:

Faster build