### PR TITLE
Compile libressl-static against libressl 2.7.3

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -135,7 +135,13 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define TLS_method SSLv23_method
 #define TLS_client_method SSLv23_client_method
 #define TLS_server_method SSLv23_server_method
+
+// This is only needed if we are not using LibreSSL 2.7.x or higher as otherwise it
+// is defined already.
+#if !defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER < 0x20700000L
 #define OPENSSL_VERSION SSLEAY_VERSION
+#endif
+
 #define OpenSSL_version SSLeay_version
 #define OPENSSL_malloc_init CRYPTO_malloc_init
 #define X509_REVOKED_get0_serialNumber(x) x->serialNumber

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.6.3</aprVersion>
     <aprMd5>57c6cc26a31fe420c546ad2234f22db4</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.6.4</libresslVersion>
+    <libresslVersion>2.7.3</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>638a20c2f9e99ee283a841cd787ab4d846d1880e180c4e96904fc327d419d11f</libresslSha256>
+    <libresslSha256>16c70d8fe1de6e9bedea0d67804b55f3894717693a05ed45e15e0e2f939c2795</libresslSha256>
     <opensslMinorVersion>1.0.2</opensslMinorVersion>
     <opensslPatchVersion>n</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>


### PR DESCRIPTION
Motivation:

Change the version of libressl to 2.7.3 for netty-tcnative-libressl-static and so ensure we can also compile with newer versions of libressl.

Modifications:

Slightly change the ifdef to only define OPENSSL_VERSION if not using libressl 2.7.x

Result:

Use latest libressl