### PR TITLE
Adding Automatic-Module-Name to all manifests.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -30,6 +30,23 @@
     to BoringSSL and Apache APR.
   </description>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>io.netty.tcnative.boringssl</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <profiles>
     <!-- Default profile that builds a platform-specific jar -->
     <profile>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -40,6 +40,22 @@
   </properties>
 
   <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>io.netty.tcnative.libressl</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
 
       <!-- Add the LibreSSL version to the manifest. -->

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -35,6 +35,22 @@
   </properties>
 
   <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>io.netty.tcnative.openssl.dynamic</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <!--
         Set the classifier property based on the settings of the os-detector-plugin.

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -38,6 +38,22 @@
   </properties>
 
   <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>io.netty.tcnative.openssl</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <!-- Add the OpenSSL version to the manifest. -->
       <plugin>


### PR DESCRIPTION
Motivation:

When the library is used as a JPMS dependency or transitive dependency
("tcnative-boringssl-static" for example), JVM attempts to trasform it
into a module and fails because "static" is a reserved word.

Modifications:

The change adds "Automatic-Module-Name" to manifests of all jar files.

Result:

JVM will use the "Automatic-Module-Name" instead of deriving the
module name from the jar file name.
The declared module name can also be used as a dependency name
in JPMS module declaration.