### PR TITLE
Fix shading support on Windows

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -191,7 +191,7 @@ static char* netty_internal_tcnative_util_strndup(const char *s, size_t n) {
     char* copy = _strdup(s);
     if (copy != NULL && n < strlen(copy)) {
         // mark the end
-        copy[n + 1] = '\0';
+        copy[n] = '\0';
     }
     return copy;
 #else


### PR DESCRIPTION
When shading (based on the work from #272), I'm getting the following error on Windows:
```
java.lang.NoClassDefFoundError: shaded/nio/netty/internal/tcnative/Library
```
Note the extra **n** in the above class name (shaded/**n**io/netty/internal/tcnative/Library, when it should be looking for shaded/io/netty/internal/tcnative/Library).

Everything works works as expected on Linux.

I haven't gone through the build steps to test this, but from reading the source, it looks like a simple off-by-one error, hoping you'll agree.

Thanks.