### PR TITLE
Update to latest java8 release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.202-08"
+        java_version : "adopt@1.8.212-03"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "adopt@1.8.202-08"
+        java_version : "adopt@1.8.212-03"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8

--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.202-08"
+        java_version : "adopt@1.8.212-03"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8


### PR DESCRIPTION
Motivation:

There was a new java8 release, we should use it.

Modifications:

Update to adopt@1.8.212-03

Result:

Use latest java8 version on the CI