### PR TITLE
Fix dockerfile for debian 7

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -11,7 +11,9 @@ ENV GO_VERSION 1.9.3
 ENV GCC_VERSION 4.9.4
 
 # install dependencies
-RUN apt-get -y update && apt-get -y install \
+RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list && \
+ echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free" >> /etc/apt/sources.list && \ 
+ apt-get -y update && apt-get --force-yes -y install \
  autoconf \
  automake \
  bzip2 \
@@ -23,10 +25,13 @@ RUN apt-get -y update && apt-get -y install \
  gnupg \
  g++ \
  libapr1-dev \
+ libssl1.0.0=1.0.1e-2+deb7u20 \
  libssl-dev \
  libtool \
+ libc-bin=2.13-38+deb7u10 \
+ libc6=2.13-38+deb7u10 libc6-dev \
  make \
- perl \
+ perl-base=5.14.2-21+deb7u3 \
  tar \
  unzip \
  wget \


### PR DESCRIPTION
Motivation:

Packages for debian 7 are now served via archive.debian.org so we need to adjust the docker file to be able to build the image

Modifications:

- Explicitly use archive.debian.org
- Pin versions where needed

Result:

Be able to build debian 7 docker image again