### PR TITLE
Init pointers to NULL when declared

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -61,7 +61,7 @@ static jclass    byteArrayClass;
 
 jstring tcn_new_stringn(JNIEnv *env, const char *str, size_t l)
 {
-    jstring result;
+    jstring result = NULL;
     jbyteArray bytes = 0;
 
     if (!str)
@@ -400,7 +400,7 @@ static void netty_internal_tcnative_Library_JNI_OnUnLoad(JNIEnv* env) {
 }
 
 static jint JNI_OnLoad_netty_tcnative0(JavaVM* vm, void* reserved) {
-    JNIEnv* env;
+    JNIEnv* env = NULL;
     if ((*vm)->GetEnv(vm, (void**) &env, TCN_JNI_VERSION) != JNI_OK) {
         return JNI_ERR;
     }
@@ -460,7 +460,7 @@ static jint JNI_OnLoad_netty_tcnative0(JavaVM* vm, void* reserved) {
 }
 
 static void JNI_OnUnload_netty_tcnative0(JavaVM* vm, void* reserved) {
-    JNIEnv* env;
+    JNIEnv* env = NULL;
     if ((*vm)->GetEnv(vm, (void**) &env, TCN_JNI_VERSION) != JNI_OK) {
         // Something is wrong but nothing we can do about this :(
         return;

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -289,7 +289,7 @@ static int bio_java_bytebuffer_create(BIO* bio) {
 }
 
 static int bio_java_bytebuffer_destroy(BIO* bio) {
-    struct TCN_bio_bytebuffer* bioUserData;
+    struct TCN_bio_bytebuffer* bioUserData = NULL;
 
     if (bio == NULL) {
         return 0;
@@ -357,7 +357,7 @@ static long bio_java_bytebuffer_ctrl(BIO* bio, int cmd, long num, void* ptr) {
  */
 static int ssl_ui_reader(UI *ui, UI_STRING *uis)
 {
-    const char *password;
+    const char *password = NULL;
     switch (UI_get_string_type(uis)) {
     case UIT_PROMPT:
     case UIT_VERIFY:
@@ -392,7 +392,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
 
 TCN_IMPLEMENT_CALL(jint, SSL, bioLengthByteBuffer)(TCN_STDARGS, jlong bioAddress) {
     BIO* bio = J2P(bioAddress, BIO*);
-    struct TCN_bio_bytebuffer* bioUserData;
+    struct TCN_bio_bytebuffer* bioUserData = NULL;
 
     TCN_CHECK_NULL(bio, bioAddress, 0);
 
@@ -402,7 +402,7 @@ TCN_IMPLEMENT_CALL(jint, SSL, bioLengthByteBuffer)(TCN_STDARGS, jlong bioAddress
 
 TCN_IMPLEMENT_CALL(jint, SSL, bioLengthNonApplication)(TCN_STDARGS, jlong bioAddress) {
     BIO* bio = J2P(bioAddress, BIO*);
-    struct TCN_bio_bytebuffer* bioUserData;
+    struct TCN_bio_bytebuffer* bioUserData = NULL;
 
     TCN_CHECK_NULL(bio, bioAddress, 0);
 
@@ -560,7 +560,7 @@ static ENGINE *ssl_try_load_engine(const char *engine)
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2090000fL)
 
-static apr_thread_mutex_t **ssl_lock_cs;
+static apr_thread_mutex_t **ssl_lock_cs = NULL;
 static int                  ssl_lock_num_locks;
 
 static void ssl_thread_lock(int mode, int type,
@@ -625,8 +625,8 @@ static apr_status_t ssl_thread_cleanup(void *data)
 static struct CRYPTO_dynlock_value *ssl_dyn_create_function(const char *file,
                                                      int line)
 {
-    struct CRYPTO_dynlock_value *value;
-    apr_pool_t *p;
+    struct CRYPTO_dynlock_value *value = NULL;
+    apr_pool_t *p = NULL;
     apr_status_t rv;
 
     /*
@@ -1006,7 +1006,7 @@ TCN_IMPLEMENT_CALL(void, SSL, bioClearByteBuffer)(TCN_STDARGS, jlong bioAddress)
 
 TCN_IMPLEMENT_CALL(jint, SSL, bioFlushByteBuffer)(TCN_STDARGS, jlong bioAddress) {
     BIO* bio = J2P(bioAddress, BIO*);
-    struct TCN_bio_bytebuffer* bioUserData;
+    struct TCN_bio_bytebuffer* bioUserData = NULL;
 
     return (bio == NULL ||
            (bioUserData = (struct TCN_bio_bytebuffer*) BIO_get_data(bio)) == NULL ||
@@ -1138,7 +1138,7 @@ TCN_IMPLEMENT_CALL(jlong, SSL, bioNewByteBuffer)(TCN_STDARGS,
                                                  jlong ssl /* SSL* */,
                                                  jint nonApplicationBufferSize) {
     SSL* ssl_ = J2P(ssl, SSL*);
-    BIO* bio;
+    BIO* bio = NULL;
     struct TCN_bio_bytebuffer* bioUserData;
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
@@ -1524,8 +1524,8 @@ TCN_IMPLEMENT_CALL(jlong, SSL, setTimeout)(TCN_STDARGS, jlong ssl, jlong seconds
 
 TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl, jint level, jint depth)
 {
-    tcn_ssl_verify_config_t* verify_config;
-    tcn_ssl_ctxt_t* c;
+    tcn_ssl_verify_config_t* verify_config = NULL;
+    tcn_ssl_ctxt_t* c = NULL;
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
@@ -1631,13 +1631,13 @@ TCN_IMPLEMENT_CALL(jint, SSL, getMaxWrapOverhead)(TCN_STDARGS, jlong ssl)
 
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
 {
-    STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *sk = NULL;
     int len;
-    jobjectArray array;
-    const SSL_CIPHER *cipher;
-    const char *name;
+    jobjectArray array = NULL;
+    const SSL_CIPHER *cipher = NULL;
+    const char *name = NULL;
     int i;
-    jstring c_name;
+    jstring c_name = NULL;
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
@@ -2647,8 +2647,8 @@ complete:
     int i;
     int nsig;
     int psignhash;
-    jobjectArray array;
-    jstring algString;
+    jobjectArray array = NULL;
+    jstring algString = NULL;
 
     UNREFERENCED(o);
 

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -655,11 +655,11 @@ static X509 *load_pem_cert(tcn_ssl_ctxt_t *c, const char *file)
 static int ssl_load_pkcs12(tcn_ssl_ctxt_t *c, const char *file,
                            EVP_PKEY **pkey, X509 **cert, STACK_OF(X509) **ca)
 {
-    const char *pass;
+    const char *pass = NULL;
     char        buff[PEM_BUFSIZE];
     int         len, rc = 0;
-    PKCS12     *p12;
-    BIO        *in;
+    PKCS12     *p12 = NULL;
+    BIO        *in = NULL;
 
     if ((in = BIO_new(BIO_s_file())) == 0)
         return 0;
@@ -729,8 +729,9 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificate)(TCN_STDARGS, jlong ctx,
     TCN_ALLOC_CSTRING(password);
     EVP_PKEY *pkey = NULL;
     X509 *xcert = NULL;
-    const char *key_file, *cert_file;
-    const char *p;
+    const char *key_file = NULL;
+    const char *cert_file = NULL;
+    const char *p = NULL;
     char *old_password = NULL;
     char err[ERR_LEN];
 
@@ -909,8 +910,8 @@ static int initProtocols(JNIEnv *e, unsigned char **proto_data,
     // We will call realloc to increase this if needed.
     size_t p_data_size = 128;
     size_t p_data_len = 0;
-    jstring proto_string;
-    const char *proto_chars;
+    jstring proto_string = NULL;
+    const char *proto_chars = NULL;
     size_t proto_chars_len;
     int cnt;
 
@@ -1346,9 +1347,9 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys0)(TCN_STDARGS, jlong c
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    jbyte* b;
-    jbyte* key;
-    tcn_ssl_ticket_key_t* ticket_keys;
+    jbyte* b = NULL;
+    jbyte* key = NULL;
+    tcn_ssl_ticket_key_t* ticket_keys = NULL;
     int i;
     int cnt;
 
@@ -1803,8 +1804,8 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
 
 #ifndef LIBRESSL_VERSION_NUMBER
 static jbyteArray keyTypes(JNIEnv* e, SSL* ssl) {
-    jbyte* ctype_bytes;
-    jbyteArray types;
+    jbyte* ctype_bytes = NULL;
+    jbyteArray types = NULL;
     int ctype_num = tcn_SSL_get0_certificate_types(ssl, (const uint8_t **) &ctype_bytes);
     if (ctype_num <= 0) {
         // No idea what we should use... Let the caller handle it.
@@ -2453,7 +2454,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong
     TCN_CHECK_NULL(c, ctx, JNI_FALSE);
 
     int len = (*e)->GetArrayLength(e, sidCtx);
-    unsigned char *buf;
+    unsigned char *buf = NULL;
     int res;
 
     UNREFERENCED(o);

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -401,7 +401,7 @@ error:
 
 DH *tcn_SSL_dh_get_tmp_param(int key_len)
 {
-    DH *dh;
+    DH *dh = NULL;
 
     if (key_len == 512)
         dh = get_dh(SSL_TMP_KEY_DH_512);
@@ -467,7 +467,7 @@ DH *tcn_SSL_callback_tmp_DH_4096(SSL *ssl, int export, int keylen)
  */
 int tcn_SSL_CTX_use_certificate_chain(SSL_CTX *ctx, const char *file, bool skipfirst)
 {
-    BIO *bio;
+    BIO *bio = NULL;
     int n;
 
     if ((bio = BIO_new(BIO_s_file())) == NULL)
@@ -588,7 +588,7 @@ int tcn_SSL_use_certificate_chain_bio(SSL *ssl, BIO *bio, bool skipfirst)
     // Only supported on openssl 1.0.2+ and LibreSSL 2.9.2
     return -1;
 #else
-    X509 *x509;
+    X509 *x509 = NULL;
     unsigned long err;
     int n;
 
@@ -710,9 +710,9 @@ int select_next_proto(SSL *ssl, const unsigned char **out, unsigned char *outlen
 
     unsigned int i = 0;
     unsigned char target_proto_len;
-    unsigned char *p;
-    const unsigned char *end;
-    unsigned char *proto;
+    unsigned char *p = NULL;
+    const unsigned char *end = NULL;
+    unsigned char *proto = NULL;
     unsigned char proto_len;
 
     while (i < supported_protos_len) {


### PR DESCRIPTION
Motivation:

It's considered a good practice to init pointers to NULL when declared to have a defined value when accessing these.

Modifications:

Init pointers to NULL when declaring

Result:

Safer and cleaner code