### PR TITLE
Expose way to use SSL_CTX_set_cert_cb as general replacement of SSL_C…

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -224,6 +224,9 @@ struct tcn_ssl_ctxt_t {
     jobject                  cert_requested_callback;
     jmethodID                cert_requested_callback_method;
 
+    jobject                  certificate_callback;
+    jmethodID                certificate_callback_method;
+
     jobject                  sni_hostname_matcher;
     jmethodID                sni_hostname_matcher_method;
 
@@ -317,6 +320,9 @@ const char *tcn_SSL_cipher_authentication_method(const SSL_CIPHER *);
     extern X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl) __attribute__((weak));
     extern void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param, unsigned int flags) __attribute__((weak));
     extern int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param, const char *name, size_t namelen) __attribute__((weak));
+
+    extern int SSL_get_sigalgs(SSL *s, int idx, int *psign, int *phash, int *psignhash, unsigned char *rsig, unsigned char *rhash) __attribute__((weak));
+    extern void SSL_CTX_set_cert_cb(SSL_CTX *c, int (*cert_cb)(SSL *ssl, void *arg), void *arg) __attribute__((weak));
 #endif
 
 #endif /* SSL_PRIVATE_H */

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallback.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallback.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Is called during handshake and hooked into openssl via {@code SSL_CTX_set_cert_cb}.
+ *
+ * IMPORTANT: Implementations of this interface should be static as it is stored as a global reference via JNI. This
+ *            means if you use an inner / anonymous class to implement this and also depend on the finalizer of the
+ *            class to free up the SSLContext the finalizer will never run as the object is never GC, due the hard
+ *            reference to the enclosing class. This will most likely result in a memory leak.
+ */
+public interface CertificateCallback {
+
+    /**
+     * The types contained in the {@code keyTypeBytes} array.
+     */
+    // Extracted from https://github.com/openssl/openssl/blob/master/include/openssl/tls1.h
+    byte TLS_CT_RSA_SIGN = 1;
+    byte TLS_CT_DSS_SIGN = 2;
+    byte TLS_CT_RSA_FIXED_DH = 3;
+    byte TLS_CT_DSS_FIXED_DH = 4;
+    byte TLS_CT_ECDSA_SIGN = 64;
+    byte TLS_CT_RSA_FIXED_ECDH = 65;
+    byte TLS_CT_ECDSA_FIXED_ECDH = 66;
+
+    /**
+     * Called during cert selection. If a certificate chain / key should be used
+     * {@link SSL#setKeyMaterial(long, long, long)} must be called from this callback after
+     * all preparations / validations were completed.
+     *
+     * @param ssl                       the SSL instance
+     * @param keyTypeBytes              an array of the key types on client-mode or {@code null} on server-mode.
+     * @param asn1DerEncodedPrincipals  the principals or {@code null}.
+     *
+     */
+    void handle(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals) throws Exception;
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateRequestedCallback.java
@@ -21,21 +21,24 @@ package io.netty.internal.tcnative;
  * IMPORTANT: Implementations of this interface should be static as it is stored as a global reference via JNI. This
  *            means if you use an inner / anonymous class to implement this and also depend on the finalizer of the
  *            class to free up the SSLContext the finalizer will never run as the object is never GC, due the hard
- *            reference to the enclosing class. This will most likely result in a memory leak.
+ *            reference to the enclosing class. This will most likely result in a memory leak.+
+ *
+ * @deprecated use {@link CertificateCallback}
  */
+@Deprecated
 public interface CertificateRequestedCallback {
 
     /**
      * The types contained in the {@code keyTypeBytes} array.
      */
     // Extracted from https://github.com/openssl/openssl/blob/master/include/openssl/tls1.h
-    byte TLS_CT_RSA_SIGN = 1;
-    byte TLS_CT_DSS_SIGN = 2;
-    byte TLS_CT_RSA_FIXED_DH = 3;
-    byte TLS_CT_DSS_FIXED_DH = 4;
-    byte TLS_CT_ECDSA_SIGN = 64;
-    byte TLS_CT_RSA_FIXED_ECDH = 65;
-    byte TLS_CT_ECDSA_FIXED_ECDH = 66;
+    byte TLS_CT_RSA_SIGN = CertificateCallback.TLS_CT_RSA_SIGN;
+    byte TLS_CT_DSS_SIGN = CertificateCallback.TLS_CT_DSS_SIGN;
+    byte TLS_CT_RSA_FIXED_DH = CertificateCallback.TLS_CT_RSA_FIXED_DH;
+    byte TLS_CT_DSS_FIXED_DH = CertificateCallback.TLS_CT_DSS_FIXED_DH;
+    byte TLS_CT_ECDSA_SIGN = CertificateCallback.TLS_CT_ECDSA_SIGN;
+    byte TLS_CT_RSA_FIXED_ECDH = CertificateCallback.TLS_CT_RSA_FIXED_ECDH;
+    byte TLS_CT_ECDSA_FIXED_ECDH = CertificateCallback.TLS_CT_ECDSA_FIXED_ECDH;
 
     /**
      * Called during cert selection. If a certificate chain / key should be used

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -678,15 +678,31 @@ public final class SSL {
      * {@link #parseX509Chain(long)} and {@link #parsePrivateKey(long, String)}. It's important to note that the caller
      * of the method is responsible to free the passed in chain and key in any case as this method will increment the
      * reference count of the chain and key.
+     *
+     * @deprecated use {@link #setKeyMaterial(long, long, long)}
      */
-    public static native void setKeyMaterialServerSide(long ssl, long chain, long key) throws Exception;
+    @Deprecated
+    public static void setKeyMaterialServerSide(long ssl, long chain, long key) throws Exception {
+        setKeyMaterial(ssl, chain, key);
+    }
+
+    /**
+     * Sets the keymaterial to be used. The passed in chain and key needs to be generated via
+     * {@link #parseX509Chain(long)} and {@link #parsePrivateKey(long, String)}. It's important to note that the caller
+     * of the method is responsible to free the passed in chain and key in any case as this method will increment the
+     * reference count of the chain and key.
+     */
+    public static native void setKeyMaterial(long ssl, long chain, long key) throws Exception;
 
     /**
      * Sets the keymaterial to be used for the client side. The passed in chain and key needs to be generated via
      * {@link #parseX509Chain(long)} and {@link #parsePrivateKey(long, String)}. It's important to note that the caller
      * of the method is responsible to free the passed in chain and key in any case as this method will increment the
      * reference count of the chain and key.
+     *
+     * @deprecated use {@link #setKeyMaterial(long, long, long)}
      */
+    @Deprecated
     public static native void setKeyMaterialClientSide(long ssl, long x509Out, long pkeyOut, long chain, long key) throws Exception;
 
     /**
@@ -722,4 +738,21 @@ public final class SSL {
      * @throws Exception throws if setting the fips mode failed.
      */
     public static native void fipsModeSet(int mode) throws Exception;
+
+    /**
+     * Return the SNI hostname that was sent as part of the SSL Hello.
+     * @param ssl the SSL instance (SSL *)
+     * @return the SNI hostname or {@code null} if none was used.
+     */
+    public static native String getSniHostname(long ssl);
+
+    /**
+     * Return the signature algorithms that the remote peer supports or {@code null} if none are supported.
+     * See <a href="https://www.openssl.org/docs/man1.1.0/ssl/SSL_get_sigalgs.html"> man SSL_get_sigalgs</a> for more details.
+     * The returned names are generated using {@code OBJ_nid2ln} with the {@code psignhash} as parameter.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the signature algorithms or {@code null}.
+     */
+    public static native String[] getSigAlgs(long ssl);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -487,6 +487,15 @@ public final class SSLContext {
     public static native void setCertRequestedCallback(long ctx, CertificateRequestedCallback callback);
 
     /**
+     * Allow to hook {@link CertificateCallback} into the certificate choosing process.
+     * This will call {@code SSL_CTX_set_cert_cb} and so replace the default verification
+     * callback used by openssl
+     * @param ctx Server or Client context to use.
+     * @param callback the callback to call during certificate selection.
+     */
+    public static native void setCertificateCallback(long ctx, CertificateCallback callback);
+
+    /**
      * Allow to hook {@link SniHostNameMatcher} into the sni processing.
      * This will call {@code SSL_CTX_set_tlsext_servername_callback} and so replace the default
      * callback used by openssl


### PR DESCRIPTION
…TX_set_client_cert_cb and expose some more functions.

Motivation:

Currently we only support SSL_CTX_set_client_cert_cb which only works for client side and so we have no good way to setup certificates on the server-side in a proper way that is "safe". Beside this SSL_CTX_set_client_cert_cb should be considered as "deprecated" and SSL_CTX_set_cert_cb should be use as its replacement.

By using SSL_CTX_set_cert_cb we can also ensure the SSL Hello was send and so the SNI / algorithms etc can be accessed in all cases. Methods for doing so were also mssing.

Modifications:

- Add method to make use of SSL_CTX_set_cert_cb and mark the old methods that uses SSL_CTX_set_client_cert_cb as deprecated (+ the old callback interface).
- Add method to retrieve requested SNI hostname
- Add methods to retrieve the supported signature algorithms by the peer.

Result:

More correct way to hook in validation / keymaterial selection when using client / server mode and ways to retrieve addional infos.