### PR TITLE
Remove unused function tcn_X509_up_ref

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -277,7 +277,6 @@ X509        *load_pem_cert_bio(const char *, const BIO *);
 EVP_PKEY    *load_pem_key_bio(const char *, const BIO *);
 int         tcn_set_verify_config(tcn_ssl_verify_config_t* c, jint tcn_mode, jint depth);
 int         tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey);
-int         tcn_X509_up_ref(X509* cert);
 int         SSL_callback_next_protos(SSL *, const unsigned char **, unsigned int *, void *);
 int         SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 int         SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -583,18 +583,6 @@ int tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey) {
 #endif
 }
 
-int tcn_X509_up_ref(X509* cert) {
-#if defined(OPENSSL_IS_BORINGSSL)
-    // Workaround for https://bugs.chromium.org/p/boringssl/issues/detail?id=89#
-    X509_up_ref(cert);
-    return 1;
-#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-    return CRYPTO_add(&cert->references, 1, CRYPTO_LOCK_X509);
-#else
-    return X509_up_ref(cert);
-#endif
-}
-
 int tcn_set_verify_config(tcn_ssl_verify_config_t* c, jint tcn_mode, jint depth) {
     if (depth >= 0) {
         c->verify_depth = depth;


### PR DESCRIPTION
Motivation:

This function isn't used, it is a leftover from the fix for #353.

Modifications:

Remove the unused function.

Result:

No more dead code.