### PR TITLE
Guard against OOME errors in native code

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -138,11 +138,7 @@ jclass tcn_get_byte_array_class()
 
 jint tcn_get_java_env(JNIEnv **env)
 {
-    if ((*tcn_global_vm)->GetEnv(tcn_global_vm, (void **)env,
-                                 TCN_JNI_VERSION)) {
-        return JNI_ERR;
-    }
-    return JNI_OK;
+    return (*tcn_global_vm)->GetEnv(tcn_global_vm, (void **)env, TCN_JNI_VERSION);
 }
 
 // TODO: Share code with netty natives utilities.


### PR DESCRIPTION
Motivation:

Most of the New* functions may return NULL if no memory was left to fullfill the operation. We need to guard against this. Beside this we also need to guard against the case when we can not obtain a JNIEnv* reference for the calling thread.

Modifications:

- Add multiple NULL guards
- Ensure we could obtain a JNIEnv* reference and if not fail gracefully
- Guard against the case when the previously stored context was already cleared and we try to access it in an async callback.

Result:

Less possibilities for crashes