### PR TITLE
Ensure multiple shaded version of the same netty-tcnative artifact ca…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -239,7 +239,8 @@
                   <configureArgs>
                     <configureArg>--with-ssl=no</configureArg>
                     <configureArg>--with-apr=${aprHome}</configureArg>
-                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -Wunused-variable</configureArg>
+                    <configureArg>--with-static-libs</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused-variable</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
                   </configureArgs>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -63,6 +63,7 @@
               <configureArgs>
                 <configureArg>--with-ssl=${sslHome}</configureArg>
                 <configureArg>--with-apr=${aprHome}</configureArg>
+                <configureArg>--with-static-libs</configureArg>
               </configureArgs>
             </configuration>
           </execution>
@@ -149,8 +150,9 @@
         </plugins>
       </build>
     </profile>
+
     <profile>
-      <id>build-libressl-linux-mac</id>
+      <id>build-libressl-non-windows</id>
       <activation>
         <os>
           <family>!windows</family>
@@ -163,7 +165,7 @@
             <executions>
               <!-- Download and build LibreSSL -->
               <execution>
-                <id>build-libressl-linux-mac</id>
+                <id>build-libressl-non-windows</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>run</goal>

--- a/openssl-dynamic/src/main/native-package/configure.ac
+++ b/openssl-dynamic/src/main/native-package/configure.ac
@@ -28,8 +28,8 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
-${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -Wunused-variable"}
-${CXXFLAGS="-O3 -Werror -fno-omit-frame-pointer -Wunused-variable"}
+${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused-variable"}
+${CXXFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused-variable"}
 
 ## -----------------------------------------------
 ## Application Checks

--- a/openssl-dynamic/src/main/native-package/m4/custom.m4
+++ b/openssl-dynamic/src/main/native-package/m4/custom.m4
@@ -41,7 +41,10 @@ AC_DEFUN([CUSTOM_M4_SETUP],
     esac
   ])
 
-  dnl Make sure OpenSSL is available in the system.
+  dnl Check if the libs we link against are static
+  TCN_CHECK_STATIC
+
+  dnl Make sure OpenSSL is available in the system and set extra flags if we compile against a static version.
   if $use_openssl ; then
     TCN_CHECK_SSL_TOOLKIT
   fi

--- a/openssl-dynamic/src/main/native-package/m4/tcnative.m4
+++ b/openssl-dynamic/src/main/native-package/m4/tcnative.m4
@@ -276,6 +276,32 @@ dnl as the help string.
 AC_DEFUN([TCN_HELP_STRING],[ifelse(regexp(AC_ACVERSION, 2\.1), -1, AC_HELP_STRING($1,$2),[  ]$1 substr([                       ],len($1))$2)])dnl
 
 dnl
+dnl TCN_CHECK_STATIC
+dnl Will prepare more LDFLAGS that should be set to ensure we do not export any functions from the static compiled APR / OpenSSL libs.
+dnl
+AC_DEFUN([TCN_CHECK_STATIC],[
+    LD_FLAGS_STATIC=""
+
+    AC_ARG_WITH(static-libs,
+      [  --with-static-libs     The libraries we link against are static.],
+      [
+
+      case $host in
+      *-darwin*)
+          LD_FLAGS_STATIC="-Wl,-exported_symbol,_JNI_*"
+          ;;
+      *linux*)
+          LD_FLAGS_STATIC="-Wl,--exclude-libs,ALL"
+          ;;
+      *)
+          LD_FLAGS_STATIC=""
+          ;;
+      esac
+
+    ])
+])
+
+dnl
 dnl TCN_CHECK_SSL_TOOLKIT
 dnl
 dnl Configure for the detected openssl toolkit installation, giving
@@ -410,4 +436,6 @@ then
     APR_ADDTO(TCNATIVE_LDFLAGS, [$TCN_OPENSSL_LIBS])
     APR_ADDTO(CFLAGS, [-DHAVE_OPENSSL])
 fi
+
+APR_ADDTO(LDFLAGS, [$LD_FLAGS_STATIC])
 ])

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -73,6 +73,7 @@
               <configureArgs>
                 <configureArg>--with-ssl=${sslHome}</configureArg>
                 <configureArg>--with-apr=${aprHome}</configureArg>
+                <configureArg>--with-static-libs</configureArg>
               </configureArgs>
             </configuration>
           </execution>
@@ -186,7 +187,7 @@
       <id>build-openssl-linux</id>
       <activation>
         <os>
-          <family>unix</family>
+          <family>linux</family>
         </os>
       </activation>
       <build>


### PR DESCRIPTION
…n be loaded as long as the shaded prefix is different

Motivation:

We should support to load multiple shaded versions of the same netty-tcnative artifact as netty-tcnative is often used in multiple dependencies.

This is related to https://github.com/netty/netty/issues/7272.

Modifications:

- Use -fvisibility=hidden when compiling and use JNIEXPORT for things we really want to have exported
- Ensure fields are declared as static so these are not exported
- Ensure we pass the correct linker flags so functions of the static linked version of Boring|Libre|OpenSSL and APR are not visible

Result:

Be able to use multiple shaded versions of the same netty-tcnative artifact.