### PR TITLE
Use ninjia-build if possible

### DIFF
--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -261,7 +261,17 @@
                           <arg value="-GNinja" />
                           <arg value=".." />
                         </exec>
-                        <exec executable="ninja" failonerror="true" dir="${libresslBuildDir}" resolveexecutable="true" />
+                        <if>
+                          <!-- may be called ninja-build or ninja -->
+                          <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                          <available file="ninja-build" filepath="${env.PATH}" />
+                          <then>
+                            <exec executable="ninja-build" failonerror="true" dir="${libresslBuildDir}" resolveexecutable="true" />
+                          </then>
+                          <else>
+                            <exec executable="ninja" failonerror="true" dir="${libresslBuildDir}" resolveexecutable="true" />
+                          </else>
+                        </if>
                       </else>
                     </if>
                   </target>


### PR DESCRIPTION
Similar with https://github.com/netty/netty-tcnative/issues/475, on CentOS 7, ninjia is called ninjia-build, try to use `ninjia-build` if possible.