### PR TITLE
Remove duplicate defination of osname in MANIFEST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
                 <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
-                <condition property="tcnative.snippet" value="libnetty_tcnative.jnilib;osname=macos;osname=macosx;">
+                <condition property="tcnative.snippet" value="libnetty_tcnative.jnilib;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=${os.detected.arch}" />


### PR DESCRIPTION
Motivation:

The MANIFEST contained a duplicated defination of osname for macosx

Modifications:

Remove duplication

Result:

No more duplicated defination.