### PR TITLE
Correctly handle the case whe netty_internal_tcnative_util_strndup re…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -265,7 +265,10 @@ static char* parsePackagePrefix(const char* libraryPathName, jint* status) {
     // packagePrefix length is > 0
     // Make a copy so we can modify the value without impacting libraryPathName.
     size_t packagePrefixLen = packageNameEnd - packagePrefix;
-    packagePrefix = netty_internal_tcnative_util_strndup(packagePrefix, packagePrefixLen);
+    if (packagePrefix = netty_internal_tcnative_util_strndup(packagePrefix, packagePrefixLen)) == NULL) {
+        *status = JNI_ERR;
+        return NULL;
+    }
     // Make sure the packagePrefix is in the correct format for the JNI functions it will be used with.
     char* temp = packagePrefix;
     packageNameEnd = packagePrefix + packagePrefixLen;

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -265,7 +265,7 @@ static char* parsePackagePrefix(const char* libraryPathName, jint* status) {
     // packagePrefix length is > 0
     // Make a copy so we can modify the value without impacting libraryPathName.
     size_t packagePrefixLen = packageNameEnd - packagePrefix;
-    if (packagePrefix = netty_internal_tcnative_util_strndup(packagePrefix, packagePrefixLen)) == NULL) {
+    if ((packagePrefix = netty_internal_tcnative_util_strndup(packagePrefix, packagePrefixLen)) == NULL) {
         *status = JNI_ERR;
         return NULL;
     }


### PR DESCRIPTION
…turns NULL

Motivation:

netty_internal_tcnative_util_strndup may return NULL if there is not enought memory left to fullfill the allocation.

Modifications:

Correctly handle the case when netty_internal_tcnative_util_strndup returns NULL.

Result:

No more segfault possible when using netty_internal_tcnative_util_strndup during loading the JNI lib