### PR TITLE
Include architecture in native lib name.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -188,7 +188,7 @@
                       </and>
                       <then>
                         <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
-                          <arg value="libnetty_tcnative.so" />
+                          <arg value="libnetty_tcnative_${os.detected.arch}.so" />
                         </exec>
                       </then>
                     </if>
@@ -221,7 +221,7 @@
                 </goals>
                 <phase>compile</phase>
                 <configuration>
-                  <name>netty_tcnative</name>
+                  <name>netty_tcnative_${os.detected.arch}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>
@@ -343,15 +343,15 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_${uberArch}.*" to="libnetty_tcnative_osx_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_${uberArch}.*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/windows-${uberArch}/META-INF/native" />
-                      <globmapper from="netty_tcnative.*" to="netty_tcnative_windows_${uberArch}.*" />
+                      <globmapper from="netty_tcnative_${uberArch}.*" to="netty_tcnative_windows_${uberArch}.*" />
                     </copy>
                   </target>
                 </configuration>
@@ -460,11 +460,11 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_${uberArch}.*" to="libnetty_tcnative_osx_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_${uberArch}.*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                   </target>
                 </configuration>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -54,7 +54,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <name>netty_tcnative</name>
+              <name>netty_tcnative_${os.detected.arch}</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -80,7 +80,7 @@
           <execution>
             <id>build-native-lib</id>
             <configuration>
-              <name>netty_tcnative</name>
+              <name>netty_tcnative_${os.detected.arch}</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>
@@ -162,7 +162,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_tcnative</name>
+                  <name>netty_tcnative_${os.detected.arch}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>

--- a/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
+++ b/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractNativeTest {
         if (directories == null || directories.length != 1) {
             throw new IllegalStateException("Could not find platform specific native directory");
         }
-        String libName = System.mapLibraryName("netty_tcnative")
+        String libName = System.mapLibraryName("netty_tcnative_x86_64")
                 // Fix the filename (this is needed for macOS).
                 .replace(".dylib", ".jnilib");
         String libPath = directories[0].getAbsoluteFile() + File.separator + libName;

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -64,7 +64,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <name>netty_tcnative</name>
+              <name>netty_tcnative_${os.detected.arch}</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>

--- a/pom.xml
+++ b/pom.xml
@@ -212,15 +212,15 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <condition property="tcnative.snippet" value="libnetty_tcnative.so;osname=linux">
+                <condition property="tcnative.snippet" value="libnetty_tcnative_${os.detected.arch}.so;osname=linux">
                   <equals arg1="${os.detected.name}" arg2="linux" />
                 </condition>
                 <!-- In OSGi specification, the alias of Windows family is win32, case insensitive -->
-                <condition property="tcnative.snippet" value="netty_tcnative.dll;osname=win32">
+                <condition property="tcnative.snippet" value="netty_tcnative_${os.detected.arch}.dll;osname=win32">
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
                 <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
-                <condition property="tcnative.snippet" value="libnetty_tcnative.jnilib;osname=macosx;">
+                <condition property="tcnative.snippet" value="libnetty_tcnative_${os.detected.arch}.jnilib;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=${os.detected.arch}" />


### PR DESCRIPTION
Motivation:

We should include the architecture in the native lib name to allow not load it if the architecture not match.
This is related to https://github.com/netty/netty/pull/7163.

Modifications:

Add architecture to native lib name.

Result:

Fixes [#307].