### PR TITLE
Allow to set FIPS mode if compiled with FIPS support.

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -697,4 +697,12 @@ public final class SSL {
      * @param ssl the SSL instance (SSL *)
      */
     public static native byte[] getOcspResponse(long ssl);
+
+    /**
+     * Set the FIPS mode to use. See <a href="https://wiki.openssl.org/index.php/FIPS_mode_set()"> man FIPS_mode_set</a>.
+     *
+     * @param mode the mode to use.
+     * @throws Exception throws if setting the fips mode failed.
+     */
+    public static native void fipsModeSet(int mode) throws Exception;
 }


### PR DESCRIPTION
Motivation:

We had some users that are interested to build their own netty-tcnative artifacts and use FIPS. We should allow to enable it.

Modifications:

Allow to change the fips mode if its compiled with support for it.

Result:

Possible to use netty-tcnative with FIPS.