### PR TITLE
Correctly handle loading of native lib on windows when full path is g…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -418,13 +418,6 @@ jint JNI_OnLoad_netty_tcnative(JavaVM* vm, void* reserved) {
         dllPath[dllPathLen] = '\0';
     }
 
-    char* dllTmpPath = dllPath;
-    // replace \ with /
-    for(; *dllTmpPath != '\0'; ++dllTmpPath) {
-        if (*dllTmpPath == '\\') {
-            *dllTmpPath = '/';
-        }
-    }
     name = dllPath;
 #endif
     char* packagePrefix = parsePackagePrefix(name, &status);


### PR DESCRIPTION
…iven

Motivation:

We failed to remove some code that replaced \ with / on windows and so made our parsePackagePrefix function return something invalid on windows.

Modification:

Remove code that replaces \ with /.

Result:

Works again on windows.