### PR TITLE
Add an alternative library name for Java8 statically linked JNI

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
@@ -37,7 +37,12 @@ import java.io.File;
 public final class Library {
 
     /* Default library names */
-    private static final String [] NAMES = {"netty-tcnative", "libnetty-tcnative", "netty-tcnative-1", "libnetty-tcnative-1"};
+    private static final String [] NAMES = {
+        "netty-tcnative",
+        "netty_tcnative",
+        "libnetty-tcnative",
+        "netty-tcnative-1",
+        "libnetty-tcnative-1"};
     /*
      * A handle to the unique Library singleton instance.
      */


### PR DESCRIPTION
Motivation:
Java 8 adds a way for JNI code to be loaded by using a suffixed
version of the `JNI_OnLoad` function.  Such a functions looks
like:  `jint JNI_OnLoad_my_code(...)`, and can be loaded with
`System.loadLibrary("my_code")`.  Currently, Netty TCNative uses
dashes "-" instead of underscores in the library name, which makes
it not possible to be defined in C.

A work around for this is just manually call `System.loadLibrary`
with the right name out of band, but since TCNative code can try
multiple library names anyways, it makes since to do it in
`Library`.

Modifcations:
Add a "netty_tcnative" name to try loading in addition to
"netty-tcnative".

Results:
No more out of band initializationl; no more maintaining patches
to get TCNative to work.