### PR TITLE
Update to libressl 2.7.4 for libressl-static

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <aprVersion>1.6.3</aprVersion>
     <aprMd5>57c6cc26a31fe420c546ad2234f22db4</aprMd5>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.7.3</libresslVersion>
+    <libresslVersion>2.7.4</libresslVersion>
     <!--
         NB: libressl does not currently publish sha256 signatures and instead relies on signify
         to verify releases. The project does not have a securely published GPG key.
@@ -64,7 +64,7 @@
         - Verify the release: signify -V -x SHA256.sig  -p libressl.pub -m libressl-{libresslVersion}.tar.gz -e
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
-    <libresslSha256>16c70d8fe1de6e9bedea0d67804b55f3894717693a05ed45e15e0e2f939c2795</libresslSha256>
+    <libresslSha256>1e3a9fada06c1c060011470ad0ff960de28f9a0515277d7336f7e09362517da6</libresslSha256>
     <opensslMinorVersion>1.1.0</opensslMinorVersion>
     <opensslPatchVersion>h</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>


### PR DESCRIPTION
Motivation:

We should use the latest libressl version for our libressl-static build.

Modifications:

Update from 2.7.3 to 2.7.4

Result:

Use latest libressl