### PR TITLE
Cleanup BoringSSL TLSv1.3 support and consistent handle empty ciphers.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1573,6 +1573,10 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     }
     #endif
 
+    if (ciphers == NULL || (*e)->GetStringUTFLength(e, ciphers) == 0) {
+        return JNI_FALSE;
+    }
+
     TCN_ALLOC_CSTRING(ciphers);
     UNREFERENCED(o);
     if (!J2S(ciphers)) {

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -131,7 +131,6 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     //
     // See http://hg.nginx.org/nginx/rev/7ad0f4ace359
     #if defined(OPENSSL_IS_BORINGSSL)
-        SSL_CTX_set_min_proto_version(ctx, 0);
         SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
     #endif
 #else
@@ -444,6 +443,10 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCipherSuite)(TCN_STDARGS, jlong ctx,
         return JNI_FALSE;
     }
 #endif
+
+    if (ciphers == NULL || (*e)->GetStringUTFLength(e, ciphers) == 0) {
+        return JNI_FALSE;
+    }
 
     TCN_ALLOC_CSTRING(ciphers);
     UNREFERENCED(o);


### PR DESCRIPTION
Motivation:

Some code can be removed and also we should ensure we handle empty ciphers consistent between BoringSSL and OpenSSL.

Modifications:

- Remove not needed called for min protocol version when using BoringSSL
- Return when an empty ciphers string is given as this will fail in BoringSSL while just return on OpenSSL.

Result:

Cleaner and more consistent code.