### PR TITLE
Correctly init all fields of struct after malloc it.

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1681,6 +1681,7 @@ static int certificate_cb(SSL* ssl, void* arg) {
         jobject task = (*e)->NewObject(e, certificateCallbackTask_class, certificateCallbackTask_init, P2J(ssl), types, issuers, c->certificate_callback);
         sslTask = (tcn_ssl_task_t*) OPENSSL_malloc(sizeof(tcn_ssl_task_t));
         sslTask->task = (*e)->NewGlobalRef(e, task);
+        sslTask->consumed = JNI_FALSE;
         if (sslTask->task == NULL) {
             // NewGlobalRef failed because we ran out of memory, free what we malloc'ed and fail the handshake.
             OPENSSL_free(sslTask);


### PR DESCRIPTION
Motivation:

In 11120b2d81fdc7de4619c904fc73622f77824ac8 we introduced the notion of offload operations as tasks but failed to ensure we init all fields of tcn_ssl_task_t. This can lead to strange side-effects if the OPENSSL_malloc(...) implementation does not memset.

Modifications:

Correctly init consumed to JNI_FALSE.

Result:

Correctly init struct.