### PR TITLE
Update to java8-242

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-232"
+        java_version : "adopt@1.8.0-242"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "adopt@1.8.0-232"
+        java_version : "adopt@1.8.0-242"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
Motivation:

A new java 8 version was released, lets use it

Modifications:

Update to java8-242

Result:

Use latest java8 version