### PR TITLE
Removed unused calls to SSL_renegotiate

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1535,17 +1535,6 @@ TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
     ERR_clear_error();
 }
 
-TCN_IMPLEMENT_CALL(jint, SSL, renegotiate)(TCN_STDARGS,
-                                           jlong ssl /* SSL * */) {
-    SSL *ssl_ = J2P(ssl, SSL *);
-
-    TCN_CHECK_NULL(ssl_, ssl, 0);
-
-    UNREFERENCED(o);
-
-    return SSL_renegotiate(ssl_);
-}
-
 TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring hostname) {
     SSL *ssl_ = J2P(ssl, SSL *);
 
@@ -1946,7 +1935,6 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getSessionId, (J)[B, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getHandshakeCount, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(clearError, ()V, SSL) },
-  { TCN_METHOD_TABLE_ENTRY(renegotiate, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setTlsExtHostName, (JLjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setHostNameValidation, (JILjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(authenticationMethods, (J)[Ljava/lang/String;, SSL) },

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -526,14 +526,6 @@ public final class SSL {
     public static native void clearError();
 
     /**
-     * Call SSL_renegotiate.
-     *
-     * @param ssl the SSL instance (SSL *)
-     * @return the result of the operation
-     */
-    public static native int renegotiate(long ssl);
-
-    /**
      * Call SSL_set_tlsext_host_name
      *
      * @param ssl the SSL instance (SSL *)


### PR DESCRIPTION
Motivation:
Support for explicit renegotiation has been removed from Netty. Therefore SSL_renegotiate is no longer used.

Modifications:
- Remove SSL_renegotiate

Result:
Less unused methods.