### PR TITLE
Add method to retrieve the SSL_CTX pointer from the internal ctx data…

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1813,6 +1813,15 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, getMode)(TCN_STDARGS, jlong ctx)
     return (jint) SSL_CTX_get_mode(c->ctx);
 }
 
+TCN_IMPLEMENT_CALL(jlong, SSLContext, getSslCtx)(TCN_STDARGS, jlong ctx)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    TCN_CHECK_NULL(c, ctx, 0);
+    return P2J(c->ctx);
+}
+
+
 #if !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL)
 
 static const int OCSP_CLIENT_ACK = 1;
@@ -1937,7 +1946,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(setMode, (JI)I, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(getMode, (J)I, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(enableOcsp, (JZ)V, SSLContext) },
-  { TCN_METHOD_TABLE_ENTRY(disableOcsp, (J)V, SSLContext) }
+  { TCN_METHOD_TABLE_ENTRY(disableOcsp, (J)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getSslCtx, (J)J, SSLContext) }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -597,4 +597,9 @@ public final class SSLContext {
      * <p><a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html">Search for OCSP</a>
      */
     public static native void disableOcsp(long ctx);
+
+    /**
+     * Returns the {@code SSL_CTX}.
+     */
+    public static native long getSslCtx(long ctx);
 }


### PR DESCRIPTION
…structure used by netty-tcnative

Motivation:

To hook up custom processing per SSL_CTX we should allow to retrieve the SSL_CTX that was created internally via SSLContext.make(...).

Modifications:

Add SSLContext.getSslCtx(...)

Result:

Be able to hookup custom SSL_CTX initialization easily