### PR TITLE
Ensure we also use underscore for the native library when using windows

### DIFF
--- a/openssl-dynamic/src/main/native-package/vs2010.vcxproj
+++ b/openssl-dynamic/src/main/native-package/vs2010.vcxproj
@@ -19,8 +19,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectName>netty-tcnative</ProjectName>
-    <RootNamespace>netty-tcnative</RootNamespace>
+    <ProjectName>netty_tcnative</ProjectName>
+    <RootNamespace>netty_tcnative</RootNamespace>
     <ProjectGuid>{42EB387C-0D16-471E-8859-C2CF31F8094D}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/vs2010.vcxproj.static.template
+++ b/vs2010.vcxproj.static.template
@@ -19,8 +19,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectName>netty-tcnative</ProjectName>
-    <RootNamespace>netty-tcnative</RootNamespace>
+    <ProjectName>netty_tcnative</ProjectName>
+    <RootNamespace>netty_tcnative</RootNamespace>
     <ProjectGuid>{42EB387C-0D16-471E-8859-C2CF31F8094D}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Motivation:

Commit a773517dd9093a9f69dba160f10c19c557d58f87 broke the build for windows as we missed to adjust the library name in the the VS files.

Modifications:

Replace netty-tcnative with netty_tcnative

Result:

Build works on windows again as well