### PR TITLE
We should disable hostname validation if an empty host or null is bas…

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -539,7 +539,7 @@ public final class SSL {
      * Values are defined as a bitmask of {@code X509_CHECK_FLAG*} values.
      * @param ssl the SSL instance (SSL*).
      * @param flags a bitmask of {@code X509_CHECK_FLAG*} values.
-     * @param hostname the hostname which is expected for validation.
+     * @param hostname the hostname which is expected for validation or {@code null} if validation should be disabled.
      */
     public static native void setHostNameValidation(long ssl, int flags, String hostname);
 


### PR DESCRIPTION
…ed into SSL.setHostNameValidation(...)

Motivation:

At the moment its not possible to disalbe hostname validation again when it was enabled before. We should allow this as we need to support this in netty.

Modifications:

Correctly handle the case of hostname been null or empty.

Result:

Be able to disable hostname validation again.