### PR TITLE
Providing docker-compose files for centos6 / debian7

### DIFF
--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -1,11 +1,9 @@
-FROM centos:6
-MAINTAINER netty@googlegroups.com
-
-ENTRYPOINT /bin/bash
+ARG centos_version=6
+FROM centos:$centos_version
+# needed to do again after FROM due to docker limitation
+ARG centos_version
 
 ENV SOURCE_DIR /root/source
-ENV MAVEN_VERSION 3.5.0
-ENV JAVA_VERSION 1.8.0
 ENV CMAKE_VERSION_BASE 3.8
 ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
@@ -20,7 +18,6 @@ RUN yum install -y \
  git \
  glibc-devel \
  gnupg \
- java-$JAVA_VERSION-openjdk-devel \
  libapr1-dev \
  libtool \
  lsb-core \
@@ -40,15 +37,18 @@ RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSI
 
 RUN wget -q http://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
 
-RUN wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && tar xfz apache-maven-$MAVEN_VERSION-bin.tar.gz && mv apache-maven-$MAVEN_VERSION /opt/ && echo 'PATH=/opt/apache-maven-$MAVEN_VERSION/bin:$PATH' >> ~/.bashrc
-
-RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-$JAVA_VERSION/"' >> ~/.bashrc
-
 RUN wget -q http://linuxsoft.cern.ch/cern/scl/RPM-GPG-KEY-cern && mv RPM-GPG-KEY-cern /etc/pki/rpm-gpg/
-
 RUN wget -q http://linuxsoft.cern.ch/cern/scl/slc6-scl.repo && mv slc6-scl.repo /etc/yum.repos.d
-
 RUN yum install -y devtoolset-3-gcc-c++
 RUN echo 'source /opt/rh/devtoolset-3/enable' >> ~/.bashrc
 
 RUN rm -rf $SOURCE_DIR
+
+ARG java_version=1.8
+ENV JAVA_VERSION $java_version
+# installing java with jabba
+RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install $JAVA_VERSION -o /jdk" bash
+
+
+RUN echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc
+RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,16 +1,16 @@
-FROM debian:7
-MAINTAINER netty@googlegroups.com
-ENTRYPOINT /bin/bash
+ARG debian_version=7
+FROM debian:$debian_version
+# needed to do again after FROM due to docker limitation
+ARG debian_version
 
-ENV SOURCE_DIR $HOME/source
-ENV MAVEN_VERSION 3.5.0
-ENV JAVA_VERSION 7
+ENV SOURCE_DIR /root/source
 ENV CMAKE_VERSION_BASE 3.8
 ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 ENV GCC_VERSION 4.9.4
 
+# install dependencies
 RUN apt-get -y update && apt-get -y install \
  autoconf \
  automake \
@@ -25,7 +25,6 @@ RUN apt-get -y update && apt-get -y install \
  libssl-dev \
  libtool \
  make \
- openjdk-$JAVA_VERSION-jdk \
  perl \
  tar \
  unzip \
@@ -42,13 +41,17 @@ RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSI
 
 RUN wget -q http://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
 
-RUN wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && tar zxf apache-maven-$MAVEN_VERSION-bin.tar.gz && mv apache-maven-$MAVEN_VERSION /opt/ && echo 'PATH=/opt/apache-maven-$MAVEN_VERSION/bin:$PATH' >> ~/.bashrc
-
 RUN wget -q ftp://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz && tar zxf gcc-$GCC_VERSION.tar.gz
 WORKDIR gcc-$GCC_VERSION
 
 RUN ./contrib/download_prerequisites && ./configure --prefix=/opt/gcc-$GCC_VERSION/ --enable-languages=c,c++ && make && make install && echo 'PATH=/opt/gcc-$GCC_VERSION/bin:$PATH' >> ~/.bashrc && echo 'export CC=/opt/gcc-$GCC_VERSION/bin/gcc' >> ~/.bashrc && echo 'export CXX=/opt/gcc-$GCC_VERSION/bin/g++' >> ~/.bashrc
 
-RUN echo 'JAVA_HOME="/usr/lib/jvm/open-jdk"' >> ~/.bashrc
-
 RUN rm -rf $SOURCE_DIR
+
+ARG java_version=1.8
+ENV JAVA_VERSION $java_version
+# installing java with jabba
+RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMAND="install $JAVA_VERSION -o /jdk" bash
+
+RUN echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc
+RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,25 @@
+# Using the docker images
 
-** Create a docker image **
 ```
-docker build -f Dockerfile-netty-tcnative-centos6 . -t netty-tcnative-centos6
+cd /path/to/netty-tcnative/
 ```
-
-** Using the image **
+# Using the docker images
 
 ```
 cd /path/to/netty-tcnative/
 ```
 
+## centos 6 with java 8
+
 ```
-docker run -it -v ~/.m2:/root/.m2 -v ~/.ssh:/root/.ssh -v ~/.gnupg:/root/.gnupg -v `pwd`:/code -w /code netty-tcnative-centos6 bash
+docker-compose -f docker/docker-compose.centos.yaml -f docker/docker-compose.centos-6.18.yaml run build
 ```
+
+## debian 7 with java 8
+
+```
+docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build
+```
+
+etc, etc
+

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-centos:centos-6-1.8
+    build:
+      args:
+        centos_version : "6"
+        java_version : "1.8"
+
+  build:
+    image: netty-tcnative:centos-6-1.8
+
+  shell:
+    image: netty-tcnative:centos-6-1.8

--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-centos:default
+    build:
+      context: .
+      dockerfile: Dockerfile.centos
+
+  common: &common
+    image: netty-tcnative-centos:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ..:/code
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean package"
+
+  shell:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ~/.gitconfig:/root/.gitconfig
+      - ~/.gitignore:/root/.gitignore
+      - ..:/code
+    entrypoint: /bin/bash

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-debian:debian-7-1.8
+    build:
+      args:
+        debian_version : "7"
+        java_version : "1.8"
+
+  build:
+    image: netty-tcnative:debian-7-1.8
+
+  shell:
+    image: netty-tcnative:debian-7-1.8

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-debian:default
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+
+  common: &common
+    image: netty-tcnative-debian:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
+      - ..:/code
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean package"
+
+  shell:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ~/.gitconfig:/root/.gitconfig
+      - ~/.gitignore:/root/.gitignore
+      - ..:/code
+    entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

We should just use docker-compose to allow easy building via docker for the linux distributions we support. This will allow us to enhance to use different java versions easily and we will be able to re-use these for the CI.

Modifications:

Replace old dockerfiles with new ones that are used via docker-compose.

Result:

Easily be able to build netty-tcnative for supported distributions.