### PR TITLE
Allow to load a private key from the OpenSSL engine.

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -599,6 +599,23 @@ public final class SSL {
             long ssl, long certBio, long keyBio, String password) throws Exception;
 
     /**
+     * Load a private key from the used OpenSSL ENGINE via the
+     * <a href="https://www.openssl.org/docs/man1.1.0/crypto/ENGINE_load_private_key.html">ENGINE_load_private_key</a>
+     * function.
+     *
+     * <p>Be sure you understand how OpenSsl will behave with respect to reference counting!
+     *
+     * If the ownership is not transferred you need to call {@link #freePrivateKey(long)} once the key is not used
+     * anymore to prevent memory leaks.
+     *
+     * @param keyId the id of the key.
+     * @param password the password to use or {@code null} if none.
+     * @return {@code EVP_PKEY} pointer
+     * @throws Exception if an error happened
+     */
+    public static native long loadPrivateKeyFromEngine(String keyId, String password) throws Exception;
+
+    /**
      * Parse private key from BIO and return {@code EVP_PKEY} pointer.
      *
      * <p>Be sure you understand how OpenSsl will behave with respect to reference counting!


### PR DESCRIPTION
Motivation:

Its possible to plugin different behavior into OpenSSL by providing a custom OpenSSL engine. When doing so it's possible to load a private key from the engine directly.

Modifications:

Add new method which allows to load a private key from the OpenSSL engine directly and so can be used later on.

Result:

Be able to implement custom loading / store mechanism of private keys via a custom OpenSSL engine.