### PR TITLE
Upgrade to OpenSSL 1.1.1a for static build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,9 @@
     -->
     <libresslSha256>1e3a9fada06c1c060011470ad0ff960de28f9a0515277d7336f7e09362517da6</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion />
+    <opensslPatchVersion>a</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d</opensslSha256>
+    <opensslSha256>fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

We should use the latest OpenSSL version for our static build.

Modifications:

Upgrade to 1.1.1a

Result:

Use latest OpenSSL version.