### PR TITLE
Update to latest netty-build release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <netty.build.version>22</netty.build.version>
+    <netty.build.version>26</netty.build.version>
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <forceAutogen>false</forceAutogen>
     <forceConfigure>false</forceConfigure>


### PR DESCRIPTION
Motivation:

A new netty-build release is out.

Modifications:

Update to version 26

Result:

Use latest version of netty-build