### PR TITLE
Update OpenSSL to 1.1.1b and LibreSSL to 2.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,15 +56,15 @@
     <aprVersion>1.6.5</aprVersion>
     <aprSha256>70dcf9102066a2ff2ffc47e93c289c8e54c95d8dda23b503f9e61bb0cbd2d105</aprSha256>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.8.2</libresslVersion>
+    <libresslVersion>2.8.3</libresslVersion>
     <!--
       See https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/SHA256 for the SHA256 signature
     -->
-    <libresslSha256>b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5</libresslSha256>
+    <libresslSha256>9b640b13047182761a99ce3e4f000be9687566e0828b4a72709e9e6a3ef98477</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>a</opensslPatchVersion>
+    <opensslPatchVersion>b</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41</opensslSha256>
+    <opensslSha256>ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

There were new version of OpenSSL and LibreSSL released.

Modifications:

Update versions for the static builds.

Result:

Use latest versions on static builds.