### PR TITLE
Explicit specify build target for boringssl

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -220,12 +220,18 @@
                           <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
                           <available file="ninja-build" filepath="${env.PATH}" />
                           <then>
-                            <exec executable="ninja-build" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                            <property name="ninjaExecutable" value="ninja-build" />
                           </then>
                           <else>
-                            <exec executable="ninja" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                            <property name="ninjaExecutable" value="ninja" />
                           </else>
                         </if>
+                        <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="crypto/libcrypto.a" />
+                          <arg value="crypto/fipsmodule/fipsmodule" />
+                          <arg value="ssl/libssl.a" />
+                          <arg value="decrepit/libdecrepit.a" />
+                        </exec>
                       </else>
                     </if>
                   </target>


### PR DESCRIPTION
Motivation:

Some tests do not compile on centos6 after the latest update of the chromium-stable branch. To workaround this we just dont compile the tests anymore for boringssl (we didnt run these anyway).

Modifications:

Explicit specify targets when building boringssl

Result:

Be able to build boringssl-static again on cents 6