### PR TITLE
Support to offload certificate selection to different thread.

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -380,7 +380,6 @@ static void netty_internal_tcnative_Library_JNI_OnUnLoad(JNIEnv* env) {
     }
 
     TCN_UNLOAD_CLASS(env, byteArrayClass);
-
     netty_internal_tcnative_Error_JNI_OnUnLoad(env);
     netty_internal_tcnative_Buffer_JNI_OnUnLoad(env);
     netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(env);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -266,6 +266,15 @@ struct tcn_ssl_ctxt_t {
     apr_uint32_t             ticket_keys_fail;
 
     unsigned char            context_id[SHA_DIGEST_LENGTH];
+
+    int                      use_tasks;
+};
+
+// Store the callback to run and also if it was consumed via SSL.getTask(...).
+typedef struct tcn_ssl_task_t tcn_ssl_task_t;
+struct tcn_ssl_task_t {
+    jboolean consumed;
+    jobject task;
 };
 
 /*
@@ -282,6 +291,10 @@ void        tcn_SSL_set_app_data3(SSL *, void *);
 // This will initially point back to the tcn_ssl_ctxt_t in tcn_ssl_ctxt_t.
 void       *tcn_SSL_get_app_data4(SSL *);
 void        tcn_SSL_set_app_data4(SSL *, void *);
+// The app_data5 is used to store ssl_task.
+void       *tcn_SSL_get_app_data5(SSL *);
+void        tcn_SSL_set_app_data5(SSL *, void *);
+
 int         tcn_SSL_password_callback(char *, int, int, void *);
 DH         *tcn_SSL_dh_get_tmp_param(int);
 DH         *tcn_SSL_callback_tmp_DH(SSL *, int, int);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1681,6 +1681,12 @@ static int certificate_cb(SSL* ssl, void* arg) {
         jobject task = (*e)->NewObject(e, certificateCallbackTask_class, certificateCallbackTask_init, P2J(ssl), types, issuers, c->certificate_callback);
         sslTask = (tcn_ssl_task_t*) OPENSSL_malloc(sizeof(tcn_ssl_task_t));
         sslTask->task = (*e)->NewGlobalRef(e, task);
+        if (sslTask->task == NULL) {
+            // NewGlobalRef failed because we ran out of memory, free what we malloc'ed and fail the handshake.
+            OPENSSL_free(sslTask);
+
+            return 0;
+        }
         sslTask->consumed = JNI_FALSE;
 
         tcn_SSL_set_app_data5(ssl, sslTask);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -38,6 +38,14 @@
 #include <stdint.h>
 #include "sslcontext.h"
 
+
+static jclass    sslTask_class;
+static jfieldID  sslTask_returnValue;
+static jfieldID  sslTask_complete;
+
+static jclass    certificateCallbackTask_class;
+static jmethodID certificateCallbackTask_init;
+
 extern apr_pool_t *tcn_global_pool;
 
 static apr_status_t ssl_context_cleanup(void *data)
@@ -1628,8 +1636,34 @@ static int certificate_cb(SSL* ssl, void* arg) {
     jobjectArray issuers;
     JNIEnv *e;
     jbyteArray types;
+    tcn_ssl_task_t* sslTask = NULL;
 
     tcn_get_java_env(&e);
+
+    // Let's check if we retried the operation and so have stored a sslTask that runs the certificiate callback.
+    sslTask = tcn_SSL_get_app_data5(ssl);
+    if (sslTask != NULL) {
+        // Check if the task complete yet. If not the complete field will be still false.
+        if ((*e)->GetBooleanField(e, sslTask->task, sslTask_complete) == JNI_FALSE) {
+            // Not done yet, try again later.
+            return -1;
+        }
+
+        // The task is complete, retrieve the return value that should be signaled back.
+        jint ret = (*e)->GetIntField(e, sslTask->task, sslTask_returnValue);
+
+        // As we created a Global reference before we need to delete the reference as otherwise we will leak memory.
+        (*e)->DeleteGlobalRef(e, sslTask->task);
+        sslTask->task = NULL;
+
+        // The task was malloc'ed before, free it and clear it from the SSL storage.
+        OPENSSL_free(sslTask);
+        tcn_SSL_set_app_data5(ssl, NULL);
+
+        TCN_ASSERT(ret >= 0);
+
+        return ret;
+    }
 
     if (c->mode == SSL_MODE_SERVER) {
         // TODO: Consider filling these somehow.
@@ -1640,17 +1674,33 @@ static int certificate_cb(SSL* ssl, void* arg) {
         issuers = principalBytes(e, SSL_get_client_CA_list(ssl));
     }
 
-    // Execute the java callback
-    (*e)->CallVoidMethod(e, c->certificate_callback, c->certificate_callback_method,
-             P2J(ssl), types, issuers);
+    // Let's check if we should provide the certificate callback as task that can be run on another Thread.
+    if (c->use_tasks != 0) {
+        // Lets create the CertificateCallbackTask and store it on the SSL object. We then later retrieve it via
+        // SSL.getTask(ssl) and run it.
+        jobject task = (*e)->NewObject(e, certificateCallbackTask_class, certificateCallbackTask_init, P2J(ssl), types, issuers, c->certificate_callback);
+        sslTask = (tcn_ssl_task_t*) OPENSSL_malloc(sizeof(tcn_ssl_task_t));
+        sslTask->task = (*e)->NewGlobalRef(e, task);
+        sslTask->consumed = JNI_FALSE;
 
-    // Check if java threw an exception and if so signal back that we should not continue with the handshake.
-    if ((*e)->ExceptionCheck(e)) {
-        return 0;
+        tcn_SSL_set_app_data5(ssl, sslTask);
+
+        // Signal back that we want to suspend the handshake.
+        return -1;
+    } else {
+        // Execute the java callback
+        (*e)->CallVoidMethod(e, c->certificate_callback, c->certificate_callback_method,
+                 P2J(ssl), types, issuers);
+
+        // Check if java threw an exception and if so signal back that we should not continue with the handshake.
+        if ((*e)->ExceptionCheck(e)) {
+            return 0;
+        }
+
+        // Everything good...
+        return 1;
     }
 
-    // Everything good...
-    return 1;
 #endif /* defined(LIBRESSL_VERSION_NUMBER) */
 }
 
@@ -1896,6 +1946,14 @@ TCN_IMPLEMENT_CALL(void, SSLContext, disableOcsp)(TCN_STDARGS, jlong ctx) {
 #endif
 }
 
+TCN_IMPLEMENT_CALL(void, SSLContext, setUseTasks)(TCN_STDARGS, jlong ctx, jboolean useTasks) {
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    TCN_CHECK_NULL(c, ctx, /* void */);
+
+    c->use_tasks = useTasks == JNI_TRUE ? 1 : 0;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(make, (II)J, SSLContext) },
@@ -1948,7 +2006,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getMode, (J)I, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(enableOcsp, (JZ)V, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(disableOcsp, (J)V, SSLContext) },
-  { TCN_METHOD_TABLE_ENTRY(getSslCtx, (J)J, SSLContext) }
+  { TCN_METHOD_TABLE_ENTRY(getSslCtx, (J)J, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setUseTasks, (JZ)V, SSLContext) }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
@@ -2012,8 +2071,29 @@ jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* pack
     }
     freeDynamicMethodsTable(dynamicMethods);
 
+    char* sslTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLTask");
+    TCN_LOAD_CLASS(env, sslTask_class, sslTaskName, JNI_ERR);
+    free(sslTaskName);
+
+    TCN_GET_FIELD(env, sslTask_class, sslTask_returnValue, "returnValue", "I", JNI_ERR);
+    TCN_GET_FIELD(env, sslTask_class, sslTask_complete, "complete", "Z", JNI_ERR);
+
+    char* certificateCallbackTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateCallbackTask");
+    TCN_LOAD_CLASS(env, certificateCallbackTask_class, certificateCallbackTaskName, JNI_ERR);
+    free(certificateCallbackTaskName);
+
+    char* certificateCallbackName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateCallback;)V");
+    char* initArguments = netty_internal_tcnative_util_prepend("(J[B[[BL", certificateCallbackName);
+    free(certificateCallbackName);
+
+    TCN_GET_METHOD(env, certificateCallbackTask_class, certificateCallbackTask_init,
+                   "<init>", initArguments, JNI_ERR);
+    free(initArguments);
+
     return TCN_JNI_VERSION;
 }
 
 void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env) {
+    TCN_UNLOAD_CLASS(env, sslTask_class);
+    TCN_UNLOAD_CLASS(env, certificateCallbackTask_class);
 }

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -167,6 +167,8 @@ const char* tcn_SSL_cipher_authentication_method(const SSL_CIPHER* cipher){
 static int tcn_SSL_app_data2_idx = -1;
 static int tcn_SSL_app_data3_idx = -1;
 static int tcn_SSL_app_data4_idx = -1;
+static int tcn_SSL_app_data5_idx = -1;
+
 void tcn_SSL_init_app_data_idx()
 {
     int i;
@@ -184,6 +186,10 @@ void tcn_SSL_init_app_data_idx()
 
     if (tcn_SSL_app_data4_idx == -1) {
         tcn_SSL_app_data4_idx = SSL_get_ex_new_index(0, "tcn_ssl_verify_config_t*", NULL, NULL, NULL);
+    }
+
+    if (tcn_SSL_app_data5_idx == -1) {
+        tcn_SSL_app_data5_idx = SSL_get_ex_new_index(0, "tcn_ssl_task*", NULL, NULL, NULL);
     }
 }
 
@@ -216,6 +222,16 @@ void *tcn_SSL_get_app_data4(SSL *ssl)
 void tcn_SSL_set_app_data4(SSL *ssl, void *arg)
 {
     SSL_set_ex_data(ssl, tcn_SSL_app_data4_idx, arg);
+}
+
+void *tcn_SSL_get_app_data5(SSL *ssl)
+{
+    return SSL_get_ex_data(ssl, tcn_SSL_app_data5_idx);
+}
+
+void tcn_SSL_set_app_data5(SSL *ssl, void *arg)
+{
+    SSL_set_ex_data(ssl, tcn_SSL_app_data5_idx, arg);
 }
 
 int tcn_SSL_password_callback(char *buf, int bufsiz, int verify,

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallbackTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallbackTask.java
@@ -25,6 +25,7 @@ final class CertificateCallbackTask extends SSLTask {
 
     CertificateCallbackTask(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals,
                             CertificateCallback callback) {
+        // It is important that this constructor never throws. Be sure to not change this!
         super(ssl);
         // It's ok to not clone the arrays as we create these in JNI and not-reuse.
         this.keyTypeBytes = keyTypeBytes;
@@ -39,6 +40,9 @@ final class CertificateCallbackTask extends SSLTask {
             callback.handle(ssl, keyTypeBytes, asn1DerEncodedPrincipals);
             return 1;
         } catch (Exception e) {
+            // Just catch the exception and return 0 to fail the handshake.
+            // The problem is that rethrowing here is really "useless" as we will process it as part of an openssl
+            // c callback which needs to return 0 for an error to abort the handshake.
             return 0;
         }
     }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallbackTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallbackTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Execute {@link CertificateCallback#handle(long, byte[], byte[][])}.
+ */
+final class CertificateCallbackTask extends SSLTask {
+    private final byte[] keyTypeBytes;
+    private final byte[][] asn1DerEncodedPrincipals;
+    private final CertificateCallback callback;
+
+    CertificateCallbackTask(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals,
+                            CertificateCallback callback) {
+        super(ssl);
+        // It's ok to not clone the arrays as we create these in JNI and not-reuse.
+        this.keyTypeBytes = keyTypeBytes;
+        this.asn1DerEncodedPrincipals = asn1DerEncodedPrincipals;
+        this.callback = callback;
+    }
+
+    // See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html.
+    @Override
+    protected int runTask(long ssl) {
+        try {
+            callback.handle(ssl, keyTypeBytes, asn1DerEncodedPrincipals);
+            return 1;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -819,4 +819,13 @@ public final class SSL {
      * @return the random client value used for the ssl session
      */
     public static native byte[] getClientRandom(long ssl);
+
+    /**
+     * Return the {@link Runnable} thats needs to be run as an operation returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
+     * After the task was run we should retry the operations that returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the task to run.
+     */
+    public static native Runnable getTask(long ssl);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -602,4 +602,12 @@ public final class SSLContext {
      * Returns the {@code SSL_CTX}.
      */
     public static native long getSslCtx(long ctx);
+
+    /**
+     * Enable or disable producing of tasks that should be obtained via {@link SSL#getTask(int)} and run.
+     *
+     * @param ctx context to use
+     * @param useTasks {@code true} to enable, {@code false} to disable.
+     */
+    public static native void setUseTasks(long ctx, boolean useTasks);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * A SSL related task that will be returned by {@link SSL#getTask(int)}
+ */
+abstract class SSLTask implements Runnable {
+
+    private final long ssl;
+
+    // These fields are accessed via JNI.
+    private int returnValue;
+    private boolean complete;
+
+    protected SSLTask(long ssl) {
+        this.ssl = ssl;
+    }
+
+    @Override
+    public final void run() {
+        if (!complete) {
+            complete = true;
+            returnValue = runTask(ssl);
+        }
+    }
+
+    /**
+     * Run the task and return the return value that should be passed back to OpenSSL.
+     */
+    protected abstract int runTask(long ssl);
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLTask.java
@@ -27,6 +27,7 @@ abstract class SSLTask implements Runnable {
     private boolean complete;
 
     protected SSLTask(long ssl) {
+        // It is important that this constructor never throws. Be sure to not change this!
         this.ssl = ssl;
     }
 


### PR DESCRIPTION
Motiviation:

Sometimes selection of the certificate can take a long time as it may be stored on a remote system (for example). We should support to offload selection of the certificate to an other thread and be able to retry the SSL operation after it is done.

This will also allow us to support the SSLEngine abstraction of SSLEngine.getDelegatingTask() and SSLEngineResult.HandshakeStatus.NEED_TASK.

Modification:

- Introduce SSLContest.setUseTasks(...) which allows to enable / disable the usage of tasks to offload certificate selection to an other thread.
- Introduce SSL.getTask(...) which allows to retrieve the task that will do the certificate selection ( and also other tasks in the future )

Result:

Be able to execute long running tasks for certificate selection ( and also others in the future) without blocking the I/O thread.