### PR TITLE
Ensure generated-sources/java is included in jar.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -89,6 +89,24 @@
             </executions>
           </plugin>
 
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${generatedSourcesDir}/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <!-- Add the commit ID and branch to the manifest. -->
           <plugin>
             <groupId>org.apache.felix</groupId>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -55,6 +55,24 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generatedSourcesDir}/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <!-- Build the additional JAR that contains the native library. -->

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -52,6 +52,24 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generatedSourcesDir}/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <!-- Build the additional JAR that contains the native library. -->


### PR DESCRIPTION
Motivation:

ef30a10dcb9b21eb14fa1dc0bfcc249c235c809e changed the build to use generated-sources but missed to ensure we also compile the java classes in the generated jars.

Modifications:

Correctly include into jar.

Result:

Jars contain native code and java code.