### PR TITLE
Add missing include

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -63,6 +63,7 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
+#include <openssl/hmac.h>
 
 #define ERR_LEN 256
 


### PR DESCRIPTION
Motivation:
sslcontext.c uses HMAC_Init_ex(), so it should include hmac.h.

In boringssl, ssl.h used to include hmac.h, but in the future it
will not.

Modification:
Add missing hmac.h

Result:
Proper includes achieved