### PR TITLE
Update to openssl 1.1.1g

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
     -->
     <libresslSha256>df7b172bf79b957dd27ef36dcaa1fb162562c0e8999e194aa8c1a3df2f15398e</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>e</opensslPatchVersion>
+    <opensslPatchVersion>g</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>694f61ac11cb51c9bf73f54e771ff6022b0327a43bbdfa1b2f19de1662a6dcbe</opensslSha256>
+    <opensslSha256>ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

A new openssl version was released with a security fix.

Modifications:

Update to 1.1.1g

Result:

Use latest version for static linking openssl