### PR TITLE
Ignore one warning when compiling boringssl on windows

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -186,7 +186,8 @@
                             <!-- On Windows, build with /MT for static linking -->
                             <property name="cmakeAsmFlags" value="" />
                             <property name="cmakeCFlags" value="/MT" />
-                            <property name="cmakeCxxFlags" value="/MT" />
+                            <!-- Disable one warning to be able to build on windows -->
+                            <property name="cmakeCxxFlags" value="/MT /wd4091" />
                           </then>
                           <elseif>
                             <equals arg1="${os.detected.name}" arg2="linux" />


### PR DESCRIPTION
Motivation:

We need to ignore a specific warning when compiling on windows to be able to build boringssl.

Modifications:

Add /wd4091 as compiler flag on windows.

Result:

Be able to build boringssl and so boringssl-static on windows