### PR TITLE
Correctly support DH with all versions of OpenSSL / BoringSSL / LibreSSL

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -448,11 +448,7 @@ static BIO_METHOD* BIO_java_bytebuffer() {
 
 static int ssl_tmp_key_init_dh(int bits, int idx)
 {
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED) || defined(LIBRESSL_VERSION_NUMBER)
     return (SSL_temp_keys[idx] = tcn_SSL_dh_get_tmp_param(bits)) ? 0 : 1;
-#else
-    return 0;
-#endif
 }
 
 TCN_IMPLEMENT_CALL(jint, SSL, version)(TCN_STDARGS)

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -64,6 +64,7 @@
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
 #include <openssl/hmac.h>
+#include <openssl/dh.h>
 
 #define ERR_LEN 256
 


### PR DESCRIPTION
Motivation:

We did not support DH with some versions of OpenSSL / BoringSSL / LibreSSL.

Modifications:

- Remove some ifdefs etc and adjust the code to work with all of the SSL flavors we support.

Result:

Fixes https://github.com/netty/netty/issues/8165.