### PR TITLE
add suse and arch classifiers for native libraries

### DIFF
--- a/docker/Dockerfile.arch
+++ b/docker/Dockerfile.arch
@@ -1,0 +1,30 @@
+FROM archlinux/base
+
+ARG java_version=8
+ENV JAVA_VERSION $java_version
+
+# install dependencies
+# use openSSL 1.0.x for now, for highest compatibility
+RUN pacman -Sy --noconfirm --needed \
+ apr \
+ autoconf \
+ automake \
+ bzip2 \
+ cmake \
+ git \
+ glibc \
+ gcc \
+ gnupg \
+ go \
+ gzip \
+ jdk${JAVA_VERSION}-openjdk \
+ openssl-1.0 \
+ libtool \
+ lsb-release \
+ make \
+ ninja \
+ perl \
+ tar \
+ unzip \
+ wget \
+ which

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -1,0 +1,33 @@
+ARG opensuse_version=15.1
+FROM opensuse/leap:$opensuse_version
+# needed to do again after FROM due to docker limitation
+ARG opensuse_version
+
+ARG java_version=1.8.0
+ENV JAVA_VERSION $java_version
+
+# install dependencies
+# use openSSL 1.0.x for now, for highest compatibility
+RUN zypper install --force-resolution --no-recommends --no-confirm \
+ apr-devel \
+ autoconf \
+ automake \
+ bzip2 \
+ cmake \
+ git \
+ glibc-devel \
+ gcc \
+ gcc-c++ \
+ go \
+ gpg2 \
+ gzip \
+ java-${JAVA_VERSION}-devel \
+ libopenssl-1_0_0-devel \
+ libtool \
+ lsb-release \
+ make \
+ ninja \
+ perl \
+ tar \
+ unzip \
+ wget

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,5 +21,11 @@ docker-compose -f docker/docker-compose.centos.yaml -f docker/docker-compose.cen
 docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build
 ```
 
+## openSUSE Leap 15.1 with java 8
+
+```
+docker-compose -f docker/docker-compose.opensuse.yaml -f docker/docker-compose.opensuse-151.18.yaml run build
+```
+
 etc, etc
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,12 @@ cd /path/to/netty-tcnative/
 cd /path/to/netty-tcnative/
 ```
 
+## Arch Linux with java 8
+
+```
+docker-compose -f docker/docker-compose.arch.yaml -f docker/docker-compose.arch-18.yaml run build
+```
+
 ## centos 6 with java 8
 
 ```

--- a/docker/docker-compose.arch-18.yaml
+++ b/docker/docker-compose.arch-18.yaml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-arch:arch-1.8
+    build:
+      args:
+        java_version : "8"
+
+  build:
+    image: netty-tcnative-arch:arch-1.8
+
+  shell:
+    image: netty-tcnative-arch:arch-1.8

--- a/docker/docker-compose.arch.yaml
+++ b/docker/docker-compose.arch.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-arch:default
+    build:
+      context: .
+      dockerfile: Dockerfile.arch
+
+  common: &common
+    image: netty-tcnative-arch:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ..:/code
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean package"
+
+  shell:
+    <<: *common
+    environment:
+      - SANOTYPE_USER
+      - SANOTYPE_PASSWORD
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ~/.gitconfig:/root/.gitconfig
+      - ~/.gitignore:/root/.gitignore
+      - ..:/code
+    entrypoint: /bin/bash

--- a/docker/docker-compose.opensuse-151.18.yaml
+++ b/docker/docker-compose.opensuse-151.18.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-opensuse:opensuse-15.1-1.8
+    build:
+      args:
+        opensuse_version : "15.1"
+        java_version : "1.8.0"
+
+  build:
+    image: netty-tcnative-opensuse:opensuse-15.1-1.8
+
+  shell:
+    image: netty-tcnative-opensuse:opensuse-15.1-1.8

--- a/docker/docker-compose.opensuse.yaml
+++ b/docker/docker-compose.opensuse.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-opensuse:default
+    build:
+      context: .
+      dockerfile: Dockerfile.opensuse
+
+  common: &common
+    image: netty-tcnative-opensuse:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ..:/code
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean package"
+
+  shell:
+    <<: *common
+    environment:
+      - SANOTYPE_USER
+      - SANOTYPE_PASSWORD
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ~/.gitconfig:/root/.gitconfig
+      - ~/.gitignore:/root/.gitignore
+      - ..:/code
+    entrypoint: /bin/bash


### PR DESCRIPTION
As discussed in #471, this adds two more classifiers for the native libs: `suse` and `arch` to make the dynamically-linked libraries work on these systems as well.

changes:
- fixed linux release parsing by upgrading os-maven-plugin to 1.6.2 (see #482)
- add classifiers for suse and arch distributions
- add docker build files using
  - openSUSE Leap 15.1
  - Arch Linux

I'm not sure whether this covers all parts of the release pipeline (I tried to do the same that is done for Fedora already). I didn't see these docker images being used inside scripts in the repo though and I guess, you need to adapt some more settings to include the new artifacts into a release, don't you, @normanmaurer ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netty/netty-tcnative/480)
<!-- Reviewable:end -->
