### PR TITLE
Fix possible segfault when calling SSLContext.setCertificateCallback …

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2021,6 +2021,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertificateCallback)(TCN_STDARGS, jlong 
     if (!SSL_CTX_set_cert_cb) {
         UNREFERENCED(o);
         tcn_ThrowException(e, "Requires OpenSSL 1.0.2+");
+        return;
     }
 #endif // defined(__GNUC__) || defined(__GNUG__)
 


### PR DESCRIPTION
…and compiled via GCC

Motivation:

When using GCC and we use weak references to detect if we can call the function to be able to use different versions of openssl during runtime. Unfortunally we missed to return after putting an exception on the stack and so cause a segfault if we later on try to call the function which was declared as weak.

Modifications:

Add missing return after putting the exception on the stack

Result:

No more segfault if SSL_CTX_set_cert_cb not exists and GCC is used.