### PR TITLE
 Fixed the artifacts causing the native libs to not load

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>netty-tcnative-parent</artifactId>
     <version>2.0.26.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-tcnative-boringssl-static</artifactId>
+  <artifactId>netty_tcnative_boringssl_static</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/TomcatNative [BoringSSL - Static]</name>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>netty-tcnative-parent</artifactId>
     <version>2.0.26.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-tcnative</artifactId>
+  <artifactId>netty_tcnative</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/TomcatNative [OpenSSL - Dynamic]</name>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>netty-tcnative-parent</artifactId>
     <version>2.0.26.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-tcnative-openssl-static</artifactId>
+  <artifactId>netty_tcnative_openssl_static</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/TomcatNative [OpenSSL - Static]</name>


### PR DESCRIPTION
OpenSSl.java 

```java
    private static void loadTcNative() throws Exception {
        String os = PlatformDependent.normalizedOs();
        String arch = PlatformDependent.normalizedArch();

        Set<String> libNames = new LinkedHashSet<String>(4);
        String staticLibName = "netty_tcnative";

        // First, try loading the platform-specific library. Platform-specific
        // libraries will be available if using a tcnative uber jar.
        libNames.add(staticLibName + "_" + os + '_' + arch);
        if ("linux".equalsIgnoreCase(os)) {
            // Fedora SSL lib so naming (libssl.so.10 vs libssl.so.1.0.0)..
            libNames.add(staticLibName + "_" + os + '_' + arch + "_fedora");
        }
        libNames.add(staticLibName + "_" + arch);
        libNames.add(staticLibName);

        NativeLibraryLoader.loadFirstAvailable(SSL.class.getClassLoader(),
            libNames.toArray(new String[0]));
    }

```
Here the problem is that the staticLibName is "netty_tcnative" however the maven build generates the jars with a "-" which causes it to not find the native libraries. 

