### PR TITLE
Remove UNREFERENCED* macros and usage

### DIFF
--- a/openssl-dynamic/src/main/c/bb.c
+++ b/openssl-dynamic/src/main/c/bb.c
@@ -34,13 +34,11 @@
 
 TCN_IMPLEMENT_CALL(jlong, Buffer, address)(TCN_STDARGS, jobject bb)
 {
-    UNREFERENCED(o);
     return P2J((*e)->GetDirectBufferAddress(e, bb));
 }
 
 TCN_IMPLEMENT_CALL(jlong, Buffer, size)(TCN_STDARGS, jobject bb)
 {
-    UNREFERENCED(o);
     return (*e)->GetDirectBufferCapacity(e, bb);
 }
 

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -90,7 +90,6 @@ jstring tcn_new_string(JNIEnv *env, const char *str)
 TCN_IMPLEMENT_CALL(jboolean, Library, initialize0)(TCN_STDARGS)
 {
 
-    UNREFERENCED_STDARGS;
     if (!tcn_global_pool) {
         apr_initialize();
         if (apr_pool_create(&tcn_global_pool, NULL) != APR_SUCCESS) {
@@ -105,20 +104,17 @@ TCN_IMPLEMENT_CALL(jint, Library, aprMajorVersion)(TCN_STDARGS)
 {
     apr_version_t apv;
 
-    UNREFERENCED_STDARGS;
     apr_version(&apv);
     return apv.major;
 }
 
 TCN_IMPLEMENT_CALL(jstring, Library, aprVersionString)(TCN_STDARGS)
 {
-    UNREFERENCED(o);
     return AJP_TO_JSTRING(apr_version_string());
 }
 
 TCN_IMPLEMENT_CALL(jboolean, Library, aprHasThreads)(TCN_STDARGS)
 {
-    UNREFERENCED_STDARGS;
 #if APR_HAS_THREADS
     return JNI_TRUE;
 #else

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -457,13 +457,11 @@ static int ssl_tmp_key_init_dh(int bits, int idx)
 
 TCN_IMPLEMENT_CALL(jint, SSL, version)(TCN_STDARGS)
 {
-    UNREFERENCED_STDARGS;
     return OpenSSL_version_num();
 }
 
 TCN_IMPLEMENT_CALL(jstring, SSL, versionString)(TCN_STDARGS)
 {
-    UNREFERENCED(o);
     return AJP_TO_JSTRING(OpenSSL_version(OPENSSL_VERSION));
 }
 
@@ -472,8 +470,6 @@ TCN_IMPLEMENT_CALL(jstring, SSL, versionString)(TCN_STDARGS)
  */
 static apr_status_t ssl_init_cleanup(void *data)
 {
-    UNREFERENCED(data);
-
     if (!ssl_initialized)
         return APR_SUCCESS;
     ssl_initialized = 0;
@@ -566,8 +562,6 @@ static int                  ssl_lock_num_locks;
 static void ssl_thread_lock(int mode, int type,
                             const char *file, int line)
 {
-    UNREFERENCED(file);
-    UNREFERENCED(line);
     if (type < ssl_lock_num_locks) {
         if (mode & CRYPTO_LOCK) {
             apr_thread_mutex_lock(ssl_lock_cs[type]);
@@ -605,7 +599,6 @@ static void ssl_set_thread_id(CRYPTO_THREADID *id)
 
 static apr_status_t ssl_thread_cleanup(void *data)
 {
-    UNREFERENCED(data);
     CRYPTO_set_locking_callback(NULL);
     CRYPTO_THREADID_set_callback(NULL);
     CRYPTO_set_dynlock_create_callback(NULL);
@@ -730,7 +723,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, initialize)(TCN_STDARGS, jstring engine)
 
     TCN_ALLOC_CSTRING(engine);
 
-    UNREFERENCED(o);
     if (!tcn_global_pool) {
         TCN_FREE_CSTRING(engine);
         tcn_ThrowAPRException(e, APR_EINVAL);
@@ -864,8 +856,6 @@ TCN_IMPLEMENT_CALL(jlong, SSL, newMemBIO)(TCN_STDARGS)
 {
     BIO *bio = NULL;
 
-    UNREFERENCED(o);
-
     // TODO: Use BIO_s_secmem() once included in stable release
     if ((bio = BIO_new(BIO_s_mem())) == NULL) {
         tcn_ThrowException(e, "Create BIO failed");
@@ -877,14 +867,12 @@ TCN_IMPLEMENT_CALL(jlong, SSL, newMemBIO)(TCN_STDARGS)
 TCN_IMPLEMENT_CALL(jstring, SSL, getLastError)(TCN_STDARGS)
 {
     char buf[ERR_LEN];
-    UNREFERENCED(o);
     ERR_error_string_n(ERR_get_error(), buf, ERR_LEN);
     return tcn_new_string(e, buf);
 }
 
 /*** Begin Twitter 1:1 API addition ***/
 TCN_IMPLEMENT_CALL(jint, SSL, getLastErrorNumber)(TCN_STDARGS) {
-    UNREFERENCED_STDARGS;
     return ERR_get_error();
 }
 
@@ -941,8 +929,6 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
 
     TCN_CHECK_NULL(c, ctx, 0);
 
-    UNREFERENCED_STDARGS;
-
     if ((ssl = SSL_new(c->ctx)) == NULL) {
         tcn_ThrowException(e, "cannot create new ssl");
         return 0;
@@ -976,8 +962,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, getError)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
 
-    UNREFERENCED_STDARGS;
-
     return SSL_get_error(ssl_, ret);
 }
 
@@ -991,8 +975,6 @@ TCN_IMPLEMENT_CALL(jint /* status */, SSL, bioWrite)(TCN_STDARGS,
 
     TCN_CHECK_NULL(bio, bioAddress, 0);
     TCN_CHECK_NULL(wbuf, wbufAddress, 0);
-
-    UNREFERENCED_STDARGS;
 
     return BIO_write(bio, wbuf, wlen);
 }
@@ -1056,8 +1038,6 @@ TCN_IMPLEMENT_CALL(jint /* status */, SSL, writeToSSL)(TCN_STDARGS,
     TCN_CHECK_NULL(ssl_, ssl, 0);
     TCN_CHECK_NULL(w, wbuf, 0);
 
-    UNREFERENCED_STDARGS;
-
     return SSL_write(ssl_, w, wlen);
 }
 
@@ -1072,8 +1052,6 @@ TCN_IMPLEMENT_CALL(jint /* status */, SSL, readFromSSL)(TCN_STDARGS,
     TCN_CHECK_NULL(ssl_, ssl, 0);
     TCN_CHECK_NULL(r, rbuf, 0);
 
-    UNREFERENCED_STDARGS;
-
     return SSL_read(ssl_, r, rlen);
 }
 
@@ -1083,8 +1061,6 @@ TCN_IMPLEMENT_CALL(jint /* status */, SSL, getShutdown)(TCN_STDARGS,
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
-
-    UNREFERENCED_STDARGS;
 
     return SSL_get_shutdown(ssl_);
 }
@@ -1097,8 +1073,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setShutdown)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-    UNREFERENCED_STDARGS;
-
     SSL_set_shutdown(ssl_, mode);
 }
 
@@ -1109,8 +1083,6 @@ TCN_IMPLEMENT_CALL(jobject /* task */, SSL, getTask)(TCN_STDARGS,
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
-
-    UNREFERENCED_STDARGS;
 
     if ((state = tcn_SSL_get_app_state(ssl_)) == NULL) {
         return NULL;
@@ -1181,8 +1153,6 @@ TCN_IMPLEMENT_CALL(void, SSL, freeBIO)(TCN_STDARGS,
                                        jlong bio /* BIO * */) {
     BIO *bio_ = J2P(bio, BIO *);
 
-    UNREFERENCED_STDARGS;
-
     if (bio_ != NULL) {
         BIO_free(bio_);
     }
@@ -1195,8 +1165,6 @@ TCN_IMPLEMENT_CALL(jint /* status */, SSL, shutdownSSL)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
 
-    UNREFERENCED_STDARGS;
-
     return SSL_shutdown(ssl_);
 }
 
@@ -1207,8 +1175,6 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getCipherForSSL)(TCN_STDARGS,
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
-
-    UNREFERENCED_STDARGS;
 
     return AJP_TO_JSTRING(SSL_get_cipher(ssl_));
 }
@@ -1221,8 +1187,6 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getVersion)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-    UNREFERENCED_STDARGS;
-
     return AJP_TO_JSTRING(SSL_get_version(ssl_));
 }
 
@@ -1233,8 +1197,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, isInInit)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
 
-    UNREFERENCED(o);
-
     return SSL_in_init(ssl_);
 }
 
@@ -1243,8 +1205,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, doHandshake)(TCN_STDARGS,
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
-
-    UNREFERENCED(o);
 
     return SSL_do_handshake(ssl_);
 }
@@ -1257,8 +1217,6 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getNextProtoNegotiated)(TCN_STDARGS,
     unsigned int proto_len;
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
-
-    UNREFERENCED(o);
 
     SSL_get0_next_proto_negotiated(ssl_, &proto, &proto_len);
     return tcn_new_stringn(e, (char*) proto, proto_len);
@@ -1274,8 +1232,6 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
     // version of openssl.
     #if defined(__GNUC__) || defined(__GNUG__)
         if (!SSL_get0_alpn_selected) {
-            UNREFERENCED(o);
-            UNREFERENCED(ssl);
             return NULL;
         }
     #endif
@@ -1288,13 +1244,9 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
 
         TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-        UNREFERENCED(o);
-
         SSL_get0_alpn_selected(ssl_, &proto, &proto_len);
         return tcn_new_stringn(e, (char*) proto, proto_len);
     #else
-        UNREFERENCED(o);
-        UNREFERENCED(ssl);
         return NULL;
     #endif
 }
@@ -1322,8 +1274,6 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
-
-    UNREFERENCED(o);
 
     // Get a stack of all certs in the chain.
 #ifdef OPENSSL_IS_BORINGSSL
@@ -1419,8 +1369,6 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-    UNREFERENCED(o);
-
 #ifdef OPENSSL_IS_BORINGSSL
     // Get a stack of all certs in the chain, the first is the leaf.
     certs = SSL_get0_peer_certificates(ssl_);
@@ -1459,7 +1407,6 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
 TCN_IMPLEMENT_CALL(jstring, SSL, getErrorString)(TCN_STDARGS, jlong number)
 {
     char buf[ERR_LEN];
-    UNREFERENCED(o);
     ERR_error_string_n(number, buf, ERR_LEN);
     return tcn_new_string(e, buf);
 }
@@ -1477,8 +1424,6 @@ TCN_IMPLEMENT_CALL(jlong, SSL, getTime)(TCN_STDARGS, jlong ssl)
         // returns 0 if the session is NULL, so do that here.
         return 0;
     }
-
-    UNREFERENCED(o);
 
     return SSL_get_time(session);
 }
@@ -1498,8 +1443,6 @@ TCN_IMPLEMENT_CALL(jlong, SSL, getTimeout)(TCN_STDARGS, jlong ssl)
         return 0;
     }
 
-    UNREFERENCED(o);
-
     return SSL_get_timeout(session);
 }
 
@@ -1518,8 +1461,6 @@ TCN_IMPLEMENT_CALL(jlong, SSL, setTimeout)(TCN_STDARGS, jlong ssl, jlong seconds
         return 0;
     }
 
-    UNREFERENCED(o);
-
     return SSL_set_timeout(session, seconds);
 }
 
@@ -1532,7 +1473,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl, jint level, jin
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
     state = tcn_SSL_get_app_state(ssl_);
-    UNREFERENCED(o);
     TCN_ASSERT(state != NULL);
     TCN_ASSERT(state->ctx != NULL);
     TCN_ASSERT(state->verify_config != NULL);
@@ -1563,8 +1503,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setOptions)(TCN_STDARGS, jlong ssl,
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-    UNREFERENCED_STDARGS;
-
     SSL_set_options(ssl_, opt);
 }
 
@@ -1575,8 +1513,6 @@ TCN_IMPLEMENT_CALL(void, SSL, clearOptions)(TCN_STDARGS, jlong ssl,
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-    UNREFERENCED_STDARGS;
-
     SSL_clear_options(ssl_, opt);
 }
 
@@ -1585,8 +1521,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, getOptions)(TCN_STDARGS, jlong ssl)
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
-
-    UNREFERENCED_STDARGS;
 
     return SSL_get_options(ssl_);
 }
@@ -1640,8 +1574,6 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-    UNREFERENCED_STDARGS;
-
     sk = SSL_get_ciphers(ssl_);
     len = sk_SSL_CIPHER_num(sk);
 
@@ -1689,7 +1621,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     }
 
     TCN_ALLOC_CSTRING(ciphers);
-    UNREFERENCED(o);
     if (!J2S(ciphers)) {
         return JNI_FALSE;
     }
@@ -1873,8 +1804,6 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-    UNREFERENCED(o);
-
     session = SSL_get_session(ssl_);
     if (session == NULL) {
         return NULL;
@@ -1900,8 +1829,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, getHandshakeCount)(TCN_STDARGS, jlong ssl)
 
     TCN_CHECK_NULL(ssl_, ssl, 0);
 
-    UNREFERENCED(o);
-
     if ((state = tcn_SSL_get_app_state(ssl_)) != NULL) {
         return state->handshakeCount;
     }
@@ -1911,7 +1838,6 @@ TCN_IMPLEMENT_CALL(jint, SSL, getHandshakeCount)(TCN_STDARGS, jlong ssl)
 
 TCN_IMPLEMENT_CALL(void, SSL, clearError)(TCN_STDARGS)
 {
-    UNREFERENCED(o);
     ERR_clear_error();
 }
 
@@ -1921,8 +1847,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setTlsExtHostName0)(TCN_STDARGS, jlong ssl, jstrin
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
     TCN_ALLOC_CSTRING(hostname);
-
-    UNREFERENCED(o);
 
     if (SSL_set_tlsext_host_name(ssl_, J2S(hostname)) != 1) {
         char err[ERR_LEN];
@@ -1991,8 +1915,6 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-    UNREFERENCED(o);
-
     ciphers = SSL_get_ciphers(ssl_);
     len = sk_SSL_CIPHER_num(ciphers);
 
@@ -2028,7 +1950,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateBio)(TCN_STDARGS, jlong ssl,
     TCN_ALLOC_CSTRING(password);
     char err[ERR_LEN];
 
-    UNREFERENCED(o);
     TCN_ASSERT(ssl != NULL);
 
     if (key <= 0) {
@@ -2090,8 +2011,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
     TCN_CHECK_NULL(b, chain, /* void */);
 
-    UNREFERENCED(o);
-
 // This call is only used to detect if we support KeyManager or not in netty. As we know that we support it in
 // BoringSSL we can just ignore this call. In the future we should remove the method all together.
 #ifndef OPENSSL_IS_BORINGSSL
@@ -2118,8 +2037,6 @@ TCN_IMPLEMENT_CALL(jlong, SSL, loadPrivateKeyFromEngine)(TCN_STDARGS, jstring ke
 
     TCN_FREE_CSTRING(password);
     TCN_FREE_CSTRING(keyId);
-
-    UNREFERENCED(o);
 
     if (pkey == NULL) {
          ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
@@ -2161,7 +2078,6 @@ cleanup:
 TCN_IMPLEMENT_CALL(void, SSL, freePrivateKey)(TCN_STDARGS, jlong privateKey)
 {
     EVP_PKEY *key = J2P(privateKey, EVP_PKEY *);
-    UNREFERENCED(o);
     EVP_PKEY_free(key); // Safe to call with NULL as well.
 }
 
@@ -2186,8 +2102,6 @@ TCN_IMPLEMENT_CALL(jlong, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
     int n = 0;
 
     TCN_CHECK_NULL(cert_bio, x509ChainBio, 0);
-
-    UNREFERENCED(o);
 
 #ifdef OPENSSL_IS_BORINGSSL
     while (PEM_read_bio(cert_bio, &name, &header, &data, &data_len)) {
@@ -2250,11 +2164,9 @@ TCN_IMPLEMENT_CALL(void, SSL, freeX509Chain)(TCN_STDARGS, jlong x509Chain)
 {
 #ifdef OPENSSL_IS_BORINGSSL
     STACK_OF(CRYPTO_BUFFER) *chain = J2P(x509Chain, STACK_OF(CRYPTO_BUFFER) *);
-    UNREFERENCED(o);
     sk_CRYPTO_BUFFER_pop_free(chain, CRYPTO_BUFFER_free);
 #else
     STACK_OF(X509) *chain = J2P(x509Chain, STACK_OF(X509) *);
-    UNREFERENCED(o);
     sk_X509_pop_free(chain, X509_free);
 #endif // OPENSSL_IS_BORINGSSL
 }
@@ -2282,7 +2194,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
     char err[ERR_LEN];
     int i;
 
-    UNREFERENCED(o);
     TCN_ASSERT(ssl != NULL);
 
     TCN_CHECK_NULL(cchain, chain, /* void */);
@@ -2366,7 +2277,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterialClientSide)(TCN_STDARGS, jlong ssl, 
     char err[ERR_LEN];
     int i;
 
-    UNREFERENCED(o);
     TCN_ASSERT(ssl != NULL);
 
     if (cchain == NULL || pkey == NULL) {
@@ -2548,7 +2458,6 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getOcspResponse)(TCN_STDARGS, jlong ssl) {
 
 TCN_IMPLEMENT_CALL(void, SSL, fipsModeSet)(TCN_STDARGS, jint mode)
 {
-    UNREFERENCED(o);
 #ifdef OPENSSL_FIPS
     if (FIPS_mode_set((int) mode) == 0) {
         char err[ERR_LEN];
@@ -2637,7 +2546,6 @@ complete:
 // version of openssl.
 #if defined(__GNUC__) || defined(__GNUG__)
     if (!SSL_get_sigalgs) {
-        UNREFERENCED(o);
         return NULL;
     }
 #endif
@@ -2649,8 +2557,6 @@ complete:
     int psignhash;
     jobjectArray array = NULL;
     jstring algString = NULL;
-
-    UNREFERENCED(o);
 
     nsig = SSL_get_sigalgs(ssl_, 0, NULL, NULL, NULL, NULL, NULL);
     if (nsig <= 0) {

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -148,8 +148,6 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     tcn_ssl_ctxt_t *c = NULL;
     SSL_CTX *ctx = NULL;
 
-    UNREFERENCED(o);
-
 #ifdef OPENSSL_IS_BORINGSSL
     // When using BoringSSL we want to use CRYPTO_BUFFER to reduce memory usage and minimize overhead as we do not need
     // X509* at all and just need the raw bytes of the certificates to construct our Java X509Certificate.
@@ -410,7 +408,6 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, free)(TCN_STDARGS, jlong ctx)
 
     TCN_CHECK_NULL(c, ctx, 0);
 
-    UNREFERENCED_STDARGS;
     /* Run and destroy the cleanup callback */
     int result = apr_pool_cleanup_run(c->pool, c, ssl_context_cleanup);
     apr_pool_destroy(c->pool);
@@ -425,8 +422,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setContextId)(TCN_STDARGS, jlong ctx,
     TCN_CHECK_NULL(c, ctx, /* void */);
 
     TCN_ALLOC_CSTRING(id);
-
-    UNREFERENCED(o);
     if (J2S(id)) {
         EVP_Digest((const unsigned char *)J2S(id),
                    (unsigned long)strlen(J2S(id)),
@@ -442,8 +437,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setOptions)(TCN_STDARGS, jlong ctx,
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED_STDARGS;
-
     SSL_CTX_set_options(c->ctx, opt);
 }
 
@@ -452,8 +445,6 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, getOptions)(TCN_STDARGS, jlong ctx)
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
     TCN_CHECK_NULL(c, ctx, 0);
-
-    UNREFERENCED_STDARGS;
 
     return SSL_CTX_get_options(c->ctx);
 }
@@ -465,7 +456,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, clearOptions)(TCN_STDARGS, jlong ctx,
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED_STDARGS;
     SSL_CTX_clear_options(c->ctx, opt);
 }
 
@@ -489,7 +479,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCipherSuite)(TCN_STDARGS, jlong ctx,
     }
 
     TCN_ALLOC_CSTRING(ciphers);
-    UNREFERENCED(o);
     if (!J2S(ciphers)) {
         return JNI_FALSE;
     }
@@ -535,7 +524,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateChainFile)(TCN_STDARGS, j
 
     TCN_ALLOC_CSTRING(file);
 
-    UNREFERENCED(o);
     if (!J2S(file))
         return JNI_FALSE;
     if (tcn_SSL_CTX_use_certificate_chain(c->ctx, J2S(file), skipfirst) > 0)
@@ -558,7 +546,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateChainBio)(TCN_STDARGS, jl
 
     TCN_CHECK_NULL(c, ctx, JNI_FALSE);
 
-    UNREFERENCED(o);
     if (b == NULL)
         return JNI_FALSE;
     if (tcn_SSL_CTX_use_certificate_chain_bio(c->ctx, b, skipfirst) > 0)  {
@@ -576,8 +563,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCACertificateBio)(TCN_STDARGS, jlong
 
     BIO *b = J2P(certs, BIO *);
 
-    UNREFERENCED(o);
-
     return b != NULL && c->mode != SSL_MODE_CLIENT && tcn_SSL_CTX_use_client_CA_bio(c->ctx, b) > 0 ? JNI_TRUE : JNI_FALSE;
 }
 
@@ -587,7 +572,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDHLength)(TCN_STDARGS, jlong ctx, jin
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED(o);
     switch (length) {
         case 512:
             SSL_CTX_set_tmp_dh_callback(c->ctx, tcn_SSL_callback_tmp_DH_512);
@@ -735,8 +719,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificate)(TCN_STDARGS, jlong ctx,
     char *old_password = NULL;
     char err[ERR_LEN];
 
-    UNREFERENCED(o);
-
     if (J2S(password)) {
         old_password = c->password;
 
@@ -831,8 +813,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateBio)(TCN_STDARGS, jlong c
     TCN_ALLOC_CSTRING(password);
     char *old_password = NULL;
     char err[ERR_LEN];
-
-    UNREFERENCED(o);
 
     if (J2S(password)) {
         old_password = c->password;
@@ -996,8 +976,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos)(TCN_STDARGS, jlong ctx, jobje
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED(o);
-
     if (initProtocols(e, &c->next_proto_data, &c->next_proto_len, next_protos) == 0) {
         c->next_selector_failure_behavior = selectorFailureBehavior;
 
@@ -1016,9 +994,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobj
     // Only supported with GCC
     #if defined(__GNUC__) || defined(__GNUG__)
         if (!SSL_CTX_set_alpn_protos || !SSL_CTX_set_alpn_select_cb) {
-            UNREFERENCED_STDARGS;
-            UNREFERENCED(ctx);
-            UNREFERENCED(alpn_protos);
             return;
         }
     #endif
@@ -1028,8 +1003,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobj
         tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
         TCN_CHECK_NULL(c, ctx, /* void */);
-
-        UNREFERENCED(o);
 
         if (initProtocols(e, &c->alpn_proto_data, &c->alpn_proto_len, alpn_protos) == 0) {
             c->alpn_selector_failure_behavior = selectorFailureBehavior;
@@ -1042,10 +1015,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos)(TCN_STDARGS, jlong ctx, jobj
 
             }
         }
-    #else
-        UNREFERENCED_STDARGS;
-        UNREFERENCED(ctx);
-        UNREFERENCED(alpn_protos);
     #endif
 }
 
@@ -1742,8 +1711,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setVerify)(TCN_STDARGS, jlong ctx, jint lev
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED(o);
-
     int mode = tcn_set_verify_config(&c->verify_config, level, depth);
 #ifdef OPENSSL_IS_BORINGSSL
     if (c->verifier != NULL) {
@@ -1761,8 +1728,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
     TCN_CHECK_NULL(c, ctx, /* void */);
-
-    UNREFERENCED(o);
 
     jobject oldVerifier = c->verifier;
     if (verifier == NULL) {
@@ -1952,8 +1917,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED(o);
-
 #ifdef OPENSSL_IS_BORINGSSL
     tcn_Throw(e, "Not supported using BoringSSL");
 #else
@@ -2078,13 +2041,11 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertificateCallback)(TCN_STDARGS, jlong 
 #if defined(LIBRESSL_VERSION_NUMBER)
     tcn_Throw(e, "Not supported with LibreSSL");
 #else
-    UNREFERENCED(o);
 
 // Use weak linking with GCC as this will alow us to run the same packaged version with multiple
 // version of openssl.
 #if defined(__GNUC__) || defined(__GNUG__)
     if (!SSL_CTX_set_cert_cb) {
-        UNREFERENCED(o);
         tcn_ThrowException(e, "Requires OpenSSL 1.0.2+");
         return;
     }
@@ -2407,8 +2368,6 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSniHostnameMatcher)(TCN_STDARGS, jlong c
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-    UNREFERENCED(o);
-
     jobject oldMatcher = c->sni_hostname_matcher;
     if (matcher == NULL) {
         c->sni_hostname_matcher = NULL;
@@ -2453,8 +2412,6 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong
     unsigned char *buf = NULL;
     int res;
 
-    UNREFERENCED(o);
-
     if ((buf = OPENSSL_malloc(len)) == NULL) {
         return JNI_FALSE;
     }
@@ -2476,8 +2433,6 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, setMode)(TCN_STDARGS, jlong ctx, jint mode)
 
     TCN_CHECK_NULL(c, ctx, 0);
 
-    UNREFERENCED(o);
-
     return (jint) SSL_CTX_set_mode(c->ctx, mode);
 }
 
@@ -2487,8 +2442,6 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, getMode)(TCN_STDARGS, jlong ctx)
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
     TCN_CHECK_NULL(c, ctx, 0);
-
-    UNREFERENCED(o);
 
     return (jint) SSL_CTX_get_mode(c->ctx);
 }

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -58,8 +58,6 @@
 #endif
 // End includes
 
-#define UNREFERENCED(P)      (P) = (P)
-#define UNREFERENCED_STDARGS e = e; o = o
 #ifdef _WIN32
 #define LLT(X) (X)
 #else


### PR DESCRIPTION
Motivation:

Usage of UNREFERENCED* macros is not really needed.

Modifications:

Remove usage of UNREFERENCED* macros to make code style more consistent

Result:

Fixes https://github.com/netty/netty-tcnative/issues/102.