### PR TITLE
Return 0 for SSL_OP_NO_TLSv1_3 when TLSv1.3 is not supported.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -137,7 +137,7 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define OPENSSL_NO_TLS1_3
 #endif // OPENSSL_NO_TLS1_3
 
-#define SSL_OP_NO_TLSv1_3                               0x20000000U
+#define SSL_OP_NO_TLSv1_3                               0x00000000U
 #endif // SSL_OP_NO_TLSv1_3
 
 // BoringSSL does not support TLSv1.3 for now


### PR DESCRIPTION
Motivation:

We need to use 0 for SSL_OP_NO_TLSv1_3 when TLSv1.3 is not supported to not disable any protocols by mistake when its not supported at all.

Modifications:

Define SSL_OP_NO_TLSv1_3 as 0 when TLSv1.3 is not supported.

Result:

Correctly handle the case when TLSv1.3 is not supported and so be able to use it in this case.