### PR TITLE
Update to latest recommended maven version

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip


### PR DESCRIPTION
Motivation:

Latest recommended maven version is 3.6.2 so we should use it

Modifications:

Update from 3.5.2 to 3.6.2

Result:

Use latest recommended maven version