### PR TITLE
Correctly handle path seperator when using Windows and try to load na…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -243,8 +243,16 @@ static char* parsePackagePrefix(const char* libraryPathName, jint* status) {
         return NULL;
     }
 #ifdef _WIN32
+    char* tmpLibraryPathName = libraryPathName;
+
+    // replace \ with /
+    for(; *tmpLibraryPathName != '\0'; ++tmpLibraryPathName) {
+        if (*tmpLibraryPathName == '\\') {
+            *tmpLibraryPathName = '/';
+        }
+    }
     // on windows there is no lib prefix so we instead look for the previous path separator or the beginning of the string.
-    char* packagePrefix = netty_internal_tcnative_util_rstrchar(packageNameEnd, libraryPathName, '\\');
+    char* packagePrefix = netty_internal_tcnative_util_rstrchar(packageNameEnd, libraryPathName, '/');
     if (packagePrefix == NULL) {
         // The string does not have to specify a path [1].
         // [1] https://msdn.microsoft.com/en-us/library/windows/desktop/ms683200(v=vs.85).aspx
@@ -418,13 +426,6 @@ jint JNI_OnLoad_netty_tcnative(JavaVM* vm, void* reserved) {
         dllPath[dllPathLen] = '\0';
     }
 
-    char* dllTmpPath = dllPath;
-    // replace \ with /
-    for(; *dllTmpPath != '\0'; ++dllTmpPath) {
-        if (*dllTmpPath == '\\') {
-            *dllTmpPath = '/';
-        }
-    }
     name = dllPath;
 #endif
     char* packagePrefix = parsePackagePrefix(name, &status);


### PR DESCRIPTION
…tive library.

Motiviation:

Our latest changes broke the build on windows as we only handled \ as path seperator on windows.

Modifications:

When on windows replace \ with / and so allow to load the native library when either \ or / is used.

Result:

Correctly load native lib on windows in all cases and test pass again on windows.