### PR TITLE
Specify MACOSX_DEPLOYMENT_TARGET to ensure native lib can also be use…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -305,6 +305,7 @@
                     <configureArg>--with-apr=${aprHome}</configureArg>
                     <configureArg>--with-static-libs</configureArg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>${macOsxDeploymentTarget}</configureArg>
                     <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -212,6 +212,7 @@
                           <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="${cmakeOsxDeploymentTarget}" />
                           <arg value="-GNinja" />
                           <arg value=".." />
                         </exec>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -140,6 +140,7 @@
                 <configureArg>--with-apr=${aprHome}</configureArg>
                 <configureArg>--with-static-libs</configureArg>
                 <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                <configureArg>${macOsxDeploymentTarget}</configureArg>
                 <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                 <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${libresslCheckoutDir}/include</configureArg>
                 <configureArg>LDFLAGS=-L${libresslBuildDir}/ssl -L${libresslBuildDir}/crypto -L${libresslBuildDir}/tls -ltls -lssl -lcrypto</configureArg>
@@ -258,6 +259,7 @@
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
                           <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer -fPIC" />
+                          <arg value="${cmakeOsxDeploymentTarget}" />
                           <arg value="-GNinja" />
                           <arg value=".." />
                         </exec>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -204,6 +204,7 @@
                   <forceAutogen>${forceAutogen}</forceAutogen>
                   <forceConfigure>${forceConfigure}</forceConfigure>
                   <configureArgs>
+                    <configureArg>${macOsxDeploymentTarget}</configureArg>
                     <configureArg>--with-apr=/usr/local/opt/apr/libexec/</configureArg>
                   </configureArgs>
                 </configuration>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -133,6 +133,7 @@
               <forceConfigure>${forceConfigure}</forceConfigure>
               <windowsBuildTool>msbuild</windowsBuildTool>
               <configureArgs>
+                <configureArg>${macOsxDeploymentTarget}</configureArg>
                 <configureArg>--with-ssl=${sslHome}</configureArg>
                 <configureArg>--with-apr=${aprHome}</configureArg>
                 <configureArg>--with-static-libs</configureArg>
@@ -390,7 +391,7 @@
                         <echo message="Building OpenSSL" />
                         <mkdir dir="${sslHome}" />
                         <exec executable="Configure" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
-                          <arg line="darwin64-x86_64-cc -O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome}" />
+                          <arg line="darwin64-x86_64-cc -O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${sslHome} --openssldir=${sslHome} ${macOsxDeploymentTarget}" />
                         </exec>
                         <exec executable="make" failonerror="true" dir="${opensslBuildDir}" resolveexecutable="true">
                           <arg value="depend" />

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,8 @@
     <msvcSslLibs>libssl.lib;libcrypto.lib</msvcSslLibs>
     <strip.skip>false</strip.skip>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
+    <macOsxDeploymentTarget>MACOSX_DEPLOYMENT_TARGET=10.9</macOsxDeploymentTarget>
+    <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9</cmakeOsxDeploymentTarget>
   </properties>
 
   <build>
@@ -499,7 +501,7 @@
                         <echo message="Building APR" />
                         <mkdir dir="${aprHome}" />
                         <exec executable="configure" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">
-                          <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC'" />
+                          <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ${macOsxDeploymentTarget}" />
                         </exec>
                         <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true" />
                         <exec executable="make" failonerror="true" dir="${aprBuildDir}" resolveexecutable="true">


### PR DESCRIPTION
…d on older MacOS releases

Motivation:

We did not specify MACOSX_DEPLOYMENT_TARGET before which lead to a situation where we broke the ability to use netty-tcnative on MacOS 10.13 and older.

Modifications:

Use MACOSX_DEPLOYMENT_TARGET=10.9 when building lib

Result:

Fixes https://github.com/netty/netty-tcnative/issues/523