### PR TITLE
Do not install man-pages during openssl-static build to speed up things.

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -251,7 +251,8 @@
                         </exec>
                         <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
                         <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg value="install" />
+                          <!-- Don't install manpages to make things as fast a possible -->
+                          <arg value="install_sw" />
                         </exec>
                       </else>
                     </if>
@@ -321,7 +322,8 @@
                         </exec>
                         <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true" />
                         <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg value="install" />
+                          <!-- Don't install manpages to make things as fast a possible -->
+                          <arg value="install_sw" />
                         </exec>
                       </else>
                     </if>


### PR DESCRIPTION
Motivation:

We do not care about the openssl manpages so there is no need to install them during the build.

Modifications:

Use make install_sw which will skip manpage installation.

Result:

Faster build