### PR TITLE
Only specify build target on linux

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -227,12 +227,20 @@
                             <property name="ninjaExecutable" value="ninja" />
                           </else>
                         </if>
-                        <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                          <arg value="crypto/libcrypto.a" />
-                          <arg value="crypto/fipsmodule/fipsmodule" />
-                          <arg value="ssl/libssl.a" />
-                          <arg value="decrepit/libdecrepit.a" />
-                        </exec>
+                        <if>
+                          <equals arg1="${os.detected.name}" arg2="linux" />
+                          <then>
+                            <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                              <arg value="crypto/libcrypto.a" />
+                              <arg value="crypto/fipsmodule/fipsmodule" />
+                              <arg value="ssl/libssl.a" />
+                              <arg value="decrepit/libdecrepit.a" />
+                            </exec>
+                          </then>
+                          <else>
+                            <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                          </else>
+                        </if>
                       </else>
                     </if>
                   </target>


### PR DESCRIPTION
Motivation:

371ec47f4bde69aa008677081625280f41c042db did add an explicit build target. This is only needed on linux and even dont work at all on windows.

Modifications:

Only use explicit build target when on linux

Result:

Compiles again on windows