### PR TITLE
Prevert segfault when PrivateKeyMethod.* returns null

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2095,14 +2095,18 @@ static enum ssl_private_key_result_t tcn_private_key_sign_java(SSL *ssl, uint8_t
         resultBytes = (*e)->CallObjectMethod(e, c->ssl_private_key_method, c->ssl_private_key_sign_method,
                 P2J(ssl), signature_algorithm, inputArray);
         if ((*e)->ExceptionCheck(e) == JNI_FALSE) {
-            arrayLen = (*e)->GetArrayLength(e, resultBytes);
-            if (max_out >= arrayLen) {
-                b = (*e)->GetByteArrayElements(e, resultBytes, NULL);
-                memcpy(out, b, arrayLen);
-                (*e)->ReleaseByteArrayElements(e, resultBytes, b, JNI_ABORT);
-                *out_len = arrayLen;
+            if (resultBytes == NULL) {
+                ret = ssl_private_key_failure;
+            } else {
+                arrayLen = (*e)->GetArrayLength(e, resultBytes);
+                if (max_out >= arrayLen) {
+                    b = (*e)->GetByteArrayElements(e, resultBytes, NULL);
+                    memcpy(out, b, arrayLen);
+                    (*e)->ReleaseByteArrayElements(e, resultBytes, b, JNI_ABORT);
+                    *out_len = arrayLen;
 
-                ret = ssl_private_key_success;
+                    ret = ssl_private_key_success;
+                }
             }
         } else {
             (*e)->ExceptionClear(e);
@@ -2154,13 +2158,17 @@ static enum ssl_private_key_result_t tcn_private_key_decrypt_java(SSL *ssl, uint
         resultBytes = (*e)->CallObjectMethod(e, c->ssl_private_key_method, c->ssl_private_key_decrypt_method,
             P2J(ssl), inArray);
         if ((*e)->ExceptionCheck(e) == JNI_FALSE) {
-            arrayLen = (*e)->GetArrayLength(e, resultBytes);
-            if (max_out >= arrayLen) {
-                b = (*e)->GetByteArrayElements(e, resultBytes, NULL);
-                memcpy(out, b, arrayLen);
-                (*e)->ReleaseByteArrayElements(e, resultBytes, b, JNI_ABORT);
-                *out_len = arrayLen;
-                ret = ssl_private_key_success;
+            if (resultBytes == NULL) {
+                ret = ssl_private_key_failure;
+            } else {
+                arrayLen = (*e)->GetArrayLength(e, resultBytes);
+                if (max_out >= arrayLen) {
+                    b = (*e)->GetByteArrayElements(e, resultBytes, NULL);
+                    memcpy(out, b, arrayLen);
+                    (*e)->ReleaseByteArrayElements(e, resultBytes, b, JNI_ABORT);
+                    *out_len = arrayLen;
+                    ret = ssl_private_key_success;
+                }
             }
         } else {
             (*e)->ExceptionClear(e);


### PR DESCRIPTION
Motivation:

At the moment we will segfault when PrivateKeyMethod.* will return null. While these methods should never return null we should guard against this

Modifications:

Return a failure when null is returned.

Result:

No more segfault possible when methods return null.