### PR TITLE
Use type-safe wrapper for STACK_OF(SSL_CIPHERS) lookup.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1722,7 +1722,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
 
     for (i = 0; i < len; i++) {
         (*e)->SetObjectArrayElement(e, array, i,
-        (*e)->NewStringUTF(e, tcn_SSL_cipher_authentication_method((SSL_CIPHER*) sk_value((_STACK*) ciphers, i))));
+        (*e)->NewStringUTF(e, tcn_SSL_cipher_authentication_method(sk_SSL_CIPHER_value(ciphers, i))));
     }
     return array;
 }


### PR DESCRIPTION
Motivation:

The wrappers avoid casting and are more stable. This was mostly done in 94d4c41b98d37dcc26960098bd41c1624852b13a, but missed a spot.

Modifications:

Use sk_SSL_CIPHER_value instead of casting stack types manually.

Result:

Less casting.