### PR TITLE
Remove version checks for runtime version of OpenSSL as these do not …

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2103,14 +2103,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
 #if defined(LIBRESSL_VERSION_NUMBER)
     tcn_Throw(e, "Not supported with LibreSSL");
 #else
-#ifndef OPENSSL_IS_BORINGSSL
-    if (OpenSSL_version_num() < 0x10002000L) {
-        // Only supported on openssl 1.0.2+
-        tcn_Throw(e, "Only supported with OpenSSL >= 1.0.2");
-        return;
-    }
-#endif // OPENSSL_IS_BORINGSSL
-
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
@@ -2173,14 +2165,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterialClientSide)(TCN_STDARGS, jlong ssl, 
 #if defined(LIBRESSL_VERSION_NUMBER)
     tcn_Throw(e, "Not supported with LibreSSL");
 #else
-#ifndef OPENSSL_IS_BORINGSSL
-    if (OpenSSL_version_num() < 0x10002000L) {
-        // Only supported on openssl 1.0.2+
-        tcn_Throw(e, "Only supported with OpenSSL >= 1.0.2");
-        return;
-    }
-#endif // OPENSSL_IS_BORINGSSL
-
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1560,13 +1560,6 @@ static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     // Not supported with LibreSSL
     return -1;
 #else
-#ifndef OPENSSL_IS_BORINGSSL
-    if (OpenSSL_version_num() < 0x10002000L) {
-        // Only supported on openssl 1.0.2+
-        return -1;
-    }
-#endif // OPENSSL_IS_BORINGSSL
-
     tcn_ssl_ctxt_t *c = tcn_SSL_get_app_data2(ssl);
     jobjectArray issuers;
     JNIEnv *e;
@@ -1631,13 +1624,6 @@ static int certificate_cb(SSL* ssl, void* arg) {
     // Not supported with LibreSSL
     return 0;
 #else
-#ifndef OPENSSL_IS_BORINGSSL
-    if (OpenSSL_version_num() < 0x10002000L) {
-        // Only supported on openssl 1.0.2+
-        return 0;
-    }
-#endif // OPENSSL_IS_BORINGSSL
-
     tcn_ssl_ctxt_t *c = tcn_SSL_get_app_data2(ssl);
     TCN_ASSERT(c != NULL);
 

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -552,13 +552,6 @@ int tcn_SSL_use_certificate_chain_bio(SSL *ssl, BIO *bio, bool skipfirst)
     unsigned long err;
     int n;
 
-#ifndef OPENSSL_IS_BORINGSSL
-    if (OpenSSL_version_num() < 0x10002000L) {
-        // Only supported on openssl 1.0.2+
-       return -1;
-    }
-#endif
-
     /* optionally skip a leading server certificate */
     if (skipfirst) {
         if ((x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL)) == NULL) {


### PR DESCRIPTION
…work on RHEL

Motivation:

We tried to detect if KeyManagerFactory can be supported by checking the runtime version of OpenSSL. This unfortunally does not work on RHEL as it always returns the compile time version of OpenSSL.

See https://bugzilla.redhat.com/show_bug.cgi?id=1497859

It turns out we not need these checks at all as we correctly shim all the calls that only exists in certain OpenSSL versions and will fail if these are not supported.

Modifications:

Remove runtime version checks and just depend on the fact that the calls will fail.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/434.