### PR TITLE
Don't try to use strndup on Solaris as it not exists.

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -186,9 +186,13 @@ jint netty_internal_tcnative_util_register_natives(JNIEnv* env, const char* pack
 #ifndef TCN_BUILD_STATIC
 
 static char* netty_internal_tcnative_util_strndup(const char *s, size_t n) {
-// windows does not have strndup
+// windows / solaris does not have strndup
+#if defined(_WIN32) || defined(__sun)
 #ifdef _WIN32
     char* copy = _strdup(s);
+#else
+    char* copy = strdup(s);
+#endif
     if (copy != NULL && n < strlen(copy)) {
         // mark the end
         copy[n] = '\0';


### PR DESCRIPTION
Motivation:

Some users may want to use netty-tcnative on Solaris. This is currently not possible as we try to use strndup on Solaris which doesn't exists.

Modifications:

Don't try to use strndup on solaris but just use our own impl (as we do for windoes as well).

Result:

Fixes https://github.com/netty/netty-tcnative/issues/349.