### PR TITLE
Update to openssl 1.1.1e for openssl-static

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
     -->
     <libresslSha256>df7b172bf79b957dd27ef36dcaa1fb162562c0e8999e194aa8c1a3df2f15398e</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>d</opensslPatchVersion>
+    <opensslPatchVersion>e</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2</opensslSha256>
+    <opensslSha256>694f61ac11cb51c9bf73f54e771ff6022b0327a43bbdfa1b2f19de1662a6dcbe</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

There was a new release of openssl 1.1.1

Modifications:

Update to latest release for openssl-static

Result:

Use latest openssl version