### PR TITLE
Correctly assign pointer to NULL in freeDynamicTypeName

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2662,7 +2662,7 @@ static void freeDynamicMethodsTable(JNINativeMethod* dynamicMethods) {
 
 static void freeDynamicTypeName(char** dynamicTypeName) {
     free(*dynamicTypeName);
-    dynamicTypeName = NULL;
+    *dynamicTypeName = NULL;
 }
 
 static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {


### PR DESCRIPTION
Motivation:

Due a bug we did not correctly assing NULL to the pointer in freeDynamicTypeName

Modifications:

Correct dereference via * before assigning to NULL

Result:

Correctly assign NULL value