### PR TITLE
Update to latest jdk8 release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.222-10"
+        java_version : "adopt@1.8.0-232"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "adopt@1.8.222-10"
+        java_version : "adopt@1.8.0-232"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
Motivation:

We should use latest jdk8 release to build on CI

Modifications:

Update to latest adoptjdk release

Result:

Use latest jdk8