### PR TITLE
Pass a string length to X509_VERIFY_PARAM_set1_host.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1558,20 +1558,33 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-    const char* hostname = hostnameString == NULL ? NULL : (*e)->GetStringUTFChars(e, hostnameString, 0);
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
     X509_VERIFY_PARAM* param = SSL_get0_param(ssl_);
     X509_VERIFY_PARAM_set_hostflags(param, flags);
-    if (X509_VERIFY_PARAM_set1_host(param, hostname, 0) != 1) {
+#endif
+
+    if (hostnameString == NULL) {
+        return;
+    }
+
+    jsize hostnameLen = (*e)->GetStringUTFLength(e, hostnameString);
+    if (hostnameLen == 0) {
+        tcn_Throw(e, "hostname verification needs non-empty string");
+        return;
+    }
+
+    const char *hostname = (*e)->GetStringUTFChars(e, hostnameString, 0);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+    if (X509_VERIFY_PARAM_set1_host(param, hostname, hostnameLen) != 1) {
         char err[ERR_LEN];
         ERR_error_string(ERR_get_error(), err);
         tcn_Throw(e, "X509_VERIFY_PARAM_set1_host error (%s)", err);
     }
 #else
-    if (hostname != NULL && hostname[0] != '\0') {
-        tcn_ThrowException(e, "hostname verification requires OpenSSL 1.0.2+");
-    }
+    tcn_ThrowException(e, "hostname verification requires OpenSSL 1.0.2+");
 #endif
+
     (*e)->ReleaseStringUTFChars(e, hostnameString, hostname);
 }
 


### PR DESCRIPTION
BoringSSL is going to make using the “zero length means call strlen” an
error for various reasons so this change will allow the code to continue
working with BoringSSL. Additionally, by passing a length, OpenSSL can
catch cases where there's an embedded NUL in the string. Lastly, it's
not clear that JNI guarantees that the result of GetStringUTFChars is
NUL terminated[1].

This change also makes an empty hostname an error. OpenSSL considers
setting an empty hostname to disable all checks, but that seems like a
surprising behaviour when this function already supports `null` to skip
hostname checking.

[1] https://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html#wp17265