### PR TITLE
Use JNI_FALSE when calling GetStringUTFChars(...) and not 0

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1580,7 +1580,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
         return;
     }
 
-    const char *hostname = (*e)->GetStringUTFChars(e, hostnameString, 0);
+    const char *hostname = (*e)->GetStringUTFChars(e, hostnameString, JNI_FALSE);
 
     if (X509_VERIFY_PARAM_set1_host(param, hostname, hostnameLen) != 1) {
         char err[ERR_LEN];

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -841,7 +841,7 @@ static int initProtocols(JNIEnv *e, unsigned char **proto_data,
 
     for (i = 0; i < cnt; ++i) {
          proto_string = (jstring) (*e)->GetObjectArrayElement(e, protos, i);
-         proto_chars = (*e)->GetStringUTFChars(e, proto_string, 0);
+         proto_chars = (*e)->GetStringUTFChars(e, proto_string, JNI_FALSE);
 
          proto_chars_len = strlen(proto_chars);
          if (proto_chars_len > 0 && proto_chars_len <= MAX_ALPN_NPN_PROTO_SIZE) {

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -97,7 +97,7 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
 #define TCN_END_MACRO       } else (void)(0)
 
 #define TCN_ALLOC_CSTRING(V)     \
-    const char *c##V = V ? (const char *)((*e)->GetStringUTFChars(e, V, 0)) : NULL
+    const char *c##V = V ? (const char *)((*e)->GetStringUTFChars(e, V, JNI_FALSE)) : NULL
 
 #define TCN_FREE_CSTRING(V)      \
     if (c##V) (*e)->ReleaseStringUTFChars(e, V, c##V)


### PR DESCRIPTION
Motivation:

GetStringUTFChars(...) list JNI_FALSE as its argument in the docs, we should use it and not depend on the fact that 0 == JNI_FALSE.

Modifications:

Replace 0 by JNI_FALSE when using GetStringUTFChars.

Result:

Cleaner code.