### PR TITLE
We should use weak linking if possible to detect if setHostNameValida…

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1558,34 +1558,39 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
-    X509_VERIFY_PARAM* param = SSL_get0_param(ssl_);
-    X509_VERIFY_PARAM_set_hostflags(param, flags);
+// Use weak linking with GCC as this will allow us to run the same packaged version with multiple
+// version of openssl.
+#if defined(__GNUC__) || defined(__GNUG__)
+    if (!SSL_get0_param || !X509_VERIFY_PARAM_set_hostflags || !X509_VERIFY_PARAM_set1_host) {
+        tcn_ThrowException(e, "hostname verification requires OpenSSL 1.0.2+");
+        return;
+    }
 #endif
 
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)) || defined(OPENSSL_IS_BORINGSSL) || defined(__GNUC__) || defined(__GNUG__)
     if (hostnameString == NULL) {
         return;
     }
+    X509_VERIFY_PARAM* param = SSL_get0_param(ssl_);
+    X509_VERIFY_PARAM_set_hostflags(param, flags);
 
     jsize hostnameLen = (*e)->GetStringUTFLength(e, hostnameString);
     if (hostnameLen == 0) {
-        tcn_Throw(e, "hostname verification needs non-empty string");
         return;
     }
 
     const char *hostname = (*e)->GetStringUTFChars(e, hostnameString, 0);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
     if (X509_VERIFY_PARAM_set1_host(param, hostname, hostnameLen) != 1) {
         char err[ERR_LEN];
         ERR_error_string(ERR_get_error(), err);
         tcn_Throw(e, "X509_VERIFY_PARAM_set1_host error (%s)", err);
     }
+    (*e)->ReleaseStringUTFChars(e, hostnameString, hostname);
 #else
     tcn_ThrowException(e, "hostname verification requires OpenSSL 1.0.2+");
 #endif
-
-    (*e)->ReleaseStringUTFChars(e, hostnameString, hostname);
 }
 
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong ssl) {

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -292,6 +292,10 @@ const char *tcn_SSL_cipher_authentication_method(const SSL_CIPHER *);
            void *arg), void *arg) __attribute__((weak));
     extern void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
            unsigned *len) __attribute__((weak));
+
+    extern X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl) __attribute__((weak));
+    extern void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param, unsigned int flags) __attribute__((weak));
+    extern int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param, const char *name, size_t namelen) __attribute__((weak));
 #endif
 
 #endif /* SSL_PRIVATE_H */


### PR DESCRIPTION
…tion is usable

Motivation:

We did use classic ifdef blocks to detect on compile time if all functions are provided by the used openssl version that are needed for hostname validation. This is problematic as we compile on very old debian / centos versions to make the lib compatible with a wide range of dists.

Modifications:

Use weak linking for all functions needed for setHostNameValidation when GCC is used.

Result:

Be able to use setHostNameValidation on linux when the runtime version of OpenSSL provided these functions no matter which version was used during compilation.