### PR TITLE
Use generated-sources/ for copied source code during build of static …

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -240,7 +240,8 @@
                 <phase>compile</phase>
                 <configuration>
                   <name>netty_tcnative</name>
-                  <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+                  <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
+                  <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>
                   <forceConfigure>${forceConfigure}</forceConfigure>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -95,7 +95,8 @@
             <phase>compile</phase>
             <configuration>
               <name>netty_tcnative</name>
-              <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+              <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
+              <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>
               <forceConfigure>${forceConfigure}</forceConfigure>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -92,7 +92,8 @@
             <phase>compile</phase>
             <configuration>
               <name>netty_tcnative</name>
-              <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+              <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
+              <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>
               <forceConfigure>${forceConfigure}</forceConfigure>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <msvcSslLibDirs>${sslHome}/lib</msvcSslLibDirs>
     <msvcSslLibs>libssl.lib;libcrypto.lib</msvcSslLibs>
     <strip.skip>false</strip.skip>
+    <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
   </properties>
 
   <build>
@@ -170,8 +171,8 @@
                 <!-- Copy all of the code from the dynamic module -->
                 <delete dir="src" quiet="true" />
                 <mkdir dir="src" />
-                <copy todir="${basedir}/src" verbose="true">
-                  <fileset dir="${opensslDynamicDir}/src" />
+                <copy todir="${generatedSourcesDir}" verbose="true">
+                  <fileset dir="${opensslDynamicDir}/src/main" />
                 </copy>
 
                 <!-- Convert the paths to windows format -->
@@ -199,7 +200,7 @@
                 <filter token="SSL_INCLUDE_DIRS" value="${sslIncludeDirsWindowsPath}" />
                 <filter token="SSL_LIB_DIR" value="${sslLibDirsWindowsPath}" />
                 <filter token="SSL_LIBS" value="${msvcSslLibs}" />
-                <copy file="${vsStaticTemplateFile}" tofile="src/main/native-package/vs2010.vcxproj" filtering="true" overwrite="true" verbose="true" />
+                <copy file="${vsStaticTemplateFile}" tofile="${generatedSourcesDir}/native-package/vs2010.vcxproj" filtering="true" overwrite="true" verbose="true" />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
…libraries.

Motivation:

We should not put copied content in an other place then target/ during build of static modules to not confuse things.

Modifications:

Copy src/main/* into target/generated-sources during build of static artifacts.

Result:

Less confusing and more clear build