### PR TITLE
Expose a define for large TLS payloads

### DIFF
--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -126,6 +126,12 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslMaxPlaintextLe
     return SSL3_RT_MAX_PLAIN_LENGTH;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslMaxRecordLength)(TCN_STDARGS) {
+    // SSL3_RT_MAX_ENCRYPTED_OVERHEAD = Padding + Message Digest Hash
+    // IV + Padding + Message Digest + Length allowed by RFC + Extra data amount
+    return 256 + SSL3_RT_MAX_ENCRYPTED_OVERHEAD + SSL3_RT_MAX_PLAIN_LENGTH + SSL3_RT_MAX_PLAIN_LENGTH;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, x509CheckFlagAlwaysCheckSubject)(TCN_STDARGS) {
 #ifdef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
     return X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT;
@@ -499,7 +505,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslErrorWantConnect, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslErrorWantAccept, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslMaxPlaintextLength, ()I, NativeStaticallyReferencedJniMethods) },
-  { TCN_METHOD_TABLE_ENTRY(sslMaxPlaintextLength, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslMaxRecordLength, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509CheckFlagAlwaysCheckSubject, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509CheckFlagDisableWildCards, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509CheckFlagNoPartialWildCards, ()I, NativeStaticallyReferencedJniMethods) },

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -71,6 +71,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslErrorWantAccept();
 
     static native int sslMaxPlaintextLength();
+    static native int sslMaxRecordLength();
 
     static native int x509CheckFlagAlwaysCheckSubject();
     static native int x509CheckFlagDisableWildCards();

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -91,6 +91,13 @@ public final class SSL {
     public static final int SSL_MODE_RELEASE_BUFFERS                = sslModeReleaseBuffers();
 
     public static final int SSL_MAX_PLAINTEXT_LENGTH = sslMaxPlaintextLength();
+    /**
+     * The <a href="https://tools.ietf.org/html/rfc5246#section-6.2.1">TLS 1.2 RFC</a> defines the maximum length to be
+     * {@link #SSL_MAX_PLAINTEXT_LENGTH}, but there are some implementations such as
+     * <a href="http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/d5a00b1e8f78/src/share/classes/sun/security/ssl/SSLSessionImpl.java#l793">OpenJDK's SSLEngineImpl</a>
+     * that also allow sending larger packets. This can be used as a upper bound for data to support legacy systems.
+     */
+    public static final int SSL_MAX_RECORD_LENGTH = sslMaxRecordLength();
 
     // https://www.openssl.org/docs/man1.0.2/crypto/X509_check_host.html
     public static final int X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT = x509CheckFlagAlwaysCheckSubject();


### PR DESCRIPTION
Motivation:
Some SSL implementations (e.g. OpenJDK [1]) use payload sizes greater than 2^14 (the
maximum allowed by the TLS 1.2 RFC). tcnative doesn't expose any defines
to accommodate these large payload sizes.

[1] http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/d5a00b1e8f78/src/share/classes/sun/security/ssl/SSLSessionImpl.java#l793
[2] https://tools.ietf.org/html/rfc5246#section-6.2.1

Modifications:
- Expose a define to accommodate TLS records greater than 2^14

Result:
Netty has a define to use for TLS records greater than 2^14