### PR TITLE
Update to libressl 2.9.3

### DIFF
--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -136,9 +136,12 @@
               <forceConfigure>${forceConfigure}</forceConfigure>
               <windowsBuildTool>msbuild</windowsBuildTool>
               <configureArgs>
-                <configureArg>--with-ssl=${sslHome}</configureArg>
+                <configureArg>--with-ssl=no</configureArg>
                 <configureArg>--with-apr=${aprHome}</configureArg>
                 <configureArg>--with-static-libs</configureArg>
+                <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
+                <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${libresslCheckoutDir}/include</configureArg>
+                <configureArg>LDFLAGS=-L${libresslBuildDir}/ssl -L${libresslBuildDir}/crypto -L${libresslBuildDir}/tls -ltls -lssl -lcrypto</configureArg>
               </configureArgs>
             </configuration>
           </execution>
@@ -242,20 +245,22 @@
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
                     <if>
-                      <available file="${sslHome}" />
+                      <available file="${libresslBuildDir}" />
                       <then>
                         <echo message="LibreSSL was already build, skipping the build step." />
                       </then>
                       <else>
                         <echo message="Building LibreSSL" />
-                        <mkdir dir="${sslHome}" />
-                        <exec executable="configure" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
-                          <arg line="--disable-shared --prefix=${sslHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
+                        <mkdir dir="${libresslBuildDir}" />
+                        <exec executable="cmake" failonerror="true" dir="${libresslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer -fPIC" />
+                          <arg value="-GNinja" />
+                          <arg value=".." />
                         </exec>
-                        <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true" />
-                        <exec executable="make" failonerror="true" dir="${libresslCheckoutDir}" resolveexecutable="true">
-                          <arg line="install" />
-                        </exec>
+                        <exec executable="ninja" failonerror="true" dir="${libresslBuildDir}" resolveexecutable="true" />
                       </else>
                     </if>
                   </target>

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,11 @@
     <aprVersion>1.6.5</aprVersion>
     <aprSha256>70dcf9102066a2ff2ffc47e93c289c8e54c95d8dda23b503f9e61bb0cbd2d105</aprSha256>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>2.8.3</libresslVersion>
+    <libresslVersion>2.9.2</libresslVersion>
     <!--
       See https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/SHA256 for the SHA256 signature
     -->
-    <libresslSha256>9b640b13047182761a99ce3e4f000be9687566e0828b4a72709e9e6a3ef98477</libresslSha256>
+    <libresslSha256>c4c78167fae325b47aebd8beb54b6041d6f6a56b3743f4bd5d79b15642f9d5d4</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
     <opensslPatchVersion>b</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>


### PR DESCRIPTION
Motivation:

Latest stable release of libressl is 2.9.3

Modifications:

Update to latest stable release of libressl

Result:

Use latest stable release