### PR TITLE
Allow to also compile from older tags when new openssl version was re…

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -138,6 +138,13 @@
                         <include name="**/openssl-${opensslVersion}.tar.gz" />
                       </fileset>
                     </ftp>
+                    <if>
+                      <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz"/>
+                      <then>
+                        <echo>Move old version of openssl to correct directory</echo>
+                        <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz"/>
+                      </then>
+                    </if>
                     <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
                     <gunzip src="${project.build.directory}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/" />
                     <untar src="${project.build.directory}/openssl-${opensslVersion}.tar" dest="${project.build.directory}/" />
@@ -198,12 +205,22 @@
                 </goals>
                 <configuration>
                   <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
                     <!-- Download the openssl source. -->
                     <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
                       <fileset dir="${project.build.directory}">
                         <include name="**/openssl-${opensslVersion}.tar.gz" />
                       </fileset>
                     </ftp>
+                    <if>
+                      <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz"/>
+                      <then>
+                        <echo>Move old version of openssl to correct directory</echo>
+                        <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz"/>
+                      </then>
+                    </if>
                     <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
                     <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
                       <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
@@ -248,12 +265,22 @@
                 </goals>
                 <configuration>
                   <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
                     <!-- Download the openssl source. -->
                     <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
                       <fileset dir="${project.build.directory}">
                         <include name="**/openssl-${opensslVersion}.tar.gz" />
                       </fileset>
                     </ftp>
+                    <if>
+                      <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz"/>
+                      <then>
+                        <echo>Move old version of openssl to correct directory</echo>
+                        <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz"/>
+                      </then>
+                    </if>
                     <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
                     <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
                       <arg line="xfvz openssl-${opensslVersion}.tar.gz" />

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,9 @@
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
     <libresslSha256>e57f5e3d5842a81fe9351b6e817fcaf0a749ca4ef35a91465edba9e071dce7c4</libresslSha256>
-    <opensslVersion>1.0.2m</opensslVersion>
+    <opensslMinorVersion>1.0.2</opensslMinorVersion>
+    <opensslPatchVersion>m</opensslPatchVersion>
+    <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
     <opensslSha256>8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>


### PR DESCRIPTION
…leased.

Motivation:

When a new version of openssl is released they move the old release to a sub-directory which will fail the build from a tag which depends on an older version.

Modifications:

Add an extra ant steps to move the tar.gz file to the correct directory if it was an old release.

Result:

Build works even if it lists an older version of openssl. Fixes [#321].