### PR TITLE
Correctly free memory when loading of classes / fields / methods fail…

### DIFF
--- a/openssl-dynamic/src/main/c/error.c
+++ b/openssl-dynamic/src/main/c/error.c
@@ -68,10 +68,12 @@ void tcn_ThrowAPRException(JNIEnv *e, apr_status_t err)
 
 jint netty_internal_tcnative_Error_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
 
-    TCN_LOAD_CLASS(env, exceptionClass, "java/lang/Exception", JNI_ERR);
-    TCN_LOAD_CLASS(env, nullPointerExceptionClass, "java/lang/NullPointerException", JNI_ERR);
+    TCN_LOAD_CLASS(env, exceptionClass, "java/lang/Exception", error);
+    TCN_LOAD_CLASS(env, nullPointerExceptionClass, "java/lang/NullPointerException", error);
 
     return TCN_JNI_VERSION;
+error:
+    return JNI_ERR;
 }
 
 void netty_internal_tcnative_Error_JNI_OnUnLoad(JNIEnv* env) {

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -165,18 +165,18 @@ char* netty_internal_tcnative_util_prepend(const char* prefix, const char* str) 
 }
 
 jint netty_internal_tcnative_util_register_natives(JNIEnv* env, const char* packagePrefix, const char* className, const JNINativeMethod* methods, jint numMethods) {
-    char* nettyClassName = netty_internal_tcnative_util_prepend(packagePrefix, className);
-    if (nettyClassName == NULL) {
-        return JNI_ERR;
-    }
+    char* nettyClassName = NULL;
+    int retValue = JNI_ERR;
+    
+    TCN_PREPEND(packagePrefix, className, nettyClassName, done);
+   
     jclass nativeCls = (*env)->FindClass(env, nettyClassName);
-    free(nettyClassName);
-    nettyClassName = NULL;
-    if (nativeCls == NULL) {
-        return JNI_ERR;
+    if (nativeCls != NULL) {
+        retValue = (*env)->RegisterNatives(env, nativeCls, methods, numMethods);
     }
-
-    return (*env)->RegisterNatives(env, nativeCls, methods, numMethods);
+done:
+    free(nettyClassName);
+    return retValue;
 }
 
 #ifndef TCN_BUILD_STATIC
@@ -356,14 +356,14 @@ static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* 
 
 
     /* Initialize global java.lang.String class */
-    TCN_LOAD_CLASS(env, jString_class, "java/lang/String", JNI_ERR);
+    TCN_LOAD_CLASS(env, jString_class, "java/lang/String", error);
 
     TCN_GET_METHOD(env, jString_class, jString_init,
-                   "<init>", "([B)V", JNI_ERR);
+                   "<init>", "([B)V", error);
     TCN_GET_METHOD(env, jString_class, jString_getBytes,
-                   "getBytes", "()[B", JNI_ERR);
+                   "getBytes", "()[B", error);
 
-    TCN_LOAD_CLASS(env, byteArrayClass, "[B", JNI_ERR);
+    TCN_LOAD_CLASS(env, byteArrayClass, "[B", error);
 
     return TCN_JNI_VERSION;
 error:

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2569,201 +2569,128 @@ static void freeDynamicMethodsTable(JNINativeMethod* dynamicMethods) {
     }
 }
 
+static void freeDynamicTypeName(char** dynamicTypeName) {
+    free(*dynamicTypeName);
+    dynamicTypeName = NULL;
+}
+
 static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
+    char* dynamicTypeName = NULL;
     int len = sizeof(JNINativeMethod) * dynamicMethodsTableSize();
     JNINativeMethod* dynamicMethods = malloc(len);
     if (dynamicMethods == NULL) {
-        return NULL;
+        goto error;
     }
     memset(dynamicMethods, 0, len);
-
     memcpy(dynamicMethods, fixed_method_table, sizeof(fixed_method_table));
-    char* dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateVerifier;)V");
-    if (dynamicTypeName == NULL) {
-        goto error;
-    }
+
     JNINativeMethod* dynamicMethod = &dynamicMethods[fixed_method_table_size];
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateVerifier;)V", dynamicTypeName, error);
+    TCN_PREPEND("(JL", dynamicTypeName,  dynamicMethod->signature, error);
+    freeDynamicTypeName(&dynamicTypeName);
     dynamicMethod->name = "setCertVerifyCallback";
-    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
     dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setCertVerifyCallback);
-    free(dynamicTypeName);
-    if (dynamicMethod->signature == NULL) {
-        goto error;
-    }
 
-    if ((dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateRequestedCallback;)V")) == NULL) {
-        goto error;
-    }
     dynamicMethod = &dynamicMethods[fixed_method_table_size + 1];
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateRequestedCallback;)V", dynamicTypeName, error);
+    TCN_PREPEND("(JL", dynamicTypeName,  dynamicMethod->signature, error);
+    freeDynamicTypeName(&dynamicTypeName);
     dynamicMethod->name = "setCertRequestedCallback";
-    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
     dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setCertRequestedCallback);
-    free(dynamicTypeName);
-    if (dynamicMethod->signature == NULL) {
-        goto error;
-    }
 
-    if ((dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateCallback;)V")) == NULL) {
-        goto error;
-    }
     dynamicMethod = &dynamicMethods[fixed_method_table_size + 2];
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateCallback;)V", dynamicTypeName, error);
+    TCN_PREPEND("(JL", dynamicTypeName,  dynamicMethod->signature, error);
+    freeDynamicTypeName(&dynamicTypeName);
     dynamicMethod->name = "setCertificateCallback";
-    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
     dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setCertificateCallback);
-    free(dynamicTypeName);
-    if (dynamicMethod->signature == NULL) {
-        goto error;
-    }
 
-    if ((dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SniHostNameMatcher;)V")) == NULL) {
-        goto error;
-    }
     dynamicMethod = &dynamicMethods[fixed_method_table_size + 3];
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SniHostNameMatcher;)V", dynamicTypeName, error);
+    TCN_PREPEND("(JL", dynamicTypeName,  dynamicMethod->signature, error);
+    freeDynamicTypeName(&dynamicTypeName);
     dynamicMethod->name = "setSniHostnameMatcher";
-    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
     dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setSniHostnameMatcher);
-    free(dynamicTypeName);
-    if (dynamicMethod->signature == NULL) {
-        goto error;
-    }
-
-    if ((dynamicTypeName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethod;)V")) == NULL) {
-        goto error;
-    }
+  
     dynamicMethod = &dynamicMethods[fixed_method_table_size + 4];
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethod;)V", dynamicTypeName, error); 
+    TCN_PREPEND("(JL", dynamicTypeName,  dynamicMethod->signature, error);
+    freeDynamicTypeName(&dynamicTypeName);
     dynamicMethod->name = "setPrivateKeyMethod";
-    dynamicMethod->signature = netty_internal_tcnative_util_prepend("(JL", dynamicTypeName);
     dynamicMethod->fnPtr = (void *) TCN_FUNCTION_NAME(SSLContext, setPrivateKeyMethod);
-    free(dynamicTypeName);
-    if (dynamicMethod->signature == NULL) {
-        goto error;
-    }
 
     return dynamicMethods;
 error:
     freeDynamicMethodsTable(dynamicMethods);
+    free(dynamicTypeName);
     return NULL;
 }
 
 // JNI Method Registration Table End
 
 jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    char* name = NULL;
+    char* combinedName = NULL;
     JNINativeMethod* dynamicMethods = createDynamicMethodsTable(packagePrefix);
     if (dynamicMethods == NULL) {
-        return JNI_ERR;
+        goto error;
     }
     if (netty_internal_tcnative_util_register_natives(env,
             packagePrefix,
             "io/netty/internal/tcnative/SSLContext",
             dynamicMethods,
             dynamicMethodsTableSize()) != 0) {
-        freeDynamicMethodsTable(dynamicMethods);
-        return JNI_ERR;
-    }
-    freeDynamicMethodsTable(dynamicMethods);
-
-    char* sslTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLTask");
-    if (sslTaskName == NULL) {
-        return JNI_ERR;
-    }
-    TCN_LOAD_CLASS(env, sslTask_class, sslTaskName, JNI_ERR);
-    free(sslTaskName);
-
-    TCN_GET_FIELD(env, sslTask_class, sslTask_returnValue, "returnValue", "I", JNI_ERR);
-    TCN_GET_FIELD(env, sslTask_class, sslTask_complete, "complete", "Z", JNI_ERR);
-
-    char* certificateCallbackTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateCallbackTask");
-    if (certificateCallbackTaskName == NULL) {
-        return JNI_ERR;
-    }
-    TCN_LOAD_CLASS(env, certificateCallbackTask_class, certificateCallbackTaskName, JNI_ERR);
-    free(certificateCallbackTaskName);
-
-    char* certificateCallbackName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateCallback;)V");
-    if (certificateCallbackName == NULL) {
-        return JNI_ERR;
-    }
-    char* initArguments = netty_internal_tcnative_util_prepend("(J[B[[BL", certificateCallbackName);
-    free(certificateCallbackName);
-    if (initArguments == NULL) {
-        return JNI_ERR;
+        goto error;
     }
 
-    TCN_GET_METHOD(env, certificateCallbackTask_class, certificateCallbackTask_init,
-                   "<init>", initArguments, JNI_ERR);
-    free(initArguments);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLTask", name, error);
+    TCN_LOAD_CLASS(env, sslTask_class, name, error);
+    TCN_GET_FIELD(env, sslTask_class, sslTask_returnValue, "returnValue", "I", error);
+    TCN_GET_FIELD(env, sslTask_class, sslTask_complete, "complete", "Z", error);
 
-    char* certificateVerifierTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateVerifierTask");
-    if (certificateVerifierTaskName == NULL) {
-        return JNI_ERR;
-    }
-    TCN_LOAD_CLASS(env, certificateVerifierTask_class, certificateVerifierTaskName, JNI_ERR);
-    free(certificateVerifierTaskName);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateCallbackTask", name, error);
+    TCN_LOAD_CLASS(env, certificateCallbackTask_class, name, error);
 
-    char* certificateVerifierName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/CertificateVerifier;)V");
-    if (certificateVerifierTaskName == NULL) {
-        return JNI_ERR;
-    }
-    initArguments = netty_internal_tcnative_util_prepend("(J[[BLjava/lang/String;L", certificateVerifierName);
-    free(certificateVerifierName);
-    if (initArguments == NULL) {
-        return JNI_ERR;
-    }
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateCallback;)V", name, error);
+    TCN_PREPEND("(J[B[[BL", name, combinedName, error);
+    TCN_REASSIGN(name, combinedName);
+    TCN_GET_METHOD(env, certificateCallbackTask_class, certificateCallbackTask_init, "<init>", name, error);
 
-    TCN_GET_METHOD(env, certificateVerifierTask_class, certificateVerifierTask_init, "<init>", initArguments, JNI_ERR);
-    free(initArguments);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateVerifierTask", name, error);
+    TCN_LOAD_CLASS(env, certificateVerifierTask_class, name, error);
+  
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/CertificateVerifier;)V", name, error);
+    TCN_PREPEND("(J[[BLjava/lang/String;L", name, combinedName, error);
+    TCN_REASSIGN(name, combinedName);
+    TCN_GET_METHOD(env, certificateVerifierTask_class, certificateVerifierTask_init, "<init>", name, error);
 
-    char* sslPrivateKeyMethodTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethodTask");
-    if (sslPrivateKeyMethodTaskName == NULL) {
-        return JNI_ERR;
-    }
-    TCN_LOAD_CLASS(env, sslPrivateKeyMethodTask_class, sslPrivateKeyMethodTaskName, JNI_ERR);
-    free(sslPrivateKeyMethodTaskName);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethodTask", name, error);
+    TCN_LOAD_CLASS(env, sslPrivateKeyMethodTask_class, name, error);
+    TCN_GET_FIELD(env, sslPrivateKeyMethodTask_class, sslPrivateKeyMethodTask_resultBytes, "resultBytes", "[B", error);
 
-    TCN_GET_FIELD(env, sslPrivateKeyMethodTask_class, sslPrivateKeyMethodTask_resultBytes, "resultBytes", "[B", JNI_ERR);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask", name, error);
+    TCN_LOAD_CLASS(env, sslPrivateKeyMethodSignTask_class, name, error);
 
-    char* sslPrivateKeyMethodSignTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask");
-    if (sslPrivateKeyMethodSignTaskName == NULL) {
-        return JNI_ERR;
-    }
-    TCN_LOAD_CLASS(env, sslPrivateKeyMethodSignTask_class, sslPrivateKeyMethodSignTaskName, JNI_ERR);
-    free(sslPrivateKeyMethodSignTaskName);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethod;)V", name, error);
+    TCN_PREPEND("(JI[BL", name, combinedName, error);
+    TCN_REASSIGN(name, combinedName);
+    TCN_GET_METHOD(env, sslPrivateKeyMethodSignTask_class, sslPrivateKeyMethodSignTask_init, "<init>", name, error);
 
-    char* callbackName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethod;)V");
-    if (callbackName == NULL) {
-        return JNI_ERR;
-    }
-    initArguments = netty_internal_tcnative_util_prepend("(JI[BL", callbackName);
-    free(callbackName);
-    if (initArguments == NULL) {
-        return JNI_ERR;
-    }
-    TCN_GET_METHOD(env, sslPrivateKeyMethodSignTask_class, sslPrivateKeyMethodSignTask_init,
-                   "<init>", initArguments, JNI_ERR);
-    free(initArguments);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethodDecryptTask", name, error);
+    TCN_LOAD_CLASS(env, sslPrivateKeyMethodDecryptTask_class, name, error);
 
-    char* sslPrivateKeyMethodDecryptTaskName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethodDecryptTask");
-    if (sslPrivateKeyMethodDecryptTaskName == NULL) {
-        return JNI_ERR;
-    }
-    TCN_LOAD_CLASS(env, sslPrivateKeyMethodDecryptTask_class, sslPrivateKeyMethodDecryptTaskName, JNI_ERR);
-    free(sslPrivateKeyMethodDecryptTaskName);
-
-    callbackName = netty_internal_tcnative_util_prepend(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethod;)V");
-    if (callbackName == NULL) {
-        return JNI_ERR;
-    }
-    initArguments = netty_internal_tcnative_util_prepend("(J[BL", callbackName);
-    free(callbackName);
-    if (initArguments == NULL) {
-        return JNI_ERR;
-    }
-
-    TCN_GET_METHOD(env, sslPrivateKeyMethodDecryptTask_class, sslPrivateKeyMethodDecryptTask_init,
-                   "<init>", initArguments, JNI_ERR);
-    free(initArguments);
+    TCN_PREPEND(packagePrefix, "io/netty/internal/tcnative/SSLPrivateKeyMethod;)V", name, error);
+    TCN_PREPEND("(J[BL", name, combinedName, error);
+    TCN_REASSIGN(name, combinedName);
+    TCN_GET_METHOD(env, sslPrivateKeyMethodDecryptTask_class, sslPrivateKeyMethodDecryptTask_init, "<init>", name, error);
 
     return TCN_JNI_VERSION;
+error:
+    free(name);
+    free(combinedName);
+    freeDynamicMethodsTable(dynamicMethods);
+
+    return JNI_ERR;
 }
 
 void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env) {

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -133,10 +133,13 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
         jclass _##C = (*(E))->FindClass((E), N);    \
         if (_##C == NULL) {                         \
             (*(E))->ExceptionClear((E));            \
-            return R;                               \
+            goto R;                                 \
         }                                           \
         C = (*(E))->NewGlobalRef((E), _##C);        \
         (*(E))->DeleteLocalRef((E), _##C);          \
+        if (C == NULL) {                            \
+            goto R;                                 \
+        }                                           \
     TCN_END_MACRO
 
 #define TCN_UNLOAD_CLASS(E, C)                      \
@@ -146,15 +149,15 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
     TCN_BEGIN_MACRO                                 \
         M = (*(E))->GetMethodID((E), C, N, S);      \
         if (M == NULL) {                            \
-            return R;                               \
+            goto R;                                 \
         }                                           \
     TCN_END_MACRO
 
-#define TCN_GET_FIELD(E, C, F, N, S, R)            \
+#define TCN_GET_FIELD(E, C, F, N, S, R)             \
     TCN_BEGIN_MACRO                                 \
-        F = (*(E))->GetFieldID((E), C, N, S);      \
+        F = (*(E))->GetFieldID((E), C, N, S);       \
         if (F == NULL) {                            \
-            return R;                               \
+            goto R;                                 \
         }                                           \
     TCN_END_MACRO
 
@@ -163,6 +166,22 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
 #ifndef TCN_JNI_VERSION
 #define TCN_JNI_VERSION JNI_VERSION_1_6
 #endif
+
+#define TCN_REASSIGN(V1, V2)                  \
+    TCN_BEGIN_MACRO                           \
+        free(V1);                             \
+        V1 = V2;                              \
+        V2 = NULL;                            \
+    TCN_END_MACRO
+
+
+#define TCN_PREPEND(P, S, N, R)                                          \
+    TCN_BEGIN_MACRO                                                      \
+        if ((N = netty_internal_tcnative_util_prepend(P, S)) == NULL) {  \
+            goto R;                                                      \
+        }                                                                \
+    TCN_END_MACRO
+
 
 /* Return global String class
  */


### PR DESCRIPTION
…s during init

Motivation:

We did not correctly free the memory we allocated before on the heap in the case of:

 - failed to load classes
 - failed to find field
 - failed to find method

While this is very unlikely we should still ensure we free all memory.

Modifications:

- Introduce new macros to make it easier to free memory
- Use the macros

Result:

Correctly free allocated memory in all cases