### PR TITLE
Introduce a new native method to access the master key

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -789,4 +789,34 @@ public final class SSL {
      * @return the signature algorithms or {@code null}.
      */
     public static native String[] getSigAlgs(long ssl);
+
+    /**
+     * Returns the master key used for the current ssl session.
+     * This should be used extremely sparingly as leaking this key defeats the whole purpose of encryption
+     * especially forward secrecy. This exists here strictly for debugging purposes.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the master key used for the ssl session
+     */
+    public static native byte[] getMasterKey(long ssl);
+
+    /**
+     * Extracts the random value sent from the server to the client during the initial SSL/TLS handshake.
+     * This is needed to extract the HMAC & keys from the master key according to the TLS PRF.
+     * <b>This is not a random number generator.</b>
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the random server value used for the ssl session
+     */
+    public static native byte[] getServerRandom(long ssl);
+
+    /**
+     * Extracts the random value sent from the client to the server during the initial SSL/TLS handshake.
+     * This is needed to extract the HMAC & keys from the master key according to the TLS PRF.
+     * <b>This is not a random number generator.</b>
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the random client value used for the ssl session
+     */
+    public static native byte[] getClientRandom(long ssl);
 }


### PR DESCRIPTION
This change accompanies the broader pull-request introduced by 
https://github.com/netty/netty/pull/8653 to allow access to the SSL session master key for debugging purposes.

Accessing the master key is useful if you ever need to decrypt the TLS session for debugging purposes with tools such as Wireshark.

Access of the field from the SSL session struct is direct as the wrapper method was only introduced in 1.1.0+  https://www.openssl.org/docs/man1.1.0/ssl/SSL_SESSION_get_master_key.html