### PR TITLE
Use correct CXXFLAGS depending on OS.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -141,28 +141,35 @@
                       <equals arg1="${os.detected.name}" arg2="windows" />
                       <then>
                         <!-- On Windows, build with /MT for static linking -->
-                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_C_FLAGS_RELEASE=/MT" />
-                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=/MT" />
-                          <arg value="-GNinja" />
-                          <arg value=".." />
-                        </exec>
+                        <property name="cmakeAsmFlags" value="" />
+                        <property name="cmakeCFlags" value="/MT" />
+                        <property name="cmakeCxxFlags" value="/MT" />
                       </then>
+                      <elseif>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <then>
+                          <!-- On *nix, add ASM flags to disable executable stack -->
+                          <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                          <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                          <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized" />
+                        </then>
+                      </elseif>
                       <else>
                         <!-- On *nix, add ASM flags to disable executable stack -->
-                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
-                          <arg value="-DCMAKE_C_FLAGS_RELEASE=-std=c99 -O3 -fno-omit-frame-pointer" />
-                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized" />
-                          <arg value="-GNinja" />
-                          <arg value=".." />
-                        </exec>
+                        <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                        <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                        <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
                       </else>
                     </if>
+                    <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                      <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                      <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                      <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                      <arg value="-GNinja" />
+                      <arg value=".." />
+                    </exec>
                     <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
                   </target>
                 </configuration>


### PR DESCRIPTION
Motivation:

72b45657c99986bfbd14164cbbe31fc709d0fcd0 added some extra CXXFLAGS for the build which fixed the build on linux but broke it on macOS.

Modifications:

Use correct CXXFLAGS depending on OS.

Result:

Build works again on all platforms.