### PR TITLE
Explicit specify java version to use to ensure we rebuild image when …

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8"
+        java_version : "1.8.192"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "1.8"
+        java_version : "1.8.192"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
…java version changes.

Motivation:

We should explicit specify the java version to use to ensure docker will rebuild the image once a new java version was released and we specify it.

Modifications:

- Explicit specify the java versions to use

Result:

Ensure latest java versions are used during testing