### PR TITLE
Do not return early in certificate_cb if keytypes could not be detected.

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1618,10 +1618,6 @@ static int certificate_cb(SSL* ssl, void* arg) {
         issuers = NULL;
     } else {
         types = keyTypes(e, ssl);
-        if (types == NULL) {
-            return 0;
-        }
-
         issuers = principalBytes(e, SSL_get_client_CA_list(ssl));
     }
 


### PR DESCRIPTION
Motivation:

We must not return early in certificate_cb if keytypes could not be detected as we correctly handle this case in the Java code. This is especially important to correctly support TLSv1.3

Modifications:

Do not return early when the keytypes could not be detected and just let the java callback handle it.

Result:

Be able to use TLSv1.3 correctly.