### PR TITLE
Update to latest JDK8 release.

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8.192"
+        java_version : "1.8.202"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "1.8.192"
+        java_version : "1.8.202"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
Motivation:

We should build with the latest JDK8 release.

Modifications:

Update JDK version.

Result:

Use latest JDK8 release on CI.