### PR TITLE
Fixup classifier in boringssl/pom.xml from aarch_64 to aarch64

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -711,7 +711,7 @@
                       <groupId>io.netty</groupId>
                       <artifactId>netty-tcnative-boringssl-static</artifactId>
                       <version>${project.version}</version>
-                      <classifier>linux-aarch_64</classifier>
+                      <classifier>linux-aarch64</classifier>
                       <type>jar</type>
                       <outputDirectory>${unpackDir}/linux-aarch_64</outputDirectory>
                     </artifactItem>


### PR DESCRIPTION
Fixup classifier specification in boringssl-static/pom.xml to correct a typo that was also seen in recent release of netty.