### PR TITLE
Update to libressl 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.6.3</aprVersion>
     <aprMd5>57c6cc26a31fe420c546ad2234f22db4</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.5.5</libresslVersion>
+    <libresslVersion>2.6.4</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>e57f5e3d5842a81fe9351b6e817fcaf0a749ca4ef35a91465edba9e071dce7c4</libresslSha256>
+    <libresslSha256>638a20c2f9e99ee283a841cd787ab4d846d1880e180c4e96904fc327d419d11f</libresslSha256>
     <opensslMinorVersion>1.0.2</opensslMinorVersion>
     <opensslPatchVersion>m</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>


### PR DESCRIPTION
Motivation:

Use latest stable libressl version

Modifications:

Bump up version to 2.6.4

Result:
Building against latest libressl version