### PR TITLE
Allow to set key material without reparsing certificate chain / priva…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -58,9 +58,6 @@ static jclass    jString_class;
 static jmethodID jString_init;
 static jmethodID jString_getBytes;
 static jclass    byteArrayClass;
-static jclass    keyMaterialClass;
-static jfieldID  keyMaterialCertificateChainFieldId;
-static jfieldID  keyMaterialPrivateKeyFieldId;
 
 jstring tcn_new_stringn(JNIEnv *env, const char *str, size_t l)
 {
@@ -137,16 +134,6 @@ jclass tcn_get_string_class()
 jclass tcn_get_byte_array_class()
 {
     return byteArrayClass;
-}
-
-jfieldID tcn_get_key_material_certificate_chain_field()
-{
-    return keyMaterialCertificateChainFieldId;
-}
-
-jfieldID tcn_get_key_material_private_key_field()
-{
-    return keyMaterialPrivateKeyFieldId;
 }
 
 jint tcn_get_java_env(JNIEnv **env)
@@ -351,20 +338,6 @@ jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* package
 
     TCN_LOAD_CLASS(env, byteArrayClass, "[B", JNI_ERR);
 
-    char* keyMaterialClassName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateRequestedCallback$KeyMaterial");
-    jclass keyMaterialClassLocal = (*env)->FindClass(env, keyMaterialClassName);
-    free(keyMaterialClassName);
-    keyMaterialClassName = NULL;
-    if (keyMaterialClassLocal == NULL) {
-        return JNI_ERR;
-    }
-    keyMaterialClass = (*env)->NewGlobalRef(env, keyMaterialClassLocal);
-
-    TCN_GET_FIELD(env, keyMaterialClass, keyMaterialCertificateChainFieldId,
-                   "certificateChain", "J", JNI_ERR);
-    TCN_GET_FIELD(env, keyMaterialClass, keyMaterialPrivateKeyFieldId,
-                   "privateKey", "J", JNI_ERR);
-
     return TCN_JNI_VERSION;
 }
 
@@ -375,7 +348,6 @@ void netty_internal_tcnative_Library_JNI_OnUnLoad(JNIEnv* env) {
     }
 
     TCN_UNLOAD_CLASS(env, byteArrayClass);
-    TCN_UNLOAD_CLASS(env, keyMaterialClass);
 
     netty_internal_tcnative_Error_JNI_OnUnLoad(env);
     netty_internal_tcnative_Buffer_JNI_OnUnLoad(env);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -277,6 +277,7 @@ X509        *load_pem_cert_bio(const char *, const BIO *);
 EVP_PKEY    *load_pem_key_bio(const char *, const BIO *);
 int         tcn_set_verify_config(tcn_ssl_verify_config_t* c, jint tcn_mode, jint depth);
 int         tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey);
+int         tcn_X509_up_ref(X509* cert);
 int         SSL_callback_next_protos(SSL *, const unsigned char **, unsigned int *, void *);
 int         SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 int         SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -583,6 +583,18 @@ int tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey) {
 #endif
 }
 
+int tcn_X509_up_ref(X509* cert) {
+#if defined(OPENSSL_IS_BORINGSSL)
+    // Workaround for https://bugs.chromium.org/p/boringssl/issues/detail?id=89#
+    X509_up_ref(cert);
+    return 1;
+#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+    return CRYPTO_add(&cert->references, 1, CRYPTO_LOCK_X509);
+#else
+    return X509_up_ref(cert);
+#endif
+}
+
 int tcn_set_verify_config(tcn_ssl_verify_config_t* c, jint tcn_mode, jint depth) {
     if (depth >= 0) {
         c->verify_depth = depth;

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -169,8 +169,6 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
 jclass tcn_get_string_class(void);
 
 jclass tcn_get_byte_array_class();
-jfieldID tcn_get_key_material_certificate_chain_field();
-jfieldID tcn_get_key_material_private_key_field();
 
 /* Get current thread JNIEnv
  */

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
@@ -38,47 +38,17 @@ public interface CertificateRequestedCallback {
     byte TLS_CT_ECDSA_FIXED_ECDH = 66;
 
     /**
-     * Called during cert selection.
+     * Called during cert selection. If a certificate chain / key should be used
+     * {@link SSL#setKeyMaterialClientSide(long, long, long, long, long)} must be called from this callback after
+     * all preparations / validations were completed.
      *
      * @param ssl                       the SSL instance
+     * @param certOut                   the pointer to the pointer of the certificate to use.
+     * @param keyOut                    the pointer to the pointer of the private key to use.
      * @param keyTypeBytes              an array of the key types.
      * @param asn1DerEncodedPrincipals  the principals
-     * @return material to use or {@code null} if non should be used. The ownership of all native memory goes over to
-     *                  tcnative at this point.
      *
      */
-    KeyMaterial requested(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals);
-
-    /**
-     * Holds the material to use. Tcnative is responsible releasing native memory used by the wrapped native objects.
-     */
-    // Non-final so we can extend from this later ond cache these easily in Netty.
-    class KeyMaterial {
-
-        private final long certificateChain;
-        private final long privateKey;
-
-        public KeyMaterial(long certificateChain, long privateKey) {
-            this.certificateChain = certificateChain;
-            this.privateKey = privateKey;
-        }
-
-        /**
-         * Returns a {@code EVP_PKEY} pointer
-         *
-         * @return the {@code EVP_PKEY} pointer
-         */
-        public final long privateKey() {
-            return privateKey;
-        }
-
-        /**
-         * Returns a x509 chain ({@code STACK_OF(X509)} pointer)
-         *
-         * @return thex509 chain ({@code STACK_OF(X509)} pointer)
-         */
-        public final long certificateChain() {
-            return certificateChain;
-        }
-    }
+    void requested(long ssl, long certOut, long keyOut, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals)
+            throws Exception;
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -657,6 +657,22 @@ public final class SSL {
     public static native void enableOcsp(long ssl);
 
     /**
+     * Sets the keymaterial to be used for the server side. The passed in chain and key needs to be generated via
+     * {@link #parseX509Chain(long)} and {@link #parsePrivateKey(long, String)}. It's important to note that the caller
+     * of the method is responsible to free the passed in chain and key in any case as this method will increment the
+     * reference count of the chain and key.
+     */
+    public static native void setKeyMaterialServerSide(long ssl, long chain, long key) throws Exception;
+
+    /**
+     * Sets the keymaterial to be used for the client side. The passed in chain and key needs to be generated via
+     * {@link #parseX509Chain(long)} and {@link #parsePrivateKey(long, String)}. It's important to note that the caller
+     * of the method is responsible to free the passed in chain and key in any case as this method will increment the
+     * reference count of the chain and key.
+     */
+    public static native void setKeyMaterialClientSide(long ssl, long x509Out, long pkeyOut, long chain, long key) throws Exception;
+
+    /**
      * Sets the OCSP response for the given {@link SSLEngine} or throws an
      * exception in case of an error.
      *


### PR DESCRIPTION
…te key.

Motiviation:

During profiling one of the bottlenecks that could be observed was that we always needed to re-parse the certificate chain / private key on each handshake. This is kind of wasteful and it may be prefered to just use the same instance all the time.

Modification:

- Add two new methods that allow to directly set the keymaterial without re-parsing it all the time.
- Change the CertificateRequestCallback to not return the KeyMaterial but to have the user directly call a method to set the keymaterial. This allows for better life-time management of the keymaterial, as it may be re-used by the user for performance reasons.

Result:

More flexible and performant way of handling keymaterial (cert chain + private key).