### PR TITLE
Allow to implement custom private key signing mechanisms when using B…

### DIFF
--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -485,6 +485,62 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslErrorWantCerti
     return SSL_ERROR_WANT_CERTIFICATE_VERIFY;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslErrorWantPrivateKeyOperation)(TCN_STDARGS) {
+    return SSL_ERROR_WANT_PRIVATE_KEY_OPERATION;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcsSha1)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PKCS1_SHA1;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcsSha256)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PKCS1_SHA256;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcsSha384)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PKCS1_SHA384;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcsSha512)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PKCS1_SHA512;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignEcdsaPkcsSha1)(TCN_STDARGS) {
+    return SSL_SIGN_ECDSA_SHA1;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignEcdsaSecp256r1Sha256)(TCN_STDARGS) {
+    return SSL_SIGN_ECDSA_SECP256R1_SHA256;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignEcdsaSecp384r1Sha384)(TCN_STDARGS) {
+    return SSL_SIGN_ECDSA_SECP384R1_SHA384;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignEcdsaSecp521r1Sha512)(TCN_STDARGS) {
+    return SSL_SIGN_ECDSA_SECP521R1_SHA512;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPssRsaeSha256)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PSS_RSAE_SHA256;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPssRsaeSha384)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PSS_RSAE_SHA384;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPssRsaeSha512)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PSS_RSAE_SHA512;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignEd25519)(TCN_STDARGS) {
+    return SSL_SIGN_ED25519;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcs1Md5Sha1)(TCN_STDARGS) {
+    return SSL_SIGN_RSA_PKCS1_MD5_SHA1;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpCipherServerPreference, ()I, NativeStaticallyReferencedJniMethods) },
@@ -587,7 +643,21 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(x509vErrIpAddressMismatch, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509vErrDaneNoMatch, ()I, NativeStaticallyReferencedJniMethods) },
   // BoringSSL specific
-  { TCN_METHOD_TABLE_ENTRY(sslErrorWantCertificateVerify, ()I, NativeStaticallyReferencedJniMethods) }
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantCertificateVerify, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslErrorWantPrivateKeyOperation, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcsSha1, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcsSha256, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcsSha384, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcsSha512, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignEcdsaPkcsSha1, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignEcdsaSecp256r1Sha256, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignEcdsaSecp384r1Sha384, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignEcdsaSecp521r1Sha512, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPssRsaeSha256, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPssRsaeSha384, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPssRsaeSha512, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignEd25519, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcs1Md5Sha1, ()I, NativeStaticallyReferencedJniMethods) }
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2261,7 +2261,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         certs[i] = sk_CRYPTO_BUFFER_value(cchain, i);
     }
 
-    if (numCerts <= 0 || SSL_set_chain_and_key(ssl_, certs, numCerts, pkey, NULL) <= 0) {
+    if (numCerts <= 0 || SSL_set_chain_and_key(ssl_, certs, numCerts, pkey, pkey == NULL ? &private_key_method : NULL) <= 0) {
 #else
     // SSL_use_certificate will increment the reference count of the cert.
     if (numCerts <= 0 || SSL_use_certificate(ssl_, sk_X509_value(cchain, 0)) <= 0) {

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -183,6 +183,67 @@ extern void *SSL_temp_keys[SSL_TMP_KEY_MAX];
 #define TCN_X509_V_ERR_UNSPECIFIED (X509_V_ERR_UNSPECIFIED)
 #endif /*X509_V_ERR_UNSPECIFIED*/
 
+// BoringSSL compat
+#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SSL_ERROR_WANT_PRIVATE_KEY_OPERATION
+#define SSL_ERROR_WANT_PRIVATE_KEY_OPERATION -1
+#endif // SSL_ERROR_WANT_PRIVATE_KEY_OPERATION
+
+// SSL_SIGN_* are signature algorithm values as defined in TLS 1.3.
+#ifndef SSL_SIGN_RSA_PKCS1_SHA1
+#define SSL_SIGN_RSA_PKCS1_SHA1 0x0201
+#endif // SSL_SIGN_RSA_PKCS1_SHA1
+
+#ifndef SSL_SIGN_RSA_PKCS1_SHA256
+#define SSL_SIGN_RSA_PKCS1_SHA256 0x0401
+#endif // SSL_SIGN_RSA_PKCS1_SHA256
+
+#ifndef SSL_SIGN_RSA_PKCS1_SHA384
+#define SSL_SIGN_RSA_PKCS1_SHA384 0x0501
+#endif // SSL_SIGN_RSA_PKCS1_SHA384
+
+#ifndef SSL_SIGN_RSA_PKCS1_SHA512
+#define SSL_SIGN_RSA_PKCS1_SHA512 0x0601
+#endif // SSL_SIGN_RSA_PKCS1_SHA512
+
+#ifndef SSL_SIGN_ECDSA_SHA1
+#define SSL_SIGN_ECDSA_SHA1 0x0203
+#endif // SSL_SIGN_ECDSA_SHA1
+
+#ifndef SSL_SIGN_ECDSA_SECP256R1_SHA256
+#define SSL_SIGN_ECDSA_SECP256R1_SHA256 0x0403
+#endif // SSL_SIGN_ECDSA_SECP256R1_SHA256
+
+#ifndef SSL_SIGN_ECDSA_SECP384R1_SHA384
+#define SSL_SIGN_ECDSA_SECP384R1_SHA384 0x0503
+#endif // SSL_SIGN_ECDSA_SECP384R1_SHA384
+
+#ifndef SSL_SIGN_ECDSA_SECP521R1_SHA512
+#define SSL_SIGN_ECDSA_SECP521R1_SHA512 0x0603
+#endif
+
+#ifndef SSL_SIGN_RSA_PSS_RSAE_SHA256
+#define SSL_SIGN_RSA_PSS_RSAE_SHA256 0x0804
+#endif // SSL_SIGN_RSA_PSS_RSAE_SHA256
+
+#ifndef SSL_SIGN_RSA_PSS_RSAE_SHA384
+#define SSL_SIGN_RSA_PSS_RSAE_SHA384 0x0805
+#endif // SSL_SIGN_RSA_PSS_RSAE_SHA384
+
+#ifndef SSL_SIGN_RSA_PSS_RSAE_SHA512
+#define SSL_SIGN_RSA_PSS_RSAE_SHA512 0x0806
+#endif // SSL_SIGN_RSA_PSS_RSAE_SHA512
+
+#ifndef SSL_SIGN_ED25519
+#define SSL_SIGN_ED25519 0x0807
+#endif // SSL_SIGN_ED25519
+
+#ifndef SSL_SIGN_RSA_PKCS1_MD5_SHA1
+#define SSL_SIGN_RSA_PKCS1_MD5_SHA1 0xff01
+#endif // SSL_SIGN_RSA_PKCS1_MD5_SHA1
+
+#endif // OPENSSL_IS_BORINGSSL
+
 // OCSP stapling should be present in OpenSSL as of version 1.0.0 but
 // we've only tested 1.0.2 and we need to support 1.0.1 because the
 // dynamically linked version of netty-tcnative is built with 1.0.1.
@@ -217,6 +278,10 @@ typedef struct {
     int verify_mode;
 } tcn_ssl_verify_config_t;
 
+#ifdef OPENSSL_IS_BORINGSSL
+extern const SSL_PRIVATE_KEY_METHOD private_key_method;
+#endif // OPENSSL_IS_BORINGSSL
+
 struct tcn_ssl_ctxt_t {
     apr_pool_t*              pool;
     SSL_CTX*                 ctx;
@@ -243,6 +308,12 @@ struct tcn_ssl_ctxt_t {
 
     jobject                  sni_hostname_matcher;
     jmethodID                sni_hostname_matcher_method;
+
+#ifdef OPENSSL_IS_BORINGSSL
+    jobject                  ssl_private_key_method;
+    jmethodID                ssl_private_key_sign_method;
+    jmethodID                ssl_private_key_decrypt_method;
+#endif // OPENSSL_IS_BORINGSSL
 
     tcn_ssl_verify_config_t  verify_config;
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -22,7 +22,7 @@ package io.netty.internal.tcnative;
  * <li>JNI Calls FindClass because RegisterNatives (used to register JNI methods) requires a class</li>
  * <li>FindClass loads the class, but static members variables of that class attempt to call a JNI method which has not
  * yet been registered.</li>
- * <li>{@link java.lang.UnsatisfiedLinkError} is thrown because native method has not yet been registered.</li>
+ * <li>{@link UnsatisfiedLinkError} is thrown because native method has not yet been registered.</li>
  * </ol>
  * <strong>Static members which call JNI methods must not be declared in this class!</strong>
  */
@@ -149,4 +149,18 @@ final class NativeStaticallyReferencedJniMethods {
 
     // BoringSSL specific.
     static native int sslErrorWantCertificateVerify();
+    static native int sslErrorWantPrivateKeyOperation();
+    static native int sslSignRsaPkcsSha1();
+    static native int sslSignRsaPkcsSha256();
+    static native int sslSignRsaPkcsSha384();
+    static native int sslSignRsaPkcsSha512();
+    static native int sslSignEcdsaPkcsSha1();
+    static native int sslSignEcdsaSecp256r1Sha256();
+    static native int sslSignEcdsaSecp384r1Sha384();
+    static native int sslSignEcdsaSecp521r1Sha512();
+    static native int sslSignRsaPssRsaeSha256();
+    static native int sslSignRsaPssRsaeSha384();
+    static native int sslSignRsaPssRsaeSha512();
+    static native int sslSignEd25519();
+    static native int sslSignRsaPkcs1Md5Sha1();
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -156,6 +156,8 @@ public final class SSL {
     public static final int SSL_ERROR_ZERO_RETURN      = sslErrorZeroReturn();
     public static final int SSL_ERROR_WANT_CONNECT     = sslErrorWantConnect();
     public static final int SSL_ERROR_WANT_ACCEPT      = sslErrorWantAccept();
+    // https://boringssl.googlesource.com/boringssl/+/chromium-stable/include/openssl/ssl.h#519
+    public static final int SSL_ERROR_WANT_PRIVATE_KEY_OPERATION = sslErrorWantPrivateKeyOperation();
 
     // BoringSSL specific
     public static final int SSL_ERROR_WANT_CERTIFICATE_VERIFY = sslErrorWantCertificateVerify();

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -606,10 +606,21 @@ public final class SSLContext {
     public static native long getSslCtx(long ctx);
 
     /**
-     * Enable or disable producing of tasks that should be obtained via {@link SSL#getTask(int)} and run.
+     * Enable or disable producing of tasks that should be obtained via {@link SSL#getTask(long)} and run.
      *
      * @param ctx context to use
      * @param useTasks {@code true} to enable, {@code false} to disable.
      */
     public static native void setUseTasks(long ctx, boolean useTasks);
+
+    /**
+     * Set the {@link SSLPrivateKeyMethod} to use for the given {@link SSLContext}. This allows to offload privatekey operations
+     * if needed.
+     *
+     * This method is currently only supported when {@code BoringSSL} is used.
+     *
+     * @param ctx context to use
+     * @param method method to use for the given context.
+     */
+    public static native void setPrivateKeyMethod(long ctx, SSLPrivateKeyMethod method);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethod.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethod.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Allows to customize private key signing / decrypt (when using RSA).
+ */
+public interface SSLPrivateKeyMethod {
+    int SSL_SIGN_RSA_PKCS1_SHA1 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha1();
+    int SSL_SIGN_RSA_PKCS1_SHA256 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha256();
+    int SSL_SIGN_RSA_PKCS1_SHA384 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha384();
+    int SSL_SIGN_RSA_PKCS1_SHA512 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha512();
+    int SSL_SIGN_ECDSA_SHA1 = NativeStaticallyReferencedJniMethods.sslSignEcdsaPkcsSha1();
+    int SSL_SIGN_ECDSA_SECP256R1_SHA256 = NativeStaticallyReferencedJniMethods.sslSignEcdsaSecp256r1Sha256();
+    int SSL_SIGN_ECDSA_SECP384R1_SHA384 = NativeStaticallyReferencedJniMethods.sslSignEcdsaSecp384r1Sha384();
+    int SSL_SIGN_ECDSA_SECP521R1_SHA512 = NativeStaticallyReferencedJniMethods.sslSignEcdsaSecp521r1Sha512();
+    int SSL_SIGN_RSA_PSS_RSAE_SHA256 = NativeStaticallyReferencedJniMethods.sslSignRsaPssRsaeSha256();
+    int SSL_SIGN_RSA_PSS_RSAE_SHA384 = NativeStaticallyReferencedJniMethods.sslSignRsaPssRsaeSha384();
+    int SSL_SIGN_RSA_PSS_RSAE_SHA512 = NativeStaticallyReferencedJniMethods.sslSignRsaPssRsaeSha512();
+    int SSL_SIGN_ED25519 = NativeStaticallyReferencedJniMethods.sslSignEd25519();
+    int SSL_SIGN_RSA_PKCS1_MD5_SHA1 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcs1Md5Sha1();
+
+    /**
+     * Sign the input with given EC key and returns the signed bytes.
+     *
+     * @param ssl                   the SSL instance
+     * @param signatureAlgorithm    the algorithm to use for signing
+     * @param input                 the input itself
+     * @return                      the sign
+     * @throws Exception            thrown if an error accours while signing.
+     */
+    byte[] sign(long ssl, int signatureAlgorithm, byte[] input) throws Exception;
+
+    /**
+     * Decrypts the input with the given RSA key and returns the decrypted bytes.
+     *
+     * @param ssl                   the SSL instance
+     * @param input                 the input which should be decrypted
+     * @return                      the decrypted data
+     * @throws Exception            thrown if an error accours while decrypting.
+     */
+    byte[] decrypt(long ssl, byte[] input) throws Exception;
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodDecryptTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodDecryptTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+final class SSLPrivateKeyMethodDecryptTask extends SSLPrivateKeyMethodTask {
+
+    private final byte[] input;
+
+    SSLPrivateKeyMethodDecryptTask(long ssl, byte[] input, SSLPrivateKeyMethod method) {
+        super(ssl, method);
+        // It's OK to not clone the arrays as we create these in JNI and not reuse.
+        this.input = input;
+    }
+
+    @Override
+    protected byte[] runTask(long ssl, SSLPrivateKeyMethod method) throws Exception {
+        return method.decrypt(ssl, input);
+    }
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+final class SSLPrivateKeyMethodSignTask extends SSLPrivateKeyMethodTask {
+    private final int signatureAlgorithm;
+    private final byte[] digest;
+
+    SSLPrivateKeyMethodSignTask(long ssl, int signatureAlgorithm, byte[] digest, SSLPrivateKeyMethod method) {
+        super(ssl, method);
+        this.signatureAlgorithm = signatureAlgorithm;
+        // It's OK to not clone the arrays as we create these in JNI and not reuse.
+        this.digest = digest;
+    }
+
+    @Override
+    protected byte[] runTask(long ssl, SSLPrivateKeyMethod method) throws Exception {
+        return method.sign(ssl, signatureAlgorithm, digest);
+    }
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodTask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+abstract class SSLPrivateKeyMethodTask extends SSLTask {
+    private static final byte[] EMPTY = new byte[0];
+    private final SSLPrivateKeyMethod method;
+
+    // Will be accessed via JNI.
+    private byte[] resultBytes;
+
+    SSLPrivateKeyMethodTask(long ssl, SSLPrivateKeyMethod method) {
+        super(ssl);
+        this.method = method;
+    }
+
+    @Override
+    protected final int runTask(long ssl) {
+        try {
+            resultBytes = runTask(ssl, method);
+            return 1;
+        } catch (Exception e) {
+            // Return 0 as this signals back that the operation failed.
+            resultBytes = EMPTY;
+            return 0;
+        }
+    }
+
+    protected abstract byte[] runTask(long ssl, SSLPrivateKeyMethod method) throws Exception;
+}


### PR DESCRIPTION
…oringSSL.

Motivation:

BoringSSL allows to customize the way how key signing is done an even offload it from the IO thread. We should provide a way to plugin an own implementation when BoringSSL is used.

Modifications:

Introduce SSLPrivateKeyMethod that can be used by the user to implement custom signing by using SSLContext.setPrivateKeyMethod(...)

Result:

A user is able to customize the way how keys are signed.