### PR TITLE
Include JNIEXPORT on exported symbols

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -442,7 +442,7 @@ jint JNI_OnLoad_netty_tcnative(JavaVM* vm, void* reserved) {
 }
 
 #ifndef TCN_BUILD_STATIC
-jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_OnLoad_netty_tcnative(vm, reserved);
 }
 #endif /* TCN_BUILD_STATIC */
@@ -457,7 +457,7 @@ void JNI_OnUnload_netty_tcnative(JavaVM* vm, void* reserved) {
 }
 
 #ifndef TCN_BUILD_STATIC
-void JNI_OnUnload(JavaVM* vm, void* reserved) {
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
   JNI_OnUnload_netty_tcnative(vm, reserved);
 }
 #endif /* TCN_BUILD_STATIC */


### PR DESCRIPTION

Motivation:
As noticed in https://stackoverflow.com/questions/45700277/
compilation can fail if the definition of a method doesn't
match the declaration.  It's easy enough to add this in, and make
it easy to compile.

Modification:
Add JNIEXPORT to the entry points.

* On Windows this adds: `__declspec(dllexport)`
* On Mac this adds: `__attribute__((visibility("default")))`
* On Linux (GCC 4.2+) this adds: ` __attribute__((visibility("default")))`
* On other it doesn't add anything.

Result:
Easier compilation