### PR TITLE
Share code to free / release tcn_ssl_task* instances

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -909,8 +909,7 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
 
     UNREFERENCED_STDARGS;
 
-    ssl = SSL_new(c->ctx);
-    if (ssl == NULL) {
+    if ((ssl = SSL_new(c->ctx)) == NULL) {
         tcn_ThrowException(e, "cannot create new ssl");
         return 0;
     }
@@ -924,8 +923,7 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
     tcn_SSL_set_app_data4(ssl, &c->verify_config);
 
     // Store the handshakeCount in the SSL instance.
-    handshakeCount = (int*) OPENSSL_malloc(sizeof(int));
-    if (handshakeCount == NULL) {
+    if ((handshakeCount = (int*) OPENSSL_malloc(sizeof(int))) == NULL) {
         SSL_free(ssl);
         tcn_ThrowException(e, "cannot create handshakeCount user data");
         return 0;
@@ -1130,15 +1128,8 @@ TCN_IMPLEMENT_CALL(void, SSL, freeSSL)(TCN_STDARGS,
         tcn_SSL_set_app_data4(ssl_, &c->verify_config);
     }
 
-    if (ssl_task != NULL) {
-        if (ssl_task->task != NULL) {
-            // Delete the global reference to ensure we not leak any memory.
-            (*e)->DeleteGlobalRef(e, ssl_task->task);
-            ssl_task->task = NULL;
-        }
-        OPENSSL_free(ssl_task);
-        tcn_SSL_set_app_data5(ssl_, NULL);
-    }
+    tcn_ssl_task_free(e, ssl_task);
+    tcn_SSL_set_app_data5(ssl_, NULL);
 
     SSL_free(ssl_);
 }

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -353,6 +353,9 @@ struct tcn_ssl_task_t {
     jobject task;
 };
 
+tcn_ssl_task_t* tcn_ssl_task_new(JNIEnv*, jobject);
+void tcn_ssl_task_free(JNIEnv*, tcn_ssl_task_t*);
+
 /*
  *  Additional Functions
  */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1399,8 +1399,7 @@ static const char* authentication_method(const SSL* ssl) {
     }
 }
 
-#ifndef LIBRESSL_VERSION_NUMBER
-static tcn_ssl_task_t* tcn_ssl_task_new(JNIEnv* e, jobject task) {
+tcn_ssl_task_t* tcn_ssl_task_new(JNIEnv* e, jobject task) {
     if (task == NULL) {
         // task was NULL which most likely means we did run out of memory when calling NewObject(...). Signal a failure back by returning NULL.
         return NULL;
@@ -1419,19 +1418,20 @@ static tcn_ssl_task_t* tcn_ssl_task_new(JNIEnv* e, jobject task) {
     return sslTask;
 }
 
-static void tcn_ssl_task_free(JNIEnv* e, tcn_ssl_task_t* sslTask) {
+void tcn_ssl_task_free(JNIEnv* e, tcn_ssl_task_t* sslTask) {
     if (sslTask == NULL) {
         return;
     }
 
-    // As we created a Global reference before we need to delete the reference as otherwise we will leak memory.
-    (*e)->DeleteGlobalRef(e, sslTask->task);
-    sslTask->task = NULL;
+    if (sslTask->task != NULL) {
+        // As we created a Global reference before we need to delete the reference as otherwise we will leak memory.
+        (*e)->DeleteGlobalRef(e, sslTask->task);
+        sslTask->task = NULL;
+    }
 
     // The task was malloc'ed before, free it and clear it from the SSL storage.
     OPENSSL_free(sslTask);
 }
-#endif // LIBRESSL_VERSION_NUMBER
 
 /* Android end */
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)


### PR DESCRIPTION
Motivation:

We should share the code that is used to free / destory tcn_ssl_task instances to reduce the risk of bugs

Modifications:

Re-use code and so remove duplicates

Result:

Less error-prone code