### PR TITLE
Update to adopt@1.8.222-10

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.212-04"
+        java_version : "adopt@1.8.222-10"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "adopt@1.8.212-04"
+        java_version : "adopt@1.8.222-10"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
Motivation:

We should use latest jdk 1.8 release

Modifications:

Update to adopt@1.8.222-10

Result:

Use latest jdk 1.8 on ci