### PR TITLE
Use correct return value in certificate_cb for errors.

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1609,15 +1609,16 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
 }
 
 
+// See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html for return values.
 static int certificate_cb(SSL* ssl, void* arg) {
 #if defined(LIBRESSL_VERSION_NUMBER)
     // Not supported with LibreSSL
-    return -1;
+    return 0;
 #else
 #ifndef OPENSSL_IS_BORINGSSL
     if (OpenSSL_version_num() < 0x10002000L) {
         // Only supported on openssl 1.0.2+
-        return -1;
+        return 0;
     }
 #endif // OPENSSL_IS_BORINGSSL
 
@@ -1645,7 +1646,7 @@ static int certificate_cb(SSL* ssl, void* arg) {
 
     // Check if java threw an exception and if so signal back that we should not continue with the handshake.
     if ((*e)->ExceptionCheck(e)) {
-        return -1;
+        return 0;
     }
 
     // Everything good...


### PR DESCRIPTION
Motivation:

As explained in the SSL_set_cert_cb manpage 0 should be used to signal back errors. At the moment we use -1 which should only be used to signal back that the operation should be retried later.

See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html.

At the moment -1 also works as we not correctly handle SSL_ERROR_WANT_X509_LOOKUP in nettys ReferenceCountedOpenSslEngine and just treat SSL_ERROR_WANT_X509_LOOKUP as error (which is not correct).

Modifications:

Use 0 to signal a handshake error.

Result:

Use correct return value for errors.