### PR TITLE
OpenSSL 1.1.1d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
     -->
     <libresslSha256>c4c78167fae325b47aebd8beb54b6041d6f6a56b3743f4bd5d79b15642f9d5d4</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>c</opensslPatchVersion>
+    <opensslPatchVersion>d</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96</opensslSha256>
+    <opensslSha256>1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
https://www.openssl.org/news/openssl-1.1.1-notes.html

Motivation

Staying current with OpenSSL project.

Modifications

Updating patch version and SHA256 to latest OpenSSL release.

Result

Statically compiled version of TCN will use latest OpenSSL release.