### PR TITLE
Define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when compiling…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -194,7 +194,7 @@
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
                               <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
-                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized" />
+                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                             </then>
                           </elseif>
                           <else>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -194,6 +194,7 @@
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
                               <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                              <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                               <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                             </then>
                           </elseif>


### PR DESCRIPTION
… boringssl on linux to be able to build on centos6 again.

Motivation:

We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 since the following change in boringssl:

https://boringssl.googlesource.com/boringssl/+/ce455886958b61f4b350e46a6a1a764f325853e1

Modifications:

define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS

Result:

Compiling on centos6 works again