### PR TITLE
Update to latest stable libressl release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,11 @@
     <aprVersion>1.6.5</aprVersion>
     <aprSha256>70dcf9102066a2ff2ffc47e93c289c8e54c95d8dda23b503f9e61bb0cbd2d105</aprSha256>
     <boringsslBranch>chromium-stable</boringsslBranch>
-    <libresslVersion>3.0.2</libresslVersion>
+    <libresslVersion>3.1.1</libresslVersion>
     <!--
       See https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/SHA256 for the SHA256 signature
     -->
-    <libresslSha256>df7b172bf79b957dd27ef36dcaa1fb162562c0e8999e194aa8c1a3df2f15398e</libresslSha256>
+    <libresslSha256>bdc6ce5ebb3a2eafc4c475f7eeaa5f0a8e60d9bead01efb76e2e254242b6db00</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
     <opensslPatchVersion>g</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>


### PR DESCRIPTION
Motivation:

Libressl 3.1.1 is the latest stable release which also supports TLS1.3 etc

Modifications:

Update libressl version

Result:

Use latest libressl version when compiling statically against libressl