### PR TITLE
Use CRYPTO_BUFFER when using BoringSSL to reduce memory usage and ove…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -202,6 +202,7 @@ static char* netty_internal_tcnative_util_rstrstr(char* s1rbegin, const char* s1
     return NULL;
 }
 
+#ifdef _WIN32
 static char* netty_internal_tcnative_util_rstrchar(char* s1rbegin, const char* s1rend, const char c2) {
     for (; s1rbegin >= s1rend; --s1rbegin) {
         if (*s1rbegin == c2) {
@@ -210,6 +211,7 @@ static char* netty_internal_tcnative_util_rstrchar(char* s1rbegin, const char* s
     }
     return NULL;
 }
+#endif // _WIN32
 
 static char* netty_internal_tcnative_util_strstr_last(const char* haystack, const char* needle) {
     char* prevptr = NULL;

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -607,7 +607,10 @@ public final class SSL {
      * @param bio BIO of PEM-encoded Server CA Certificates.
      * @param skipfirst Skip first certificate if chain file is inside
      *                  certificate file.
+     *
+     * @deprecated use {@link #setKeyMaterial(long, long, long)}
      */
+    @Deprecated
     public static native void setCertificateChainBio(long ssl, long bio, boolean skipfirst);
 
     /**
@@ -631,7 +634,10 @@ public final class SSL {
      * @param password Certificate password. If null and certificate
      *                 is encrypted.
      * @throws Exception if an error happened
+     *
+     * @deprecated use {@link #setKeyMaterial(long, long, long)}
      */
+    @Deprecated
     public static native void setCertificateBio(
             long ssl, long certBio, long keyBio, String password) throws Exception;
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -506,7 +506,9 @@ public final class SSLContext {
      * callback used by openssl
      * @param ctx Server or Client context to use.
      * @param callback the callback to call during certificate selection.
+     * @deprecated use {@link #setCertificateCallback(long, CertificateCallback)}
      */
+    @Deprecated
     public static native void setCertRequestedCallback(long ctx, CertificateRequestedCallback callback);
 
     /**


### PR DESCRIPTION
…rhead of parsing certificates

Motivation:

BoringSSL added support for CRYPTO_BUFFER [1] which allows to reduce the overhead of storing certificates in memory by "de-duplicate" these (as a lot of these are the same across multiple connections). Beside the memory savings using CRYPTO_BUFFER also allows us to reduce the overhead to convert from native SSL certificate representation to the Java based representation as we do not need to serialize from X509 to bytes first all the time.

[1] https://github.com/google/boringssl/blob/chromium-stable/PORTING.md#crypto_buffer

Modifications:

- When using BoringSSL do not use functions that make use of the X509* parts of the library but use the replacements that use CRYPTO_BUFFER
- When using BoringSSL use TLS_with_buffers_method() which guarantees that we do not call any functions that depend on the X509* parts of the lib.

Result:

Less overhead when using BoringSSL