### PR TITLE
Cleanup from afc666462b67bb43075fe3b34c8855ae3869ad07

### DIFF
--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -174,8 +174,6 @@ jint tcn_get_java_env(JNIEnv **);
  */
 char* netty_internal_tcnative_util_prepend(const char* prefix, const char* str);
 
-char* netty_internal_tcnative_util_rstrstr(char* s1rbegin, const char* s1rend, const char* s2);
-
 /**
  * Return type is as defined in http://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#wp5833.
  */


### PR DESCRIPTION
Motivaiton:
Commit afc6664 contains an unecessary reference to parsePackagePrefix.

Modificaitons:
- Remove unecessary line of code
- netty_internal_tcnative_util_rstrstr can be static to jnilib.c
- netty_internal_tcnative_util_strndup, netty_internal_tcnative_util_rstrstr, netty_internal_tcnative_util_strstr_last, and parsePackagePrefix can all be excluded if the TCN_NOT_DYNAMIC preprocessor flag is not defined

Result:
Less unecessary code.