### PR TITLE
Allow to release from any centos 6 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,7 +558,7 @@
                       <files>
                         <file>/etc/redhat-release</file>
                       </files>
-                      <content>release 6.9</content>
+                      <content>release 6.</content>
                     </requireFilesContent>
                   </rules>
                 </configuration>


### PR DESCRIPTION
Motivation:

We should allow to release from any centos version as long as its 6.x.

Modifications:

Not check the minor version but just the major version

Result:

Be able to release from any centos 6 version