### PR TITLE
Use git 2.x on centos6 and update maven scm plugin

### DIFF
--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -9,6 +9,9 @@ ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 
+# We want to have git 2.x for the maven scm plugin
+RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
+
 # install dependencies
 RUN yum install -y \
  apr-devel \

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>1.9.4</version>
+          <version>1.11.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
Motivation:

To be able to use the maven scm plugin with a specific revision of a repository we need to have git 2.x installed.

Modifications:

- Ensure we install git 2.x when on centos 6 (as it ships with 1.7)
- Update scm plugin

Result:

Be able to checkout specific revision with scm plugin