### PR TITLE
Support building openssl-static with older openssl releases as well

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -178,9 +178,22 @@
                       <else>
                         <echo message="Downloading OpenSSL" />
 
-                        <get src="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                        <condition property="opensslFound"> 
+                          <http url="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz"/> 
+                        </condition> 
+                         <if>
+                          <equals arg1="${opensslFound}" arg2="true" />
+                          <then>
+                            <!-- Download the openssl source. -->
+                            <get src="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                          </then>
+                          <else>
+                           <!-- Download the openssl source from the old directory -->
+                            <get src="https://www.openssl.org/source/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                          </else>
+                        </if>
                         <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
-    
+
                         <gunzip src="${project.build.directory}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/" />
                         <untar src="${project.build.directory}/openssl-${opensslVersion}.tar" dest="${project.build.directory}/" />
                       </else>
@@ -274,13 +287,26 @@
                       <else>
                         <echo message="Downloading OpenSSL" />
 
-                        <get src="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                        <condition property="opensslFound"> 
+                          <http url="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz"/> 
+                        </condition> 
+                         <if>
+                          <equals arg1="${opensslFound}" arg2="true" />
+                          <then>
+                            <!-- Download the openssl source. -->
+                            <get src="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                          </then>
+                          <else>
+                           <!-- Download the openssl source from the old directory -->
+                            <get src="https://www.openssl.org/source/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                          </else>
+                        </if>
                         <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
 
                         <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
                         <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                          <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
-                        </exec>
+                           <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
+                         </exec>
                       </else>
                     </if>
                   </target>
@@ -358,14 +384,26 @@
                       <else>
                         <echo message="Downloading OpenSSL" />
 
-                        <!-- Download the openssl source. -->
-                        <get src="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
-                          <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
-  
-                          <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
-                          <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
-                            <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
-                          </exec>
+                        <condition property="opensslFound"> 
+                          <http url="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz"/> 
+                        </condition> 
+                         <if>
+                          <equals arg1="${opensslFound}" arg2="true" />
+                          <then>
+                            <!-- Download the openssl source. -->
+                            <get src="https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                          </then>
+                          <else>
+                           <!-- Download the openssl source from the old directory -->
+                            <get src="https://www.openssl.org/source/old/${opensslMinorVersion}/openssl-${opensslVersion}.tar.gz" dest="${project.build.directory}/openssl-${opensslVersion}.tar.gz" verbose="on" />
+                          </else>
+                        </if>
+                        <checksum file="${project.build.directory}/openssl-${opensslVersion}.tar.gz" algorithm="SHA-256" property="${opensslSha256}" verifyProperty="isEqual" />
+
+                        <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->
+                        <exec executable="tar" failonerror="true" dir="${project.build.directory}/" resolveexecutable="true">
+                           <arg line="xfvz openssl-${opensslVersion}.tar.gz" />
+                         </exec>
                       </else>
                     </if>
                   </target>


### PR DESCRIPTION
Motivation:

Old openssl releases are hosted in a different location as new releases.

Modifications:

If we can not find the tarball in the expected location try to download from the location that contains old releases

Result:

https://github.com/netty/netty-tcnative/issues/536