### PR TITLE
Ignore cmake related files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 # exclude mainframer files
 mainframer
 .mainframer
+
+# exclude cmake related files
+CMakeLists.txt
+cmake-*


### PR DESCRIPTION
Motivation:

CLion is using cmake to configure the project correctly. We should ignore these as these are not needed for building itself.

Modifications:

Ingore cmake files.

Result:

More things for git to ignore