### PR TITLE
Cleanup some ifdefs to add support for some features when LibreSSL is…

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1568,7 +1568,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
 #endif
 
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)) || defined(OPENSSL_IS_BORINGSSL) || defined(__GNUC__) || defined(__GNUG__)
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)) || LIBRESSL_VERSION_NUMBER >= 0x2060000fL || defined(OPENSSL_IS_BORINGSSL) || defined(__GNUC__) || defined(__GNUG__)
     if (hostnameString == NULL) {
         return;
     }

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1306,7 +1306,7 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     TCN_ASSERT(verify_config != NULL);
 
     // Get a stack of all certs in the chain
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
     STACK_OF(X509) *sk = ctx->untrusted;
 #else
     STACK_OF(X509) *sk = X509_STORE_CTX_get0_untrusted(ctx);

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -579,11 +579,7 @@ EVP_PKEY *tcn_load_pem_key_bio(const char *password, const BIO *bio)
 }
 
 int tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey) {
-#if defined(OPENSSL_IS_BORINGSSL)
-    // Workaround for https://bugs.chromium.org/p/boringssl/issues/detail?id=89#
-    EVP_PKEY_up_ref(pkey);
-    return 1;
-#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL))
     return CRYPTO_add(&pkey->references, 1, CRYPTO_LOCK_EVP_PKEY);
 #else
     return EVP_PKEY_up_ref(pkey);
@@ -591,11 +587,7 @@ int tcn_EVP_PKEY_up_ref(EVP_PKEY* pkey) {
 }
 
 int tcn_X509_up_ref(X509* cert) {
-#if defined(OPENSSL_IS_BORINGSSL)
-    // Workaround for https://bugs.chromium.org/p/boringssl/issues/detail?id=89#
-    X509_up_ref(cert);
-    return 1;
-#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2060000fL))
     return CRYPTO_add(&cert->references, 1, CRYPTO_LOCK_X509);
 #else
     return X509_up_ref(cert);


### PR DESCRIPTION
… used.

Motivation:

In newer versions of LibreSSL some functions are now included which allows us to support for example hostname verification. Also removed some special handling for BoringSSL which is not needed anymore.

Modifications:

- Cleanup ifdefs for LibreSSL and some for BoringSSL.

Result:

Support more features when using recent version of LibreSSL and cleaner code.