### PR TITLE
aarch64 cross compile support

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -329,6 +329,322 @@
       </build>
     </profile>
 
+    <profile>
+      <id>linux-aarch64</id>
+
+      <properties>
+        <boringsslCheckoutDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslCheckoutDir>
+        <boringsslBuildDir>${boringsslCheckoutDir}/build</boringsslBuildDir>
+        <linkStatic>true</linkStatic>
+        <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
+        <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
+        <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
+        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch64.jar</nativeJarFile>
+      </properties>
+
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <dependencies>
+                <!-- Provides the 'requireFilesContent' enforcer rule. -->
+                <dependency>
+                  <groupId>com.ceilfors.maven.plugin</groupId>
+                  <artifactId>enforcer-rules</artifactId>
+                  <version>1.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-release-environment</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireProperty>
+                      <regexMessage>
+                        Cross compile and Release process must be performed on linux-x86_64.
+                      </regexMessage>
+                      <property>os.detected.classifier</property>
+                      <regex>^linux-x86_64.*</regex>
+                    </requireProperty>
+                    <requireFilesContent>
+                      <message>
+                        Cross compile and Release process must be performed on RHEL 7.6 or its derivatives.
+                      </message>
+                      <files>
+                        <file>/etc/redhat-release</file>
+                      </files>
+                      <content>release 7.6</content>
+                    </requireFilesContent>
+                    <requireProperty>
+                      <property>aprArmHome</property>
+                      <message>The folder of APR for aarch64 must be specified by hand. Please try -DaprArmHome=</message>
+                    </requireProperty>
+                  </rules>
+                  <ignoreCache>true</ignoreCache>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Download the BoringSSL source -->
+          <plugin>
+            <artifactId>maven-scm-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>get-boringssl</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>checkout</goal>
+                </goals>
+                <configuration>
+                  <checkoutDirectory>${boringsslCheckoutDir}</checkoutDirectory>
+                  <connectionType>developerConnection</connectionType>
+                  <developerConnectionUrl>scm:git:https://boringssl.googlesource.com/boringssl</developerConnectionUrl>
+                  <scmVersion>${boringsslBranch}</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
+                  <skipCheckoutIfExists>true</skipCheckoutIfExists>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Determine the commit ID of the source code. -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>create</goal>
+                </goals>
+                <configuration>
+                  <scmDirectory>${boringsslCheckoutDir}</scmDirectory>
+                  <buildNumberPropertyName>boringsslBuildNumber</buildNumberPropertyName>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${generatedSourcesDir}/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Add the commit ID and branch to the manifest. -->
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+              <instructions>
+                <Apr-Version>${aprVersion}</Apr-Version>
+                <BoringSSL-Revision>${boringsslBuildNumber}</BoringSSL-Revision>
+                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+              </instructions>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+
+              <!-- Only deploy to Maven Central if on centos (fedora). -->
+              <execution>
+                <id>skip-deploy</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="maven.deploy.skip" value="false" else="true">
+                      <isset property="os.detected.release.like.fedora" />
+                    </condition>
+                  </target>
+                </configuration>
+              </execution>
+
+              <!-- Build the BoringSSL static libs -->
+              <execution>
+                <id>build-boringssl</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                    <property environment="env" />
+                    <if>
+                      <available file="${boringsslBuildDir}" />
+                      <then>
+                        <echo message="BoringSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Building BoringSSL" />
+
+                        <mkdir dir="${boringsslBuildDir}" />
+
+                        <if>
+                          <equals arg1="${os.detected.name}" arg2="windows" />
+                          <then>
+                            <!-- On Windows, build with /MT for static linking -->
+                            <property name="cmakeAsmFlags" value="" />
+                            <property name="cmakeCFlags" value="/MT" />
+                            <!-- Disable one warning to be able to build on windows -->
+                            <property name="cmakeCxxFlags" value="/MT /wd4091" />
+                          </then>
+                          <elseif>
+                            <equals arg1="${os.detected.name}" arg2="linux" />
+                            <then>
+                              <!-- On *nix, add ASM flags to disable executable stack -->
+                              <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                              <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                              <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                            </then>
+                          </elseif>
+                          <else>
+                            <!-- On *nix, add ASM flags to disable executable stack -->
+                            <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                            <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                            <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
+                          </else>
+                        </if>
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="-DCMAKE_SYSTEM_NAME=Linux" />
+                          <arg value="-DCMAKE_SYSTEM_PROCESSOR=aarch64" />
+                          <arg value="-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc" />
+                          <arg value="-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++" />
+                          <arg value="-GNinja" />
+                          <arg value=".." />
+                        </exec>
+                        <if>
+                          <!-- may be called ninja-build or ninja -->
+                          <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                          <available file="ninja-build" filepath="${env.PATH}" />
+                          <then>
+                            <exec executable="ninja-build" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                          </then>
+                          <else>
+                            <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                          </else>
+                        </if>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <!-- Strip on linux. See https://github.com/netty/netty-tcnative/issues/129 -->
+                    <if>
+                      <and>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <equals arg1="${strip.skip}" arg2="false" />
+                      </and>
+                      <then>
+                        <exec executable="aarch64-linux-gnu-strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
+                          <arg value="--strip-debug" />
+                          <arg value="libnetty_tcnative.so" />
+                        </exec>
+                      </then>
+                    </if>
+
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                    </copy>
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <attachartifact file="${nativeJarFile}" classifier="${os.detected.name}-aarch64" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Configure the distribution statically linked against OpenSSL and APR -->
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <name>netty_tcnative</name>
+                  <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
+                  <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
+                  <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                  <forceAutogen>${forceAutogen}</forceAutogen>
+                  <forceConfigure>${forceConfigure}</forceConfigure>
+                  <windowsBuildTool>msbuild</windowsBuildTool>
+                  <!-- <verbose>true</verbose> -->
+                  <configureArgs>
+                    <configureArg>--with-ssl=no</configureArg>
+                    <configureArg>--with-apr=${aprArmHome}</configureArg>
+                    <configureArg>--with-static-libs</configureArg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
+                    <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
+                    <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
+                    <configureArg>--host=aarch64-linux-gnu</configureArg>
+                  </configureArgs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!--
       Profile that builds the uber-jar containing native libraries for all platforms. When this
       is active, it will automatically disable the default profile. This should only be used
@@ -395,6 +711,14 @@
                       <groupId>io.netty</groupId>
                       <artifactId>netty-tcnative-boringssl-static</artifactId>
                       <version>${project.version}</version>
+                      <classifier>linux-aarch_64</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${unpackDir}/linux-aarch_64</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>io.netty</groupId>
+                      <artifactId>netty-tcnative-boringssl-static</artifactId>
+                      <version>${project.version}</version>
                       <classifier>windows-${uberArch}</classifier>
                       <type>jar</type>
                       <outputDirectory>${unpackDir}/windows-${uberArch}</outputDirectory>
@@ -436,6 +760,10 @@
                       <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
+                      <fileset dir="${unpackDir}/linux-aarch_64/META-INF/native" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_aarch_64.*" />
+                    </copy>
+                    <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/windows-${uberArch}/META-INF/native" />
                       <globmapper from="netty_tcnative.*" to="netty_tcnative_windows_${uberArch}.*" />
                     </copy>
@@ -464,6 +792,7 @@
                     <Bundle-NativeCode>
                       META-INF/native/libnetty_tcnative_osx_${uberArch}.jnilib;osname=macos;osname=macosx;processor=${uberArch},
                       META-INF/native/libnetty_tcnative_linux_${uberArch}.so;osname=linux;processor=${uberArch},
+                      META-INF/native/libnetty_tcnative_linux_aarch_64.so;osname=linux;processor=aarch_64,
                       META-INF/native/netty_tcnative_windows_${uberArch}.dll;osname=win32;processor=${uberArch}
                     </Bundle-NativeCode>
                   </instructions>

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,0 +1,67 @@
+FROM centos:7.6.1810
+
+ARG gcc_version=4.9-2016.02
+ARG openssl_version=1_1_1d
+ARG apr_version=1.6.5
+
+ENV GCC_VERSION $gcc_version
+ENV OPENSSL_VERSION $openssl_version
+ENV APR_VERSION $apr_version
+
+# Install requirements
+RUN  set -x && \
+  yum -y install epel-release && \
+  yum -y install wget tar git make autoconf automake libtool openssl-devel ninja-build gcc-c++
+
+# Install Java and Golang
+RUN yum install -y java-1.8.0-openjdk-devel golang
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
+
+# Install aarch64 gcc 4.9 toolchain
+RUN set -x && \
+  wget https://releases.linaro.org/components/toolchain/binaries/$GCC_VERSION/aarch64-linux-gnu/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz && \
+  tar xvf gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz
+ENV PATH="/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu/bin:${PATH}"
+
+# Install CMake
+RUN yum install -y cmake3 && ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+# Cross compile Apache Apr for aarch64 - static
+RUN set -x && \
+  wget https://www-us.apache.org/dist/apr/apr-$APR_VERSION.tar.gz && \
+  tar xvf apr-$APR_VERSION.tar.gz && \
+  pushd apr-$APR_VERSION && \
+  CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --disable-shared --prefix=/opt/apr-$APR_VERSION-static --host=aarch64-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
+  make || true && \
+  pushd tools && \
+  gcc -Wall -O2 -DCROSS_COMPILE gen_test_char.c -s -o gen_test_char && \
+  popd && \
+  make && make install && \
+  popd
+
+# Cross compile Apache Apr for aarch64 - share
+RUN set -x && \
+  wget https://www-us.apache.org/dist//apr/apr-$APR_VERSION.tar.gz && \
+  tar xvf apr-$APR_VERSION.tar.gz && \
+  pushd apr-$APR_VERSION && \
+  CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --prefix=/opt/apr-$APR_VERSION-share --host=aarch64-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
+  make || true && \
+  pushd tools && \
+  gcc -Wall -O2 -DCROSS_COMPILE gen_test_char.c -s -o gen_test_char && \
+  popd && \
+  make && make install && \
+  popd
+
+# Cross compile OpenSSL for aarch64 - share
+RUN set -x && \
+  wget https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz && \
+  tar xvf OpenSSL_$OPENSSL_VERSION.tar.gz && \
+  pushd openssl-OpenSSL_$OPENSSL_VERSION && \
+  ./Configure linux-aarch64 --cross-compile-prefix=aarch64-linux-gnu- --prefix=/opt/openssl-$OPENSSL_VERSION-share shared && \
+  make && make install && \
+  popd
+
+# Get Netty-tcnative source
+RUN set -x && \
+  git clone https://github.com/netty/netty-tcnative
+

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -60,7 +60,3 @@ RUN set -x && \
   ./Configure linux-aarch64 --cross-compile-prefix=aarch64-linux-gnu- --prefix=/opt/openssl-$OPENSSL_VERSION-share shared && \
   make && make install && \
   popd
-
-# Get Netty-tcnative source
-RUN set -x && \
-  git clone https://github.com/netty/netty-tcnative

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -41,7 +41,7 @@ RUN set -x && \
 
 # Cross compile Apache Apr for aarch64 - share
 RUN set -x && \
-  wget https://www-us.apache.org/dist//apr/apr-$APR_VERSION.tar.gz && \
+  wget https://downloads.apache.org//apr/apr-$APR_VERSION.tar.gz && \
   tar xvf apr-$APR_VERSION.tar.gz && \
   pushd apr-$APR_VERSION && \
   CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --prefix=/opt/apr-$APR_VERSION-share --host=aarch64-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
@@ -64,4 +64,3 @@ RUN set -x && \
 # Get Netty-tcnative source
 RUN set -x && \
   git clone https://github.com/netty/netty-tcnative
-

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -28,7 +28,7 @@ RUN yum install -y cmake3 && ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 # Cross compile Apache Apr for aarch64 - static
 RUN set -x && \
-  wget https://www-us.apache.org/dist/apr/apr-$APR_VERSION.tar.gz && \
+  wget https://downloads.apache.org//apr/apr-$APR_VERSION.tar.gz && \
   tar xvf apr-$APR_VERSION.tar.gz && \
   pushd apr-$APR_VERSION && \
   CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --disable-shared --prefix=/opt/apr-$APR_VERSION-static --host=aarch64-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,5 +33,11 @@ docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.deb
 docker-compose -f docker/docker-compose.opensuse.yaml -f docker/docker-compose.opensuse-151.18.yaml run build
 ```
 
+## centos7 with java8 for aarch64 cross compile
+
+```
+docker-compose -f docker/docker-compose.centos.yaml run cross-compile-aarch64
+```
+
 etc, etc
 

--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -55,5 +55,5 @@ services:
       - ~/.gitconfig:/root/.gitconfig:delegated
       - ~/.gitignore:/root/.gitignore:delegated
       - ..:/code:delegated
-    command: /bin/bash -cl "pushd ./openssl-dynamic && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-share -DopensslArmHome=/opt/openssl-$OPENSSL_VERSION-share -DskipTests && popd && pushd ./boringssl-static && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-static -DskipTests && popd"
+    command: /bin/bash -cl "pushd ./openssl-dynamic && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && popd && pushd ./boringssl-static && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-static -DskipTests && popd"
     working_dir: /code

--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -48,4 +48,11 @@ services:
   cross-compile-aarch64:
     image: netty-tcnative-centos:cross_compile_aarch64
     depends_on: [cross-compile-aarch64-runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2:/root/.m2:delegated
+      - ~/.gitconfig:/root/.gitconfig:delegated
+      - ~/.gitignore:/root/.gitignore:delegated
+      - ..:/code:delegated
     command: /bin/bash -cl "pushd netty-tcnative/openssl-dynamic && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-share -DopensslArmHome=/opt/openssl-$OPENSSL_VERSION-share -DskipTests && popd && pushd netty-tcnative/boringssl-static && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-static -DskipTests && popd"

--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -55,4 +55,5 @@ services:
       - ~/.gitconfig:/root/.gitconfig:delegated
       - ~/.gitignore:/root/.gitignore:delegated
       - ..:/code:delegated
-    command: /bin/bash -cl "pushd netty-tcnative/openssl-dynamic && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-share -DopensslArmHome=/opt/openssl-$OPENSSL_VERSION-share -DskipTests && popd && pushd netty-tcnative/boringssl-static && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-static -DskipTests && popd"
+    command: /bin/bash -cl "pushd ./openssl-dynamic && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-share -DopensslArmHome=/opt/openssl-$OPENSSL_VERSION-share -DskipTests && popd && pushd ./boringssl-static && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-static -DskipTests && popd"
+    working_dir: /code

--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -34,3 +34,18 @@ services:
       - ~/.gitignore:/root/.gitignore:delegated
       - ..:/code:delegated
     entrypoint: /bin/bash
+
+  cross-compile-aarch64-runtime-setup:
+    image: netty-tcnative-centos:cross_compile_aarch64
+    build:
+      context: .
+      dockerfile: Dockerfile.cross_compile_aarch64
+      args:
+        gcc_version: "4.9-2016.02"
+        apr_version: "1.6.5"
+        openssl_version: "1_1_1d"
+
+  cross-compile-aarch64:
+    image: netty-tcnative-centos:cross_compile_aarch64
+    depends_on: [cross-compile-aarch64-runtime-setup]
+    command: /bin/bash -cl "pushd netty-tcnative/openssl-dynamic && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-share -DopensslArmHome=/opt/openssl-$OPENSSL_VERSION-share -DskipTests && popd && pushd netty-tcnative/boringssl-static && ../mvnw clean install -Plinux-aarch64 -DaprArmHome=/opt/apr-$APR_VERSION-static -DskipTests && popd"

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -219,5 +219,159 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>linux-aarch64</id>
+
+      <properties>
+        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch64.jar</nativeJarFile>
+      </properties>
+
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-jar-plugin</artifactId>
+              <configuration>
+                <archive>
+                  <manifestEntries>
+                    <Automatic-Module-Name>io.netty.tcnative.openssl.dynamic</Automatic-Module-Name>
+                  </manifestEntries>
+                </archive>
+              </configuration>
+            </plugin>
+            <plugin>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <dependencies>
+                <!-- Provides the 'requireFilesContent' enforcer rule. -->
+                <dependency>
+                  <groupId>com.ceilfors.maven.plugin</groupId>
+                  <artifactId>enforcer-rules</artifactId>
+                  <version>1.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-release-environment</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireProperty>
+                      <regexMessage>
+                        Cross compile and Release process must be performed on linux-x86_64.
+                      </regexMessage>
+                      <property>os.detected.classifier</property>
+                      <regex>^linux-x86_64.*</regex>
+                    </requireProperty>
+                    <requireFilesContent>
+                      <message>
+                        Cross compile and Release process must be performed on RHEL 7.6 or its derivatives.
+                      </message>
+                      <files>
+                        <file>/etc/redhat-release</file>
+                      </files>
+                      <content>release 7.6</content>
+                    </requireFilesContent>
+                    <requireProperty>
+                      <property>aprArmHome</property>
+                      <message>The folder of APR for aarch64 must be specified by hand. Please try -DaprArmHome=</message>
+                    </requireProperty>
+                    <requireProperty>
+                      <property>opensslArmHome</property>
+                      <message>The folder of OpenSSL for aarch64 must be specified by hand. Please try -DopensslArmHome=</message>
+                    </requireProperty>
+                  </rules>
+                  <ignoreCache>true</ignoreCache>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                    </copy>
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
+                    <condition property="classifier" value="${os.detected.name}-aarch64-fedora">
+                      <isset property="os.detected.release.like.fedora" />
+                    </condition>
+                    <condition property="classifier" value="${os.detected.name}-aarch64-suse">
+                      <isset property="os.detected.release.like.suse" />
+                    </condition>
+                    <condition property="classifier" value="${os.detected.name}-aarch64-arch">
+                      <isset property="os.detected.release.like.arch" />
+                    </condition>
+                    <condition property="classifier" value="${os.detected.name}-aarch64">
+                      <not>
+                        <or>
+                          <isset property="os.detected.release.like.fedora" />
+                          <isset property="os.detected.release.like.suse" />
+                          <isset property="os.detected.release.like.arch" />
+                        </or>
+                      </not>
+                    </condition>
+                    <attachartifact file="${nativeJarFile}" classifier="${classifier}" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Generate the .so/.dynlib/.dll as part of the build. -->
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <name>netty_tcnative</name>
+                  <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+                  <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                  <forceAutogen>${forceAutogen}</forceAutogen>
+                  <forceConfigure>${forceConfigure}</forceConfigure>
+                  <configureArgs>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>--with-apr=${aprArmHome}</configureArg>
+                    <configureArg>--with-ssl=${opensslArmHome}</configureArg>
+                    <configureArg>--host=aarch64-linux-gnu</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Motivation:

openssl-dynamic and boringssl-static which are packaged in Maven Repo don't support aarch64 platform.

Modifications:

Add cross compile support for openssl-dynamic and boringssl-static. Now their linux aarch64 packages can be released from the X86 machine.

**Note**:  when testing this PR locally, don't forget to fetch it in Dockerfile or fetch the PR in docker volume. 
```
# Add this after clone netty-tcnative code.
RUN set -x && \
  pushd netty-tcnative && \
  git config --global user.email "you@example.com" && \
  git config --global user.name "Your Name" && \
  git fetch origin refs/pull/517/head:pr_517 && \
  git checkout pr_517 && \
  git rebase master && \
  popd
```

Result:

Fixes #515