### PR TITLE
Support TLSv1.3 with compiling against boringssl

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1583,11 +1583,16 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     rv = SSL_set_cipher_list(ssl_, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
 #else
     if (tlsv13 == JNI_TRUE) {
+#ifdef OPENSSL_IS_BORINGSSL
+        // BoringSSL does not support setting TLSv1.3 cipher suites explicit for now.
+        rv = JNI_TRUE;
+#else
         rv = SSL_set_ciphersuites(ssl_, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
+#endif // OPENSSL_IS_BORINGSSL
     } else {
         rv = SSL_set_cipher_list(ssl_, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
     }
-#endif
+#endif // OPENSSL_NO_TLS1_3
 
     if (rv == JNI_FALSE) {
         char err[256];

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -140,13 +140,6 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define SSL_OP_NO_TLSv1_3                               0x00000000U
 #endif // SSL_OP_NO_TLSv1_3
 
-// BoringSSL does not support TLSv1.3 for now
-#ifdef OPENSSL_IS_BORINGSSL
-#ifndef OPENSSL_NO_TLS1_3
-#define OPENSSL_NO_TLS1_3
-#endif // OPENSSL_NO_TLS1_3
-#endif // OPENSSL_IS_BORINGSSL
-
 /* OpenSSL 1.0.2 compatibility */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #define TLS_method SSLv23_method


### PR DESCRIPTION
Motivation:

BoringSSL chromium-stable branch supports TLSv1.3 now so we should do as well when compile against it.

Modifications:

Add support for TLSv1.3 when using boringssl

Result:

Easier for people to use TLSv1.3 as they will get it with netty-tcnative-boringssl-static