### PR TITLE
Correctly free tcn_ssl_state_t to prevent memory leak

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -918,6 +918,11 @@ static void free_ssl_state(tcn_ssl_state_t* state) {
     tcn_get_java_env(&e);
     tcn_ssl_task_free(e, state->ssl_task);
     state->ssl_task = NULL;
+
+    // Free the tcn_ssl_state_t itself as it was allocated via OPENSSL_malloc(...) before
+    //
+    // https://github.com/netty/netty-tcnative/issues/532
+    OPENSSL_free(state);
 }
 
 TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,


### PR DESCRIPTION
Motivation:

We failed to free tcn_ssl_state_t via OPENSSL_free(...) which produced a small memory leak. This regression was introduced by https://github.com/netty/netty-tcnative/pull/498.

Modifications:

Correctly call OPENSSL_free(...) on previous allocated tcn_ssl_state_t.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/532.