### PR TITLE
Use openssl 1.0.2m in static build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
     <libresslSha256>e57f5e3d5842a81fe9351b6e817fcaf0a749ca4ef35a91465edba9e071dce7c4</libresslSha256>
-    <opensslVersion>1.0.2l</opensslVersion>
-    <opensslSha256>ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c</opensslSha256>
+    <opensslVersion>1.0.2m</opensslVersion>
+    <opensslSha256>8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

We need to use openssl 1.0.2m in the static build as it was released.

Modifications:

Update openssl version.

Result:

Using latest openssl release.