### PR TITLE
Remove calls to SSL_set_state

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1546,18 +1546,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, renegotiate)(TCN_STDARGS,
     return SSL_renegotiate(ssl_);
 }
 
-TCN_IMPLEMENT_CALL(void, SSL, setState)(TCN_STDARGS,
-                                           jlong ssl, /* SSL * */
-                                           jint state) {
-    SSL *ssl_ = J2P(ssl, SSL *);
-
-    TCN_CHECK_NULL(ssl_, ssl, /* void */);
-
-    UNREFERENCED(o);
-
-    SSL_set_state(ssl_, state);
-}
-
 TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring hostname) {
     SSL *ssl_ = J2P(ssl, SSL *);
 
@@ -1959,7 +1947,6 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getHandshakeCount, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(clearError, ()V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(renegotiate, (J)I, SSL) },
-  { TCN_METHOD_TABLE_ENTRY(setState, (JI)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setTlsExtHostName, (JLjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setHostNameValidation, (JILjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(authenticationMethods, (J)[Ljava/lang/String;, SSL) },

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -534,14 +534,6 @@ public final class SSL {
     public static native int renegotiate(long ssl);
 
     /**
-     * Call SSL_set_state.
-     *
-     * @param ssl the SSL instance (SSL *)
-     * @param state the state to set
-     */
-    public static native void setState(long ssl, int state);
-
-    /**
      * Call SSL_set_tlsext_host_name
      *
      * @param ssl the SSL instance (SSL *)


### PR DESCRIPTION
See https://github.com/netty/netty/issues/6320 for the only user of this function, and the related discussion.

After this change, netty-tcnative will build on Debian sid/unstable, against openssl 1.1.

---

### Motivation:

`SSL_set_state` has gone from openssl 1.1. Calling it is, and probably always has been, incorrect. It has only ever been used to drive an incorrect renegotiation algorithm. Doing renegotiation in this manner is potentially insecure. There have been at least two insecure renegotiation vulnerabilities in users of the OpenSSL library.

Renegotiation is not necessary for correct operation of the TLS protocol.

### Modifications:

Remove the method, and its implementation.

### Result:

Fixes: #263
Requires: https://github.com/netty/netty/issues/6320