### PR TITLE
Update to libressl 2.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.6.2</aprVersion>
     <aprMd5>98492e965963f852ab29f9e61b2ad700</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.4.5</libresslVersion>
+    <libresslVersion>2.5.5</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>d300c4e358aee951af6dfd1684ef0c034758b47171544230f3ccf6ce24fe4347</libresslSha256>
+    <libresslSha256>e57f5e3d5842a81fe9351b6e817fcaf0a749ca4ef35a91465edba9e071dce7c4</libresslSha256>
     <opensslVersion>1.0.2l</opensslVersion>
     <opensslSha256>ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>


### PR DESCRIPTION
Motivation:

libressl 2.5.5 is considered the latest stable release, we should upgrade.

Modifications:

Compile against libressl 2.5.5 in our static builds.

Result:

Use latest libressl version.