### PR TITLE
We should only strip debug symbols

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -195,6 +195,7 @@
                       </and>
                       <then>
                         <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
+                          <arg value="--strip-debug" />
                           <arg value="libnetty_tcnative.so" />
                         </exec>
                       </then>


### PR DESCRIPTION
Motivation:

At the moment we completely strip the netty-tcnative-boringssl-static lib which makes it impossible to profile / debug the native code. We should limit the stripping to debug symbols to still be able to see at least the functions that are colled.

Modifications:

Use strip --strip-debug on linux.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/359. The lib is only ca 100k bigger then before.