### PR TITLE
Use APR 1.6.2 when static compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.classifier}.jar</nativeJarFile>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <nativeJarWorkdir>${project.build.directory}/native-jar-work</nativeJarWorkdir>
-    <aprVersion>1.5.2</aprVersion>
+    <aprVersion>1.6.2</aprVersion>
     <aprMd5>98492e965963f852ab29f9e61b2ad700</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
     <libresslVersion>2.4.5</libresslVersion>


### PR DESCRIPTION
Motivation:

We should use APR 1.6.2 (the latest stable version) when compile our static releases. The old release we were using was moved to the archive and so the build fails atm.

Modifications:

Use APR 1.6.2

Result:

Use latest APR version.