### PR TITLE
Allow to offload certificate validation when using BoringSSL

### DIFF
--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -480,6 +480,11 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, x509vErrDaneNoMat
 #endif
 }
 
+// BoringSSL specific
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslErrorWantCertificateVerify)(TCN_STDARGS) {
+    return SSL_ERROR_WANT_CERTIFICATE_VERIFY;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpCipherServerPreference, ()I, NativeStaticallyReferencedJniMethods) },
@@ -580,7 +585,9 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(x509vErrHostnameMismatch, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509vErrEmailMismatch, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509vErrIpAddressMismatch, ()I, NativeStaticallyReferencedJniMethods) },
-  { TCN_METHOD_TABLE_ENTRY(x509vErrDaneNoMatch, ()I, NativeStaticallyReferencedJniMethods) }
+  { TCN_METHOD_TABLE_ENTRY(x509vErrDaneNoMatch, ()I, NativeStaticallyReferencedJniMethods) },
+  // BoringSSL specific
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantCertificateVerify, ()I, NativeStaticallyReferencedJniMethods) }
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -199,6 +199,11 @@ extern void *SSL_temp_keys[SSL_TMP_KEY_MAX];
 #define SSL_CTRL_GET_CLIENT_CERT_TYPES          103
 #endif
 
+#ifndef SSL_ERROR_WANT_CERTIFICATE_VERIFY
+// See https://github.com/google/boringssl/blob/chromium-stable/include/openssl/ssl.h#L538
+#define SSL_ERROR_WANT_CERTIFICATE_VERIFY       -1
+#endif
+
 typedef struct tcn_ssl_ctxt_t tcn_ssl_ctxt_t;
 
 typedef struct {

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateVerifierTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateVerifierTask.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+
+/**
+ * Execute {@link CertificateVerifier#verify(long, byte[][], String)}.
+ */
+final class CertificateVerifierTask extends SSLTask {
+    private final byte[][] x509;
+    private final String authAlgorithm;
+    private final CertificateVerifier verifier;
+
+    CertificateVerifierTask(long ssl, byte[][] x509, String authAlgorithm, CertificateVerifier verifier) {
+        super(ssl);
+        this.x509 = x509;
+        this.authAlgorithm = authAlgorithm;
+        this.verifier = verifier;
+    }
+
+    @Override
+    protected int runTask(long ssl) {
+        return verifier.verify(ssl, x509, authAlgorithm);
+    }
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -146,4 +146,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int x509vErrEmailMismatch();
     static native int x509vErrIpAddressMismatch();
     static native int x509vErrDaneNoMatch();
+
+    // BoringSSL specific.
+    static native int sslErrorWantCertificateVerify();
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -157,6 +157,9 @@ public final class SSL {
     public static final int SSL_ERROR_WANT_CONNECT     = sslErrorWantConnect();
     public static final int SSL_ERROR_WANT_ACCEPT      = sslErrorWantAccept();
 
+    // BoringSSL specific
+    public static final int SSL_ERROR_WANT_CERTIFICATE_VERIFY = sslErrorWantCertificateVerify();
+
     /**
      * SSL_new
      * @param ctx Server or Client context to use.


### PR DESCRIPTION
Motivation:

BoringSSL supports offloading certificate validation to a different thread. This is useful as it may need to do blocking operations and so may block the EventLoop.

Modification:

Add BoringSSL specific code which allows to offload certificate validation (just as we already have code for certificate selection).

Result:

Be able to offload certificate validation when using BoringSSL.