### PR TITLE
Add explict cast to  (void*) as needed when compiling against OpenSSL…

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1758,7 +1758,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, enableOcsp)(TCN_STDARGS, jlong ctx, jboolea
     // return value.
     //
     const int *arg = (client ? &OCSP_CLIENT_ACK : &OCSP_SERVER_ACK);
-    if (SSL_CTX_set_tlsext_status_arg(c->ctx, arg) <= 0L) {
+    if (SSL_CTX_set_tlsext_status_arg(c->ctx, (void*) arg) <= 0L) {
         tcn_ThrowException(e, "SSL_CTX_set_tlsext_status_arg() failed");
         return;
     }


### PR DESCRIPTION
… 1.1.1

Motivation:

OpenSSL 1.1.1 expect to receive an argument of type  void*, so the build currently fails as we treat warnings as errors during compilation.

Modifications:

Add cast to  (void*).

Result:

Build also passes when compiling against OpenSSL 1.1.1