### PR TITLE
Compile with -Wunused

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -287,7 +287,7 @@
                     <configureArg>--with-ssl=no</configureArg>
                     <configureArg>--with-apr=${aprHome}</configureArg>
                     <configureArg>--with-static-libs</configureArg>
-                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused-variable</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
                   </configureArgs>

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -55,6 +55,9 @@ static ENGINE *tcn_ssl_engine = NULL;
 static UI_METHOD *ui_method = NULL;
 #endif // OPENSSL_NO_ENGINE
 
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
 /* Global reference to the pool used by the dynamic mutexes */
 static apr_pool_t *dynlockpool = NULL;
 
@@ -65,6 +68,7 @@ struct CRYPTO_dynlock_value {
     int line;
     apr_thread_mutex_t *mutex;
 };
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 struct TCN_bio_bytebuffer {
     // Pointer arithmetic is done on this variable. The type must correspond to a "byte" size.
@@ -554,6 +558,8 @@ static ENGINE *ssl_try_load_engine(const char *engine)
  * To ensure thread-safetyness in OpenSSL
  */
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
 static apr_thread_mutex_t **ssl_lock_cs;
 static int                  ssl_lock_num_locks;
 
@@ -707,6 +713,7 @@ static void ssl_thread_setup(apr_pool_t *p)
      * convenience.
      */
     dynlockpool = p;
+
     CRYPTO_set_dynlock_create_callback(ssl_dyn_create_function);
     CRYPTO_set_dynlock_lock_callback(ssl_dyn_lock_function);
     CRYPTO_set_dynlock_destroy_callback(ssl_dyn_destroy_function);
@@ -714,6 +721,8 @@ static void ssl_thread_setup(apr_pool_t *p)
     apr_pool_cleanup_register(p, NULL, ssl_thread_cleanup,
                               apr_pool_cleanup_null);
 }
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
 
 TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
 {
@@ -757,8 +766,10 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
     OPENSSL_load_builtin_modules();
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
     /* Initialize thread support */
     ssl_thread_setup(tcn_global_pool);
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
     apr_status_t err = APR_SUCCESS;
 

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1362,6 +1362,7 @@ static const char* authentication_method(const SSL* ssl) {
     }
 }
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static tcn_ssl_task_t* tcn_ssl_task_new(JNIEnv* e, jobject task) {
     tcn_ssl_task_t* sslTask = (tcn_ssl_task_t*) OPENSSL_malloc(sizeof(tcn_ssl_task_t));
     if (sslTask == NULL) {
@@ -1389,7 +1390,7 @@ static void tcn_ssl_task_free(JNIEnv* e, tcn_ssl_task_t* sslTask) {
     // The task was malloc'ed before, free it and clear it from the SSL storage.
     OPENSSL_free(sslTask);
 }
-
+#endif // LIBRESSL_VERSION_NUMBER
 
 /* Android end */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
@@ -1742,6 +1743,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
     }
 }
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static jbyteArray keyTypes(JNIEnv* e, SSL* ssl) {
     jbyte* ctype_bytes;
     jbyteArray types;
@@ -1835,6 +1837,7 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
 
     return array;
 }
+#endif // LIBRESSL_VERSION_NUMBER
 
 #ifndef OPENSSL_IS_BORINGSSL
 static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
@@ -1905,12 +1908,10 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
 #endif
 }
 
+#ifndef LIBRESSL_VERSION_NUMBER
+
 // See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html for return values.
 static int certificate_cb(SSL* ssl, void* arg) {
-#if defined(LIBRESSL_VERSION_NUMBER)
-    // Not supported with LibreSSL
-    return 0;
-#else
     tcn_ssl_ctxt_t *c = tcn_SSL_get_app_data2(ssl);
     TCN_ASSERT(c != NULL);
 
@@ -1983,8 +1984,8 @@ static int certificate_cb(SSL* ssl, void* arg) {
         return 1;
     }
 
-#endif /* defined(LIBRESSL_VERSION_NUMBER) */
 }
+#endif // LIBRESSL_VERSION_NUMBER
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setCertificateCallback)(TCN_STDARGS, jlong ctx, jobject callback)
 {

--- a/openssl-dynamic/src/main/native-package/configure.ac
+++ b/openssl-dynamic/src/main/native-package/configure.ac
@@ -28,8 +28,8 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
-${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused-variable"}
-${CXXFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused-variable"}
+${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value"}
+${CXXFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value"}
 
 ## -----------------------------------------------
 ## Application Checks


### PR DESCRIPTION
Motivation:

We should compile with -Wunused so we ensure we correctly remove unused code.

Modifications:

- Add -Wunused
- Add ifdef statements to ensure we only include stuff that is actually needed.

Result:

Cleaner / smaller code.