### PR TITLE
upgrade os-maven-plugin to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
+        <version>1.6.2</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

The current os-maven-plugin (1.4.0) has problems parsing /etc/os-release files in some cases, e.g. with ID_LIKE="opensuse suse"

Modifications:

update os-maven-plugin to 1.6.2 to fix these

Result:

Fixed `os.detected.release.like` property for openSUSE and potentially others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netty/netty-tcnative/482)
<!-- Reviewable:end -->
