### PR TITLE
Skip re-download and re-compile of APR / *SSL when already done before.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -135,42 +135,52 @@
                     <!-- Add the ant tasks from ant-contrib -->
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
-                    <mkdir dir="${boringsslBuildDir}" />
-
                     <if>
-                      <equals arg1="${os.detected.name}" arg2="windows" />
+                      <available file="${boringsslBuildDir}" />
                       <then>
-                        <!-- On Windows, build with /MT for static linking -->
-                        <property name="cmakeAsmFlags" value="" />
-                        <property name="cmakeCFlags" value="/MT" />
-                        <property name="cmakeCxxFlags" value="/MT" />
+                        <echo message="BoringSSL was already build, skipping the build step." />
                       </then>
-                      <elseif>
-                        <equals arg1="${os.detected.name}" arg2="linux" />
-                        <then>
-                          <!-- On *nix, add ASM flags to disable executable stack -->
-                          <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                          <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
-                          <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized" />
-                        </then>
-                      </elseif>
                       <else>
-                        <!-- On *nix, add ASM flags to disable executable stack -->
-                        <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                        <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
-                        <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
+                        <echo message="Building BoringSSL" />
+
+                        <mkdir dir="${boringsslBuildDir}" />
+
+                        <if>
+                          <equals arg1="${os.detected.name}" arg2="windows" />
+                          <then>
+                            <!-- On Windows, build with /MT for static linking -->
+                            <property name="cmakeAsmFlags" value="" />
+                            <property name="cmakeCFlags" value="/MT" />
+                            <property name="cmakeCxxFlags" value="/MT" />
+                          </then>
+                          <elseif>
+                            <equals arg1="${os.detected.name}" arg2="linux" />
+                            <then>
+                              <!-- On *nix, add ASM flags to disable executable stack -->
+                              <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                              <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized" />
+                            </then>
+                          </elseif>
+                          <else>
+                            <!-- On *nix, add ASM flags to disable executable stack -->
+                            <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                            <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                            <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
+                          </else>
+                        </if>
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="-GNinja" />
+                          <arg value=".." />
+                        </exec>
+                        <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
                       </else>
                     </if>
-                    <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                      <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
-                      <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                      <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
-                      <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
-                      <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
-                      <arg value="-GNinja" />
-                      <arg value=".." />
-                    </exec>
-                    <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
                   </target>
                 </configuration>
               </execution>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -172,20 +172,33 @@
                 </goals>
                 <configuration>
                   <target>
-                    <get src="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${libresslArchive}" dest="${project.build.directory}/${libresslArchive}" verbose="on" />
-                    <checksum file="${project.build.directory}/${libresslArchive}" algorithm="SHA-256" property="${libresslSha256}" verifyProperty="isEqual" />
-                    <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                      <arg value="xfv" />
-                      <arg value="${libresslArchive}" />
-                    </exec>
-                    <mkdir dir="${sslHome}" />
-                    <exec executable="configure" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
-                      <arg line="--disable-shared --prefix=${sslHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
-                    </exec>
-                    <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true" />
-                    <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
-                      <arg line="install" />
-                    </exec>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${sslHome}" />
+                      <then>
+                        <echo message="LibreSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Downloading and building LibreSSL" />
+
+                        <get src="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${libresslArchive}" dest="${project.build.directory}/${libresslArchive}" verbose="on" />
+                        <checksum file="${project.build.directory}/${libresslArchive}" algorithm="SHA-256" property="${libresslSha256}" verifyProperty="isEqual" />
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                          <arg value="xfv" />
+                          <arg value="${libresslArchive}" />
+                        </exec>
+                        <mkdir dir="${sslHome}" />
+                        <exec executable="configure" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
+                          <arg line="--disable-shared --prefix=${sslHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
+                        </exec>
+                        <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true" />
+                        <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
+                          <arg line="install" />
+                        </exec>
+                      </else>
+                    </if>
                   </target>
                 </configuration>
               </execution>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -133,46 +133,56 @@
                     <!-- Add the ant tasks from ant-contrib -->
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
-                    <!-- Download the openssl source. -->
-                    <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
-                      <fileset dir="${project.build.directory}">
-                        <include name="**/openssl-${opensslVersion}.tar.gz" />
-                      </fileset>
-                    </ftp>
                     <if>
-                      <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" />
+                      <available file="${sslHome}" />
                       <then>
-                        <echo>Move old version of openssl to correct directory</echo>
-                        <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz" />
-                      </then>
-                    </if>
-                    <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
-                    <gunzip src="${project.build.directory}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/" />
-                    <untar src="${project.build.directory}/openssl-${opensslVersion}.tar" dest="${project.build.directory}/" />
-
-                    <!-- Build for the correct platform -->
-                    <pathconvert property="sslHomePath" targetos="windows">
-                      <path location="${sslHome}" />
-                    </pathconvert>
-                    <if>
-                      <equals arg1="${archBits}" arg2="32" />
-                      <then>
-                        <echo message="Building OpenSSL for Win32" />
-                        <exec executable="perl" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg line="Configure VC-WIN32 --prefix=${sslHomePath}" />
-                        </exec>
-                        <exec executable="nmake" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg line="install" />
-                        </exec>
+                        <echo message="OpenSSL was already build, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Building OpenSSL for Win64" />
-                        <exec executable="perl" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg line="Configure VC-WIN64A --prefix=${sslHome}" />
-                        </exec>
-                        <exec executable="nmake" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg line="install" />
-                        </exec>
+                        <echo message="Downloading and building OpenSSL" />
+
+                        <!-- Download the openssl source. -->
+                        <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
+                          <fileset dir="${project.build.directory}">
+                            <include name="**/openssl-${opensslVersion}.tar.gz" />
+                          </fileset>
+                        </ftp>
+                        <if>
+                          <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" />
+                          <then>
+                            <echo>Move old version of openssl to correct directory</echo>
+                            <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz" />
+                          </then>
+                        </if>
+                        <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
+                        <gunzip src="${project.build.directory}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/" />
+                        <untar src="${project.build.directory}/openssl-${opensslVersion}.tar" dest="${project.build.directory}/" />
+
+                        <!-- Build for the correct platform -->
+                        <pathconvert property="sslHomePath" targetos="windows">
+                          <path location="${sslHome}" />
+                        </pathconvert>
+                        <if>
+                          <equals arg1="${archBits}" arg2="32" />
+                          <then>
+                            <echo message="Building OpenSSL for Win32" />
+                            <exec executable="perl" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                              <arg line="Configure VC-WIN32 --prefix=${sslHomePath}" />
+                            </exec>
+                            <exec executable="nmake" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                              <arg line="install" />
+                            </exec>
+                          </then>
+                          <else>
+                            <echo message="Building OpenSSL for Win64" />
+                            <exec executable="perl" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                              <arg line="Configure VC-WIN64A --prefix=${sslHome}" />
+                            </exec>
+                            <exec executable="nmake" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                              <arg line="install" />
+                            </exec>
+                          </else>
+                        </if>
                       </else>
                     </if>
                   </target>
@@ -206,35 +216,45 @@
                     <!-- Add the ant tasks from ant-contrib -->
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
-                    <!-- Download the openssl source. -->
-                    <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
-                      <fileset dir="${project.build.directory}">
-                        <include name="**/openssl-${opensslVersion}.tar.gz" />
-                      </fileset>
-                    </ftp>
                     <if>
-                      <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" />
+                      <available file="${sslHome}" />
                       <then>
-                        <echo>Move old version of openssl to correct directory</echo>
-                        <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz" />
+                        <echo message="OpenSSL was already build, skipping the build step." />
                       </then>
-                    </if>
-                    <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
-                    <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                      <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
-                    </exec>
+                      <else>
+                        <echo message="Downloading and building OpenSSL" />
 
-                    <mkdir dir="${sslHome}" />
-                    <exec executable="config" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
-                    </exec>
-                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg value="depend" />
-                    </exec>
-                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
-                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg value="install" />
-                    </exec>
+                        <!-- Download the openssl source. -->
+                        <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
+                          <fileset dir="${project.build.directory}">
+                            <include name="**/openssl-${opensslVersion}.tar.gz" />
+                          </fileset>
+                        </ftp>
+                        <if>
+                          <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" />
+                          <then>
+                            <echo>Move old version of openssl to correct directory</echo>
+                            <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz" />
+                          </then>
+                        </if>
+                        <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                          <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
+                        </exec>
+
+                        <mkdir dir="${sslHome}" />
+                        <exec executable="config" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                          <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
+                        </exec>
+                        <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                          <arg value="depend" />
+                        </exec>
+                        <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
+                        <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                          <arg value="install" />
+                        </exec>
+                      </else>
+                    </if>
                   </target>
                 </configuration>
               </execution>
@@ -266,35 +286,45 @@
                     <!-- Add the ant tasks from ant-contrib -->
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
-                    <!-- Download the openssl source. -->
-                    <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
-                      <fileset dir="${project.build.directory}">
-                        <include name="**/openssl-${opensslVersion}.tar.gz" />
-                      </fileset>
-                    </ftp>
                     <if>
-                      <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" />
+                      <available file="${sslHome}" />
                       <then>
-                        <echo>Move old version of openssl to correct directory</echo>
-                        <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz" />
+                        <echo message="OpenSSL was already build, skipping the build step." />
                       </then>
-                    </if>
-                    <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
-                    <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                      <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
-                    </exec>
+                      <else>
+                        <echo message="Downloading and building OpenSSL" />
 
-                    <mkdir dir="${sslHome}" />
-                    <exec executable="Configure" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg line="darwin64-x86_64-cc -O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
-                    </exec>
-                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg value="depend" />
-                    </exec>
-                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
-                    <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                      <arg value="install" />
-                    </exec>
+                        <!-- Download the openssl source. -->
+                        <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
+                          <fileset dir="${project.build.directory}">
+                            <include name="**/openssl-${opensslVersion}.tar.gz" />
+                          </fileset>
+                        </ftp>
+                        <if>
+                          <available file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" />
+                          <then>
+                            <echo>Move old version of openssl to correct directory</echo>
+                            <move file="${project.build.directory}/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" tofile="${project.build.directory}/openssl-${opensslVersion}.tar.gz" />
+                          </then>
+                        </if>
+                        <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                          <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
+                        </exec>
+
+                        <mkdir dir="${sslHome}" />
+                        <exec executable="Configure" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                          <arg line="darwin64-x86_64-cc -O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
+                        </exec>
+                        <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                          <arg value="depend" />
+                        </exec>
+                        <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
+                        <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
+                          <arg value="install" />
+                        </exec>
+                      </else>
+                    </if>
                   </target>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -320,28 +320,41 @@
                 </goals>
                 <configuration>
                   <target name="build-apr" if="${linkStatic}">
-                    <property name="aprArchiveFile" value="apr-${aprVersion}-win32-src.zip" />
-                    <get src="http://archive.apache.org/dist/apr/${aprArchiveFile}" dest="${project.build.directory}/${aprArchiveFile}" verbose="on" />
-                    <unzip src="${project.build.directory}/${aprArchiveFile}" dest="${project.build.directory}" />
-                    <condition property="windowsRelease" value="Win32 Release" else="x64 Release">
-                      <equals arg1="${archBits}" arg2="32" />
-                    </condition>
-                    <echo message="archBits=${archBits}. Using windowsRelease=${windowsRelease}" />
-                    <!-- On Windows, force building APR with /MT for static linking -->
-                    <replace dir="${aprBuildDir}" token="/MD" value="/MT">
-                      <include name="*.mak" />
-                    </replace>
-                    <retry retrycount="3">
-                      <exec executable="nmake" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
-                        <arg line="/f Makefile.win ARCH=&quot;${windowsRelease}&quot; PREFIX=..\apr buildall install" />
-                      </exec>
-                    </retry>
-                    <copy todir="${aprHome}/include">
-                      <fileset dir="${aprBuildDir}/include/arch/win32" includes="*.h" />
-                    </copy>
-                    <copy todir="${aprHome}">
-                      <fileset dir="${aprBuildDir}/include/arch" includes="*.h" />
-                    </copy>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${aprHome}" />
+                      <then>
+                        <echo message="APR was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Downloading and building APR" />
+
+                        <property name="aprArchiveFile" value="apr-${aprVersion}-win32-src.zip" />
+                        <get src="http://archive.apache.org/dist/apr/${aprArchiveFile}" dest="${project.build.directory}/${aprArchiveFile}" verbose="on" />
+                        <unzip src="${project.build.directory}/${aprArchiveFile}" dest="${project.build.directory}" />
+                        <condition property="windowsRelease" value="Win32 Release" else="x64 Release">
+                          <equals arg1="${archBits}" arg2="32" />
+                        </condition>
+                        <echo message="archBits=${archBits}. Using windowsRelease=${windowsRelease}" />
+                        <!-- On Windows, force building APR with /MT for static linking -->
+                        <replace dir="${aprBuildDir}" token="/MD" value="/MT">
+                          <include name="*.mak" />
+                        </replace>
+                        <retry retrycount="3">
+                          <exec executable="nmake" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
+                            <arg line="/f Makefile.win ARCH=&quot;${windowsRelease}&quot; PREFIX=..\apr buildall install" />
+                          </exec>
+                        </retry>
+                        <copy todir="${aprHome}/include">
+                          <fileset dir="${aprBuildDir}/include/arch/win32" includes="*.h" />
+                        </copy>
+                        <copy todir="${aprHome}">
+                          <fileset dir="${aprBuildDir}/include/arch" includes="*.h" />
+                        </copy>
+                      </else>
+                    </if>
                   </target>
                 </configuration>
               </execution>
@@ -370,23 +383,36 @@
                 </goals>
                 <configuration>
                   <target if="${linkStatic}">
-                    <property name="aprTarGzFile" value="apr-${aprVersion}.tar.gz" />
-                    <property name="aprTarFile" value="apr-${aprVersion}.tar" />
-                    <get src="http://archive.apache.org/dist/apr/${aprTarGzFile}" dest="${project.build.directory}/${aprTarGzFile}" verbose="on" />
-                    <checksum file="${project.build.directory}/${aprTarGzFile}" algorithm="MD5" property="${aprMd5}" verifyProperty="isEqual" />
-                    <gunzip src="${project.build.directory}/${aprTarGzFile}" dest="${project.build.directory}" />
-                    <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
-                    <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                      <arg line="xfvz ${aprTarGzFile}" />
-                    </exec>
-                    <mkdir dir="${aprHome}" />
-                    <exec executable="configure" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
-                      <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
-                    </exec>
-                    <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true" />
-                    <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
-                      <arg line="install" />
-                    </exec>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${aprHome}" />
+                      <then>
+                        <echo message="APR was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Downloading and building APR" />
+
+                        <property name="aprTarGzFile" value="apr-${aprVersion}.tar.gz" />
+                        <property name="aprTarFile" value="apr-${aprVersion}.tar" />
+                        <get src="http://archive.apache.org/dist/apr/${aprTarGzFile}" dest="${project.build.directory}/${aprTarGzFile}" verbose="on" />
+                        <checksum file="${project.build.directory}/${aprTarGzFile}" algorithm="MD5" property="${aprMd5}" verifyProperty="isEqual" />
+                        <gunzip src="${project.build.directory}/${aprTarGzFile}" dest="${project.build.directory}" />
+                        <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                          <arg line="xfvz ${aprTarGzFile}" />
+                        </exec>
+                        <mkdir dir="${aprHome}" />
+                        <exec executable="configure" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
+                          <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
+                        </exec>
+                        <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true" />
+                        <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
+                          <arg line="install" />
+                        </exec>
+                      </else>
+                    </if>
                   </target>
                 </configuration>
               </execution>


### PR DESCRIPTION
Motivation:

At the moment we redownload and re-compile APR / *SSL when building our static compiled version of netty-tcnative even if it was compiled before and we did not request a "clean" during the build. We should better only do it when "clean" is explicit requested to speed up build times when working on changes.

Modifications:

Verify if we already compiled APR / *SSL and if so skip the step.

Result:

Be able to faster iterate and build