### PR TITLE
Fix Openssl build on windows

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -171,9 +171,8 @@
                         <exec executable="perl" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
                           <arg line="Configure VC-WIN64A --prefix=${sslHome}" />
                         </exec>
-                        <exec executable="${opensslBuildDir}/ms/do_win64a.bat" failonerror="true" dir="${opensslBuildDir}" />
                         <exec executable="nmake" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg line="-f ms\nt.mak all install" />
+                          <arg line="install" />
                         </exec>
                       </else>
                     </if>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <sslHome>${project.build.directory}/ssl</sslHome>
     <msvcSslIncludeDirs>${sslHome}/include</msvcSslIncludeDirs>
     <msvcSslLibDirs>${sslHome}/lib</msvcSslLibDirs>
-    <msvcSslLibs>ssleay32.lib;libeay32.lib</msvcSslLibs>
+    <msvcSslLibs>libssl.lib;libcrypto.lib</msvcSslLibs>
     <strip.skip>false</strip.skip>
   </properties>
 


### PR DESCRIPTION
Openssl 1.1 build changed on windows: 
1. Remove call to ms/do_win64a.bat
2. Change names of resulting ssl lib files.