### PR TITLE
Update to latest java8 release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-242"
+        java_version : "adopt@1.8.0-252"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "adopt@1.8.0-242"
+        java_version : "adopt@1.8.0-252"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8

--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.212-03"
+        java_version : "adopt@1.8.0-252"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should use latest java8 releases on the CI

Modifications:

Update java8 version

Result:

Use latest release on the CI