### PR TITLE
Define env variables to use when use shell with docker-compose

### DIFF
--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -23,6 +23,9 @@ services:
 
   shell:
     <<: *common
+    environment:
+      - SANOTYPE_USER
+      - SANOTYPE_PASSWORD
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -23,6 +23,9 @@ services:
 
   shell:
     <<: *common
+    environment:
+      - SANOTYPE_USER
+      - SANOTYPE_PASSWORD
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg


### PR DESCRIPTION
Motivation:

001d915209fe85cc6716b781f2fe25b5498c36f2 introduced settings.xml to use to deploy snapshots via CI but missed to also define env variables that will be used by docker-compose.

Modifications:

Define env variables to use.

Result:

Deploy snapshots via CI works as expected.