### PR TITLE
Correctly handle the case of NewGlobalRef(...) returning NULL because…

### DIFF
--- a/openssl-dynamic/src/main/c/error.c
+++ b/openssl-dynamic/src/main/c/error.c
@@ -34,6 +34,9 @@
 
 static jclass exceptionClass;
 static jclass nullPointerExceptionClass;
+static jclass illegalArgumentExceptionClass;
+static jclass oomeClass;
+
 
 /*
  * Convenience function to help throw an java.lang.Exception.
@@ -47,6 +50,12 @@ void tcn_ThrowNullPointerException(JNIEnv *env, const char *msg)
 {
     (*env)->ThrowNew(env, nullPointerExceptionClass, msg);
 }
+
+void tcn_ThrowIllegalArgumentException(JNIEnv *env, const char *msg)
+{
+    (*env)->ThrowNew(env, illegalArgumentExceptionClass, msg);
+}
+
 void tcn_Throw(JNIEnv *env, const char *fmt, ...)
 {
     char msg[TCN_BUFFER_SZ] = {'\0'};
@@ -66,11 +75,17 @@ void tcn_ThrowAPRException(JNIEnv *e, apr_status_t err)
     tcn_ThrowException(e, serr);
 }
 
+void tcn_throwOutOfMemoryError(JNIEnv* env, const char *msg)
+{
+    (*env)->ThrowNew(env, oomeClass, msg);
+}
+
 jint netty_internal_tcnative_Error_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
 
     TCN_LOAD_CLASS(env, exceptionClass, "java/lang/Exception", error);
     TCN_LOAD_CLASS(env, nullPointerExceptionClass, "java/lang/NullPointerException", error);
-
+    TCN_LOAD_CLASS(env, illegalArgumentExceptionClass, "java/lang/IllegalArgumentException", error);
+    TCN_LOAD_CLASS(env, oomeClass, "java/lang/OutOfMemoryError", error);
     return TCN_JNI_VERSION;
 error:
     return JNI_ERR;
@@ -79,4 +94,6 @@ error:
 void netty_internal_tcnative_Error_JNI_OnUnLoad(JNIEnv* env) {
      TCN_UNLOAD_CLASS(env, exceptionClass);
      TCN_UNLOAD_CLASS(env, nullPointerExceptionClass);
+     TCN_UNLOAD_CLASS(env, illegalArgumentExceptionClass);
+     TCN_UNLOAD_CLASS(env, oomeClass);
  }

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -86,7 +86,10 @@
 void            tcn_Throw(JNIEnv *, const char *, ...);
 void            tcn_ThrowException(JNIEnv *, const char *);
 void            tcn_ThrowNullPointerException(JNIEnv *, const char *);
+void            tcn_ThrowIllegalArgumentException(JNIEnv *, const char *);
 void            tcn_ThrowAPRException(JNIEnv *, apr_status_t);
+void            tcn_throwOutOfMemoryError(JNIEnv *, const char *);
+
 jstring         tcn_new_string(JNIEnv *, const char *);
 jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
 


### PR DESCRIPTION
… of no memory left

Motivation:

We did not correctly all cases of NewGlobalRef(...) returning NULL and so may fall into some "invalid state". Beside this we also did not correctl NULL out fields in some cases.

Modifications:

Correctly handle NewGlobalRef(...) in all cases

Result:

Ensure we take into account when NewGlobalRef(...) returns NULL.