### PR TITLE
fix native-build/target/lib wanted but build in native-build/target/lib64

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -287,6 +287,7 @@
                     <configureArg>--with-ssl=no</configureArg>
                     <configureArg>--with-apr=${aprHome}</configureArg>
                     <configureArg>--with-static-libs</configureArg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -139,6 +139,7 @@
                 <configureArg>--with-ssl=no</configureArg>
                 <configureArg>--with-apr=${aprHome}</configureArg>
                 <configureArg>--with-static-libs</configureArg>
+                <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                 <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                 <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${libresslCheckoutDir}/include</configureArg>
                 <configureArg>LDFLAGS=-L${libresslBuildDir}/ssl -L${libresslBuildDir}/crypto -L${libresslBuildDir}/tls -ltls -lssl -lcrypto</configureArg>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -101,6 +101,9 @@
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>
               <forceConfigure>${forceConfigure}</forceConfigure>
+              <configureArgs>
+                <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+              </configureArgs>
               <windowsBuildTool>msbuild</windowsBuildTool>
             </configuration>
             <goals>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -136,6 +136,7 @@
                 <configureArg>--with-ssl=${sslHome}</configureArg>
                 <configureArg>--with-apr=${aprHome}</configureArg>
                 <configureArg>--with-static-libs</configureArg>
+                <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
               </configureArgs>
             </configuration>
           </execution>


### PR DESCRIPTION
openSUSE x86_64 (probably more) uses `lib64`, e.g. `/usr/lib64`, and `configure` picks this up and builds the native library in `native-build/target/lib64` where maven is not looking. Instead, explicitly specify `--libdir=${project.build.directory}/native-build/target/lib` during
configuration.

FYI: This is similar to https://github.com/fusesource/hawtjni/issues/28 and borrows its solution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netty/netty-tcnative/470)
<!-- Reviewable:end -->
