### PR TITLE
SNI may incorrectly contain hostname with trailing dot

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1646,7 +1646,7 @@ TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
     ERR_clear_error();
 }
 
-TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName)(TCN_STDARGS, jlong ssl, jstring hostname) {
+TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName0)(TCN_STDARGS, jlong ssl, jstring hostname) {
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
@@ -2325,7 +2325,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getSessionId, (J)[B, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getHandshakeCount, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(clearError, ()V, SSL) },
-  { TCN_METHOD_TABLE_ENTRY(setTlsExtHostName, (JLjava/lang/String;)V, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setTlsExtHostName0, (JLjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setHostNameValidation, (JILjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(authenticationMethods, (J)[Ljava/lang/String;, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setCertificateBio, (JJJLjava/lang/String;)V, SSL) },

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -556,7 +556,16 @@ public final class SSL {
      * @param ssl the SSL instance (SSL *)
      * @param hostname the hostname
      */
-    public static native void setTlsExtHostName(long ssl, String hostname);
+    public static void setTlsExtHostName(long ssl, String hostname) {
+        if (hostname != null && hostname.endsWith(".")) {
+            // Strip trailing dot if included.
+            // See https://github.com/netty/netty-tcnative/issues/400
+            hostname = hostname.substring(0, hostname.length() - 1);
+        }
+        setTlsExtHostName0(ssl, hostname);
+    }
+
+    private static native void setTlsExtHostName0(long ssl, String hostname);
 
     /**
      * Explicitly control <a href="https://wiki.openssl.org/index.php/Hostname_validation">hostname validation</a>


### PR DESCRIPTION
Motivation:

Hostnames like example.com may also be written as example.com. Technically those are different because the trailing dot denotes it is an absolute name and not relative (so it would disable using the search path in /etc/resolv.conf, for example).

When using encryption, the user is always expected to provide the absolute name. SNI requires the absolute name, but without the trailing dot. RFC 6066 §3 defines for SNI.

Modifications:

Strip trailing dot if included.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/400.