### PR TITLE
Use correct maven lifecycle phases during static builds.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -126,7 +126,7 @@
               <!-- Build the BoringSSL static libs -->
               <execution>
                 <id>build-boringssl</id>
-                <phase>generate-sources</phase>
+                <phase>compile</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -41,34 +41,6 @@
 
   <build>
     <plugins>
-      <!-- Configure the distribution statically linked against OpenSSL and APR -->
-      <plugin>
-        <groupId>org.fusesource.hawtjni</groupId>
-        <artifactId>maven-hawtjni-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>build-native-lib</id>
-            <goals>
-              <goal>generate</goal>
-              <goal>build</goal>
-            </goals>
-            <phase>compile</phase>
-            <configuration>
-              <name>netty_tcnative</name>
-              <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
-              <libDirectory>${nativeLibOnlyDir}</libDirectory>
-              <forceAutogen>${forceAutogen}</forceAutogen>
-              <forceConfigure>${forceConfigure}</forceConfigure>
-              <windowsBuildTool>msbuild</windowsBuildTool>
-              <configureArgs>
-                <configureArg>--with-ssl=${sslHome}</configureArg>
-                <configureArg>--with-apr=${aprHome}</configureArg>
-                <configureArg>--with-static-libs</configureArg>
-              </configureArgs>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
 
       <!-- Add the LibreSSL version to the manifest. -->
       <plugin>
@@ -104,6 +76,35 @@
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                 <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
               </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Configure the distribution statically linked against OpenSSL and APR -->
+      <plugin>
+        <groupId>org.fusesource.hawtjni</groupId>
+        <artifactId>maven-hawtjni-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-native-lib</id>
+            <goals>
+              <goal>generate</goal>
+              <goal>build</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <name>netty_tcnative</name>
+              <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+              <libDirectory>${nativeLibOnlyDir}</libDirectory>
+              <forceAutogen>${forceAutogen}</forceAutogen>
+              <forceConfigure>${forceConfigure}</forceConfigure>
+              <windowsBuildTool>msbuild</windowsBuildTool>
+              <configureArgs>
+                <configureArg>--with-ssl=${sslHome}</configureArg>
+                <configureArg>--with-apr=${aprHome}</configureArg>
+                <configureArg>--with-static-libs</configureArg>
+              </configureArgs>
             </configuration>
           </execution>
         </executions>
@@ -165,8 +166,38 @@
             <executions>
               <!-- Download and build LibreSSL -->
               <execution>
-                <id>build-libressl-non-windows</id>
+                <id>source-libressl-non-windows</id>
                 <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${libresslCheckoutDir}" />
+                      <then>
+                        <echo message="LibreSSL was already downloaded, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Downloading LibreSSL" />
+
+                        <get src="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${libresslArchive}" dest="${project.build.directory}/${libresslArchive}" verbose="on" />
+                        <checksum file="${project.build.directory}/${libresslArchive}" algorithm="SHA-256" property="${libresslSha256}" verifyProperty="isEqual" />
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                          <arg value="xfv" />
+                          <arg value="${libresslArchive}" />
+                        </exec>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>build-libressl-non-windows</id>
+                <phase>compile</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>
@@ -181,14 +212,7 @@
                         <echo message="LibreSSL was already build, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Downloading and building LibreSSL" />
-
-                        <get src="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${libresslArchive}" dest="${project.build.directory}/${libresslArchive}" verbose="on" />
-                        <checksum file="${project.build.directory}/${libresslArchive}" algorithm="SHA-256" property="${libresslSha256}" verifyProperty="isEqual" />
-                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                          <arg value="xfv" />
-                          <arg value="${libresslArchive}" />
-                        </exec>
+                        <echo message="Building LibreSSL" />
                         <mkdir dir="${sslHome}" />
                         <exec executable="configure" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
                           <arg line="--disable-shared --prefix=${sslHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -51,6 +51,33 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <!-- Build the additional JAR that contains the native library. -->
+          <execution>
+            <id>native-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy todir="${nativeJarWorkdir}">
+                  <zipfileset src="${defaultJarFile}" />
+                </copy>
+                <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                  <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                  <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                </copy>
+                <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Configure the distribution statically linked against OpenSSL and APR -->
       <plugin>
         <groupId>org.fusesource.hawtjni</groupId>
@@ -79,33 +106,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <!-- Build the additional JAR that contains the native library. -->
-          <execution>
-            <id>native-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <copy todir="${nativeJarWorkdir}">
-                  <zipfileset src="${defaultJarFile}" />
-                </copy>
-                <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
-                  <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
-                  <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
-                </copy>
-                <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -123,7 +123,7 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <id>build-openssl</id>
+                <id>source-openssl</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>run</goal>
@@ -134,12 +134,12 @@
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
                     <if>
-                      <available file="${sslHome}" />
+                      <available file="${opensslBuildDir}" />
                       <then>
-                        <echo message="OpenSSL was already build, skipping the build step." />
+                        <echo message="OpenSSL was already downloaded, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Downloading and building OpenSSL" />
+                        <echo message="Downloading OpenSSL" />
 
                         <!-- Download the openssl source. -->
                         <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
@@ -157,6 +157,30 @@
                         <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
                         <gunzip src="${project.build.directory}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/" />
                         <untar src="${project.build.directory}/openssl-${opensslVersion}.tar" dest="${project.build.directory}/" />
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>build-openssl</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${sslHome}" />
+                      <then>
+                        <echo message="OpenSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Building OpenSSL" />
 
                         <!-- Build for the correct platform -->
                         <pathconvert property="sslHomePath" targetos="windows">
@@ -206,7 +230,7 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <id>build-openssl</id>
+                <id>source-openssl</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>run</goal>
@@ -217,12 +241,12 @@
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
                     <if>
-                      <available file="${sslHome}" />
+                      <available file="${opensslBuildDir}" />
                       <then>
-                        <echo message="OpenSSL was already build, skipping the build step." />
+                        <echo message="OpenSSL was already downloaded, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Downloading and building OpenSSL" />
+                        <echo message="Downloading OpenSSL" />
 
                         <!-- Download the openssl source. -->
                         <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
@@ -241,7 +265,30 @@
                         <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
                           <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
                         </exec>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
 
+              <execution>
+                <id>build-openssl</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${sslHome}" />
+                      <then>
+                        <echo message="OpenSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Building OpenSSL" />
                         <mkdir dir="${sslHome}" />
                         <exec executable="config" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
                           <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
@@ -277,7 +324,7 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <id>build-openssl</id>
+                <id>source-openssl</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>run</goal>
@@ -288,12 +335,12 @@
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
                     <if>
-                      <available file="${sslHome}" />
+                      <available file="${opensslBuildDir}" />
                       <then>
-                        <echo message="OpenSSL was already build, skipping the build step." />
+                        <echo message="OpenSSL was already downloaded, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Downloading and building OpenSSL" />
+                        <echo message="Downloading OpenSSL" />
 
                         <!-- Download the openssl source. -->
                         <ftp action="get" server="ftp.openssl.org" remotedir="source" userid="anonymous" password="anonymous" passive="yes" verbose="yes">
@@ -312,7 +359,29 @@
                         <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
                           <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
                         </exec>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>build-openssl</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
+                    <if>
+                      <available file="${sslHome}" />
+                      <then>
+                        <echo message="OpenSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Building OpenSSL" />
                         <mkdir dir="${sslHome}" />
                         <exec executable="Configure" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
                           <arg line="darwin64-x86_64-cc -O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />

--- a/pom.xml
+++ b/pom.xml
@@ -313,13 +313,43 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <id>build-apr</id>
+                <id>source-apr</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <target name="build-apr" if="${linkStatic}">
+                  <target if="${linkStatic}">
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${aprBuildDir}" />
+                      <then>
+                        <echo message="APR was already downloaded, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Downloading APR" />
+
+                        <property name="aprArchiveFile" value="apr-${aprVersion}-win32-src.zip" />
+                        <get src="http://archive.apache.org/dist/apr/${aprArchiveFile}" dest="${project.build.directory}/${aprArchiveFile}" verbose="on" />
+                        <unzip src="${project.build.directory}/${aprArchiveFile}" dest="${project.build.directory}" />
+                        <condition property="windowsRelease" value="Win32 Release" else="x64 Release">
+                          <equals arg1="${archBits}" arg2="32" />
+                        </condition>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>build-apr</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target if="${linkStatic}">
                     <!-- Add the ant tasks from ant-contrib -->
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
@@ -329,11 +359,8 @@
                         <echo message="APR was already build, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Downloading and building APR" />
+                        <echo message="Building APR" />
 
-                        <property name="aprArchiveFile" value="apr-${aprVersion}-win32-src.zip" />
-                        <get src="http://archive.apache.org/dist/apr/${aprArchiveFile}" dest="${project.build.directory}/${aprArchiveFile}" verbose="on" />
-                        <unzip src="${project.build.directory}/${aprArchiveFile}" dest="${project.build.directory}" />
                         <condition property="windowsRelease" value="Win32 Release" else="x64 Release">
                           <equals arg1="${archBits}" arg2="32" />
                         </condition>
@@ -376,8 +403,41 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <id>build-apr-linux-mac</id>
+                <id>source-apr-linux-mac</id>
                 <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target if="${linkStatic}">
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <if>
+                      <available file="${aprBuildDir}" />
+                      <then>
+                        <echo message="APR was already downloaded, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Downloading and unpacking APR" />
+
+                        <property name="aprTarGzFile" value="apr-${aprVersion}.tar.gz" />
+                        <property name="aprTarFile" value="apr-${aprVersion}.tar" />
+                        <get src="http://archive.apache.org/dist/apr/${aprTarGzFile}" dest="${project.build.directory}/${aprTarGzFile}" verbose="on" />
+                        <checksum file="${project.build.directory}/${aprTarGzFile}" algorithm="MD5" property="${aprMd5}" verifyProperty="isEqual" />
+                        <gunzip src="${project.build.directory}/${aprTarGzFile}" dest="${project.build.directory}" />
+                        <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                          <arg line="xfvz ${aprTarGzFile}" />
+                        </exec>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>build-apr-linux-mac</id>
+                <phase>compile</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>
@@ -392,17 +452,7 @@
                         <echo message="APR was already build, skipping the build step." />
                       </then>
                       <else>
-                        <echo message="Downloading and building APR" />
-
-                        <property name="aprTarGzFile" value="apr-${aprVersion}.tar.gz" />
-                        <property name="aprTarFile" value="apr-${aprVersion}.tar" />
-                        <get src="http://archive.apache.org/dist/apr/${aprTarGzFile}" dest="${project.build.directory}/${aprTarGzFile}" verbose="on" />
-                        <checksum file="${project.build.directory}/${aprTarGzFile}" algorithm="MD5" property="${aprMd5}" verifyProperty="isEqual" />
-                        <gunzip src="${project.build.directory}/${aprTarGzFile}" dest="${project.build.directory}" />
-                        <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
-                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                          <arg line="xfvz ${aprTarGzFile}" />
-                        </exec>
+                        <echo message="Building APR" />
                         <mkdir dir="${aprHome}" />
                         <exec executable="configure" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
                           <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />


### PR DESCRIPTION
Motivation:

We should use the correct phases for the native build. Which means we should ownload download and unpack the needed resources during generate-sources but do the compilation during the compile phase.

Modifications:

Break up tasks to execute in the correct phase.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/120.