### PR TITLE
Use adoptjdk builds for the CI

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8.202"
+        java_version : "adopt@1.8.202-08"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "1.8.202"
+        java_version : "adopt@1.8.202-08"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
Motivation:

We should use non oracle builds on the CI as JDK8 is not supported anymore.

Modifications:

Use adoptjdk builds

Result:

Use non oracle JDK builds on the CI.