### PR TITLE
Use underscore in native library names to allow loading in all enviro…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -188,7 +188,7 @@
                       </and>
                       <then>
                         <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
-                          <arg value="libnetty-tcnative.so" />
+                          <arg value="libnetty_tcnative.so" />
                         </exec>
                       </then>
                     </if>
@@ -221,7 +221,7 @@
                 </goals>
                 <phase>compile</phase>
                 <configuration>
-                  <name>netty-tcnative</name>
+                  <name>netty_tcnative</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>
@@ -342,15 +342,15 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-x86_64/META-INF/native" />
-                      <globmapper from="libnetty-tcnative.*" to="libnetty-tcnative-osx-x86_64.*" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_x86_64.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-x86_64/META-INF/native" />
-                      <globmapper from="libnetty-tcnative.*" to="libnetty-tcnative-linux-x86_64.*" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_x86_64.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/windows-x86_64/META-INF/native" />
-                      <globmapper from="netty-tcnative.*" to="netty-tcnative-windows-x86_64.*" />
+                      <globmapper from="netty_tcnative.*" to="netty_tcnative_windows_x86_64.*" />
                     </copy>
                   </target>
                 </configuration>
@@ -375,9 +375,9 @@
                   <instructions>
                     <Export-Package>io.netty.internal.tcnative.*</Export-Package>
                     <Bundle-NativeCode>
-                      META-INF/native/libnetty-tcnative-osx-x86_64.jnilib;osname=macos;osname=macosx;processor=x86_64,
-                      META-INF/native/libnetty-tcnative-linux-x86_64.so;osname=linux;processor=x86_64,
-                      META-INF/native/netty-tcnative-windows-x86_64.dll;osname=win32;processor=x86_64
+                      META-INF/native/libnetty_tcnative_osx_x86_64.jnilib;osname=macos;osname=macosx;processor=x86_64,
+                      META-INF/native/libnetty_tcnative_linux_x86_64.so;osname=linux;processor=x86_64,
+                      META-INF/native/netty_tcnative_windows_x86_64.dll;osname=win32;processor=x86_64
                     </Bundle-NativeCode>
                   </instructions>
                 </configuration>
@@ -458,11 +458,11 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-x86_64/META-INF/native" />
-                      <globmapper from="libnetty-tcnative.*" to="libnetty-tcnative-osx-x86_64.*" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_x86_64.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-x86_64/META-INF/native" />
-                      <globmapper from="libnetty-tcnative.*" to="libnetty-tcnative-linux-x86_64.*" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_x86_64.*" />
                     </copy>
                   </target>
                 </configuration>
@@ -487,9 +487,9 @@
                   <instructions>
                     <Export-Package>io.netty.internal.tcnative.*</Export-Package>
                     <Bundle-NativeCode>
-                      META-INF/native/libnetty-tcnative-osx-x86_64.jnilib;osname=macos;osname=macosx;processor=x86_64,
-                      META-INF/native/libnetty-tcnative-linux-x86_64.so;osname=linux;processor=x86_64,
-                      META-INF/native/netty-tcnative-windows-x86_64.dll;osname=win32;processor=x86_64
+                      META-INF/native/libnetty_tcnative_osx_x86_64.jnilib;osname=macos;osname=macosx;processor=x86_64,
+                      META-INF/native/libnetty_tcnative_linux_x86_64.so;osname=linux;processor=x86_64,
+                      META-INF/native/netty_tcnative_windows_x86_64.dll;osname=win32;processor=x86_64
                     </Bundle-NativeCode>
                   </instructions>
                 </configuration>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -54,7 +54,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <name>netty-tcnative</name>
+              <name>netty_tcnative</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -80,7 +80,7 @@
           <execution>
             <id>build-native-lib</id>
             <configuration>
-              <name>netty-tcnative</name>
+              <name>netty_tcnative</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>
@@ -162,7 +162,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty-tcnative</name>
+                  <name>netty_tcnative</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -233,11 +233,11 @@ static char* netty_internal_tcnative_util_strstr_last(const char* haystack, cons
 }
 
 /**
- * The expected format of the library name is "lib<>netty-tcnative" on non windows platforms and "<>netty-tcnative" on windows,
+ * The expected format of the library name is "lib<>netty_tcnative" on non windows platforms and "<>netty_tcnative" on windows,
  *  where the <> portion is what we will return.
  */
 static char* parsePackagePrefix(const char* libraryPathName, jint* status) {
-    char* packageNameEnd = netty_internal_tcnative_util_strstr_last(libraryPathName, "netty-tcnative");
+    char* packageNameEnd = netty_internal_tcnative_util_strstr_last(libraryPathName, "netty_tcnative");
     if (packageNameEnd == NULL) {
         *status = JNI_ERR;
         return NULL;
@@ -273,7 +273,7 @@ static char* parsePackagePrefix(const char* libraryPathName, jint* status) {
     packageNameEnd = packagePrefix + packagePrefixLen;
     // Package names must be sanitized, in JNI packages names are separated by '/' characters.
     for (; temp != packageNameEnd; ++temp) {
-        if (*temp == '-') {
+        if (*temp == '_') {
             *temp = '/';
         }
     }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/Library.java
@@ -38,11 +38,12 @@ public final class Library {
 
     /* Default library names */
     private static final String [] NAMES = {
-        "netty-tcnative",
         "netty_tcnative",
-        "libnetty-tcnative",
-        "netty-tcnative-1",
-        "libnetty-tcnative-1"};
+        "libnetty_tcnative"
+    };
+
+    private static final String PROVIDED = "provided";
+
     /*
      * A handle to the unique Library singleton instance.
      */
@@ -84,9 +85,8 @@ public final class Library {
         }
     }
 
-    private Library(String libraryName)
-    {
-        if (!"provided".equals(libraryName)) {
+    private Library(String libraryName) {
+        if (!PROVIDED.equals(libraryName)) {
             System.loadLibrary(libraryName);
         }
     }
@@ -110,7 +110,7 @@ public final class Library {
      * @throws Exception if an error happens during initialization
      */
     public static boolean initialize() throws Exception {
-        return initialize("provided", null);
+        return initialize(PROVIDED, null);
     }
 
     /**

--- a/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
+++ b/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractNativeTest {
         if (directories == null || directories.length != 1) {
             throw new IllegalStateException("Could not find platform specific native directory");
         }
-        String libName = System.mapLibraryName("netty-tcnative")
+        String libName = System.mapLibraryName("netty_tcnative")
                 // Fix the filename (this is needed for macOS).
                 .replace(".dylib", ".jnilib");
         String libPath = directories[0].getAbsoluteFile() + File.separator + libName;

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -64,7 +64,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <name>netty-tcnative</name>
+              <name>netty_tcnative</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>

--- a/pom.xml
+++ b/pom.xml
@@ -212,15 +212,15 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <condition property="tcnative.snippet" value="libnetty-tcnative.so;osname=linux">
+                <condition property="tcnative.snippet" value="libnetty_tcnative.so;osname=linux">
                   <equals arg1="${os.detected.name}" arg2="linux" />
                 </condition>
                 <!-- In OSGi specification, the alias of Windows family is win32, case insensitive -->
-                <condition property="tcnative.snippet" value="netty-tcnative.dll;osname=win32">
+                <condition property="tcnative.snippet" value="netty_tcnative.dll;osname=win32">
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
                 <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
-                <condition property="tcnative.snippet" value="libnetty-tcnative.jnilib;osname=macos;osname=macosx;">
+                <condition property="tcnative.snippet" value="libnetty_tcnative.jnilib;osname=macos;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=x86_64" />


### PR DESCRIPTION
Motivation:

At the moment we try to load the library using multiple names which includes names using - but also _ . We should just use _ all the time.

This is a followup of cf0c7e0aa4f962b3e65df5fa6ccb34265ab77aec.

Modifications:

Replace - by _

Result:

Make the loading code more consistent.