### PR TITLE
Add support for TLSv1.3 when compiled against openssl 1.1.1

### DIFF
--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -42,6 +42,10 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpNoTLSv12)(TC
     return SSL_OP_NO_TLSv1_2;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpNoTLSv13)(TCN_STDARGS) {
+    return SSL_OP_NO_TLSv1_3;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpNoTicket)(TCN_STDARGS) {
     return SSL_OP_NO_TICKET;
 }
@@ -484,6 +488,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv1, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv11, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv12, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv13, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTicket, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoCompression, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheOff, ()I, NativeStaticallyReferencedJniMethods) },

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -131,6 +131,22 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define TLS1_3_VERSION 0x0304
 #endif
 
+#ifndef SSL_OP_NO_TLSv1_3
+// TLSV1_3 is not really supported by the underlying OPENSSL version
+#ifndef OPENSSL_NO_TLS1_3
+#define OPENSSL_NO_TLS1_3
+#endif // OPENSSL_NO_TLS1_3
+
+#define SSL_OP_NO_TLSv1_3                               0x20000000U
+#endif // SSL_OP_NO_TLSv1_3
+
+// BoringSSL does not support TLSv1.3 for now
+#ifdef OPENSSL_IS_BORINGSSL
+#ifndef OPENSSL_NO_TLS1_3
+#define OPENSSL_NO_TLS1_3
+#endif // OPENSSL_NO_TLS1_3
+#endif // OPENSSL_IS_BORINGSSL
+
 /* OpenSSL 1.0.2 compatibility */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #define TLS_method SSLv23_method

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -106,6 +106,12 @@ const char* tcn_SSL_cipher_authentication_method(const SSL_CIPHER* cipher){
                 default:
                     return TCN_UNKNOWN_AUTH_METHOD;
             }
+#ifndef OPENSSL_NO_TLS1_3
+        case NID_kx_any:
+            // Let us just pick one as we could use whatever we want.
+            // See https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_get_kx_nid.html
+            return "ECDHE_" SSL_TXT_RSA;
+#endif
         default:
             return TCN_UNKNOWN_AUTH_METHOD;
     }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -40,6 +40,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslOpNoTLSv1();
     static native int sslOpNoTLSv11();
     static native int sslOpNoTLSv12();
+    static native int sslOpNoTLSv13();
     static native int sslOpNoTicket();
 
     /**

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -50,9 +50,10 @@ public final class SSL {
     public static final int SSL_PROTOCOL_TLSV1 = (1<<2);
     public static final int SSL_PROTOCOL_TLSV1_1 = (1<<3);
     public static final int SSL_PROTOCOL_TLSV1_2 = (1<<4);
+    public static final int SSL_PROTOCOL_TLSV1_3 = (1<<5);
 
     /** TLS_*method according to <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_new.html">SSL_CTX_new</a> */
-    public static final int SSL_PROTOCOL_TLS   = (SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2);
+    public static final int SSL_PROTOCOL_TLS   = (SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2 | SSL_PROTOCOL_TLSV1_3);
     public static final int SSL_PROTOCOL_ALL   = (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_TLS);
 
     /*
@@ -69,6 +70,7 @@ public final class SSL {
     public static final int SSL_OP_NO_TLSv1 = sslOpNoTLSv1();
     public static final int SSL_OP_NO_TLSv1_1 = sslOpNoTLSv11();
     public static final int SSL_OP_NO_TLSv1_2 = sslOpNoTLSv12();
+    public static final int SSL_OP_NO_TLSv1_3 = sslOpNoTLSv13();
     public static final int SSL_OP_NO_TICKET = sslOpNoTicket();
 
     public static final int SSL_OP_NO_COMPRESSION = sslOpNoCompression();
@@ -500,10 +502,33 @@ public final class SSL {
      * @param ciphers an SSL cipher specification
      * @return {@code true} if successful
      * @throws Exception if an error happened
+     * @deprecated Use {@link #setCipherSuites(long, String, boolean)}
      */
-    public static native boolean setCipherSuites(long ssl, String ciphers)
-            throws Exception;
+    @Deprecated
+    public static boolean setCipherSuites(long ssl, String ciphers)
+            throws Exception {
+        return setCipherSuites(ssl, ciphers, false);
+    }
 
+    /**
+     * Returns the cipher suites available for negotiation in SSL handshake.
+     * <p>
+     * This complex directive uses a colon-separated cipher-spec string consisting
+     * of OpenSSL cipher specifications to configure the Cipher Suite the client
+     * is permitted to negotiate in the SSL handshake phase. Notice that this
+     * directive can be used both in per-server and per-directory context.
+     * In per-server context it applies to the standard SSL handshake when a
+     * connection is established. In per-directory context it forces a SSL
+     * renegotiation with the reconfigured Cipher Suite after the HTTP request
+     * was read but before the HTTP response is sent.
+     * @param ssl the SSL instance (SSL *)
+     * @param ciphers an SSL cipher specification
+     * @param tlsv13 {@code true} if the ciphers are for TLSv1.3
+     * @return {@code true} if successful
+     * @throws Exception if an error happened
+     */
+    public static native boolean setCipherSuites(long ssl, String ciphers, boolean tlsv13)
+            throws Exception;
     /**
      * Returns the ID of the session as byte array representation.
      *

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -110,8 +110,31 @@ public final class SSLContext {
      * @param ciphers An SSL cipher specification.
      * @return {@code true} if successful
      * @throws Exception if an error happened
+     * @deprecated Use {@link #setCipherSuite(long, String, boolean)}.
      */
-    public static native boolean setCipherSuite(long ctx, String ciphers) throws Exception;
+    @Deprecated
+    public static boolean setCipherSuite(long ctx, String ciphers) throws Exception {
+        return setCipherSuite(ctx, ciphers, false);
+    }
+
+    /**
+     * Cipher Suite available for negotiation in SSL handshake.
+     * <br>
+     * This complex directive uses a colon-separated cipher-spec string consisting
+     * of OpenSSL cipher specifications to configure the Cipher Suite the client
+     * is permitted to negotiate in the SSL handshake phase. Notice that this
+     * directive can be used both in per-server and per-directory context.
+     * In per-server context it applies to the standard SSL handshake when a
+     * connection is established. In per-directory context it forces a SSL
+     * renegotiation with the reconfigured Cipher Suite after the HTTP request
+     * was read but before the HTTP response is sent.
+     * @param ctx Server or Client context to use.
+     * @param ciphers An SSL cipher specification.
+     * @param tlsv13 {@code true} if the ciphers are for TLSv1.3
+     * @return {@code true} if successful
+     * @throws Exception if an error happened
+     */
+    public static native boolean setCipherSuite(long ctx, String ciphers, boolean tlsv13) throws Exception;
 
     /**
      * Set File of PEM-encoded Server CA Certificates

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,10 @@
         - Record the sha256: sha1sum -a 256 libressl-{libresslVersion}.tar.gz (shasum on osx)
     -->
     <libresslSha256>1e3a9fada06c1c060011470ad0ff960de28f9a0515277d7336f7e09362517da6</libresslSha256>
-    <opensslMinorVersion>1.1.0</opensslMinorVersion>
-    <opensslPatchVersion>i</opensslPatchVersion>
+    <opensslMinorVersion>1.1.1</opensslMinorVersion>
+    <opensslPatchVersion></opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00</opensslSha256>
+    <opensslSha256>2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

OpenSSL 1.1.1 was released which supports TLSv1.3 and it is the now the current LTS release. We should be able to compile against it and also support TLSv1.3.

Modifications:

- Add some new native methods to allow to set TLSv1.3 ciphersuites
- Depending on if TLSv1.3 is supported or not set some flags

Result:

Be able to compile against OpenSSL 1.1.1 and make use of TLSv1.3. Fixes https://github.com/netty/netty-tcnative/issues/345 and https://github.com/netty/netty-tcnative/issues/256