### PR TITLE
Add docker files for different linux flavors

### DIFF
--- a/docker/Dockerfile-netty-tcnative-centos6
+++ b/docker/Dockerfile-netty-tcnative-centos6
@@ -1,0 +1,53 @@
+FROM centos:6
+MAINTAINER netty@googlegroups.com
+
+ENTRYPOINT /bin/bash
+
+ENV SOURCE_DIR /root/source
+ENV MAVEN_VERSION 3.5.0
+ENV JAVA_VERSION 1.8.0
+ENV CMAKE_VERSION 3.8.2
+ENV NINJA_VERSION 1.7.2
+ENV GO_VERSION 1.9.3
+
+# install dependencies
+RUN yum install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ bzip2 \
+ git \
+ glibc-devel \
+ gnupg \
+ java-$JAVA_VERSION-openjdk-devel \
+ libapr1-dev \
+ libtool \
+ lsb-core \
+ make \
+ openssl-devel \
+ perl \
+ tar \
+ unzip \
+ wget
+
+RUN mkdir $SOURCE_DIR
+WORKDIR $SOURCE_DIR
+
+RUN wget -q https://cmake.org/files/v3.8/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
+
+RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
+
+RUN wget -q http://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
+
+RUN wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && tar xfz apache-maven-$MAVEN_VERSION-bin.tar.gz && mv apache-maven-$MAVEN_VERSION /opt/ && echo 'PATH=/opt/apache-maven-$MAVEN_VERSION/bin:$PATH' >> ~/.bashrc
+
+RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION/"' >> ~/.bashrc
+
+RUN wget -q http://linuxsoft.cern.ch/cern/scl/RPM-GPG-KEY-cern && mv RPM-GPG-KEY-cern /etc/pki/rpm-gpg/
+
+RUN wget -q http://linuxsoft.cern.ch/cern/scl/slc6-scl.repo && mv slc6-scl.repo /etc/yum.repos.d
+
+RUN yum install -y devtoolset-3-gcc-c++
+RUN echo 'source /opt/rh/devtoolset-3/enable' >> ~/.bashrc
+
+RUN rm -rf $SOURCE_DIR

--- a/docker/Dockerfile-netty-tcnative-centos6
+++ b/docker/Dockerfile-netty-tcnative-centos6
@@ -6,7 +6,8 @@ ENTRYPOINT /bin/bash
 ENV SOURCE_DIR /root/source
 ENV MAVEN_VERSION 3.5.0
 ENV JAVA_VERSION 1.8.0
-ENV CMAKE_VERSION 3.8.2
+ENV CMAKE_VERSION_BASE 3.8
+ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 
@@ -33,7 +34,7 @@ RUN yum install -y \
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
 
-RUN wget -q https://cmake.org/files/v3.8/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
+RUN wget -q https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
 

--- a/docker/Dockerfile-netty-tcnative-debian7
+++ b/docker/Dockerfile-netty-tcnative-debian7
@@ -1,0 +1,53 @@
+FROM debian:7
+MAINTAINER netty@googlegroups.com
+ENTRYPOINT /bin/bash
+
+ENV SOURCE_DIR $HOME/source
+ENV MAVEN_VERSION 3.5.0
+ENV JAVA_VERSION 7
+ENV CMAKE_VERSION 3.8.2
+ENV NINJA_VERSION 1.7.2
+ENV GO_VERSION 1.9.3
+ENV GCC_VERSION 4.9.4
+
+RUN apt-get -y update && apt-get -y install \
+ autoconf \
+ automake \
+ bzip2 \
+ cmake \
+ gcc \
+ gcc-multilib \
+ git \
+ gnupg \
+ g++ \
+ libapr1-dev \
+ libssl-dev \
+ libtool \
+ make \
+ openjdk-$JAVA_VERSION-jdk \
+ perl \
+ tar \
+ unzip \
+ wget \
+ xutils-dev \
+ zip
+
+RUN mkdir $SOURCE_DIR
+WORKDIR $SOURCE_DIR
+
+RUN wget -q https://cmake.org/files/v3.8/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
+
+RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
+
+RUN wget -q http://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
+
+RUN wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && tar zxf apache-maven-$MAVEN_VERSION-bin.tar.gz && mv apache-maven-$MAVEN_VERSION /opt/ && echo 'PATH=/opt/apache-maven-$MAVEN_VERSION/bin:$PATH' >> ~/.bashrc
+
+RUN wget -q ftp://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz && tar zxf gcc-$GCC_VERSION.tar.gz
+WORKDIR gcc-$GCC_VERSION
+
+RUN ./contrib/download_prerequisites && ./configure --prefix=/opt/gcc-$GCC_VERSION/ --enable-languages=c,c++ && make && make install && echo 'PATH=/opt/gcc-$GCC_VERSION/bin:$PATH' >> ~/.bashrc && echo 'export CC=/opt/gcc-$GCC_VERSION/bin/gcc' >> ~/.bashrc && echo 'export CXX=/opt/gcc-$GCC_VERSION/bin/g++' >> ~/.bashrc
+
+RUN echo 'JAVA_HOME="/usr/lib/jvm/open-jdk"' >> ~/.bashrc
+
+RUN rm -rf $SOURCE_DIR

--- a/docker/Dockerfile-netty-tcnative-debian7
+++ b/docker/Dockerfile-netty-tcnative-debian7
@@ -5,7 +5,8 @@ ENTRYPOINT /bin/bash
 ENV SOURCE_DIR $HOME/source
 ENV MAVEN_VERSION 3.5.0
 ENV JAVA_VERSION 7
-ENV CMAKE_VERSION 3.8.2
+ENV CMAKE_VERSION_BASE 3.8
+ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 ENV GCC_VERSION 4.9.4
@@ -35,7 +36,7 @@ RUN apt-get -y update && apt-get -y install \
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
 
-RUN wget -q https://cmake.org/files/v3.8/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
+RUN wget -q https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+
+** Create a docker image **
+```
+docker build -f Dockerfile-netty-tcnative-centos6 . -t netty-tcnative-centos6
+```
+
+** Using the image **
+
+```
+cd /path/to/netty-tcnative/
+```
+
+```
+docker run -it -v ~/.m2:/root/.m2 -v ~/.ssh:/root/.ssh -v ~/.gnupg:/root/.gnupg -v `pwd`:/code -w /code netty-tcnative-centos6 bash
+```


### PR DESCRIPTION
Motivation:

We build and release for different linux flavors. To make this easier provide docker files that can be used and also be used by others for a ready-to-use build env.

Modifications:

Add docker files for centos6 and debian7

Result:

Easier to release and build netty-tcnative.