### PR TITLE
Add methods / interfaces to write external SSL_SESSION cache and so b…

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -45,6 +45,7 @@
 #include "native_constants.h"
 #include "ssl.h"
 #include "sslcontext.h"
+#include "sslsession.h"
 #include "error.h"
 
 #ifndef TCN_JNI_VERSION
@@ -302,6 +303,7 @@ static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* 
     int errorOnLoadCalled = 0;
     int bufferOnLoadCalled = 0;
     int jniMethodsOnLoadCalled = 0;
+    int sessionOnLoadCalled = 0;
     int sslOnLoadCalled = 0;
     int contextOnLoadCalled = 0;
 
@@ -334,6 +336,11 @@ static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* 
         goto error;
     }
     contextOnLoadCalled = 1;
+
+    if (netty_internal_tcnative_SSLSession_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto error;
+    }
+    sessionOnLoadCalled = 1;
 
     apr_version_t apv;
     int apvn;
@@ -378,6 +385,9 @@ error:
     if (contextOnLoadCalled == 1) {
         netty_internal_tcnative_SSLContext_JNI_OnUnLoad(env);
     }
+    if (sessionOnLoadCalled == 1) {
+        netty_internal_tcnative_SSLSession_JNI_OnUnLoad(env);
+    }
     return JNI_ERR;
 }
 
@@ -393,6 +403,7 @@ static void netty_internal_tcnative_Library_JNI_OnUnLoad(JNIEnv* env) {
     netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(env);
     netty_internal_tcnative_SSL_JNI_OnUnLoad(env);
     netty_internal_tcnative_SSLContext_JNI_OnUnLoad(env);
+    netty_internal_tcnative_SSLSession_JNI_OnUnLoad(env);
 }
 
 /* Fix missing Dl_info & dladdr in AIX

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -62,6 +62,18 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSessCacheServe
     return SSL_SESS_CACHE_SERVER;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSessCacheClient)(TCN_STDARGS) {
+    return SSL_SESS_CACHE_CLIENT;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSessCacheNoInternalLookup)(TCN_STDARGS) {
+    return SSL_SESS_CACHE_NO_INTERNAL_LOOKUP;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSessCacheNoInternalStore)(TCN_STDARGS) {
+    return SSL_SESS_CACHE_NO_INTERNAL_STORE;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslStConnect)(TCN_STDARGS) {
     return SSL_ST_CONNECT;
 }
@@ -554,6 +566,9 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpNoCompression, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheOff, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheServer, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSessCacheClient, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSessCacheNoInternalLookup, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslSessCacheNoInternalStore, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslStConnect, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslStAccept, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslModeEnablePartialWrite, ()I, NativeStaticallyReferencedJniMethods) },

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -309,6 +309,10 @@ struct tcn_ssl_ctxt_t {
     jobject                  sni_hostname_matcher;
     jmethodID                sni_hostname_matcher_method;
 
+    jobject                  ssl_session_cache;
+    jmethodID                ssl_session_cache_creation_method;
+    jmethodID                ssl_session_cache_get_method;
+
 #ifdef OPENSSL_IS_BORINGSSL
     jobject                  ssl_private_key_method;
     jmethodID                ssl_private_key_sign_method;
@@ -377,10 +381,12 @@ struct tcn_ssl_state_t {
 /*
  *  Additional Functions
  */
-void        tcn_SSL_init_app_state_idx(void);
-// The app_data2 is used to store the tcn_ssl_ctxt_t pointer for the SSL instance.
+void        tcn_init_app_state_idx(void);
+// The app_data is used to store the tcn_ssl_ctxt_t pointer for the SSL instance.
 void       *tcn_SSL_get_app_state(const SSL *);
 void        tcn_SSL_set_app_state(SSL *, void *);
+void       *tcn_SSL_CTX_get_app_state(const SSL_CTX *);
+void        tcn_SSL_CTX_set_app_state(SSL_CTX *, void *);
 
 int         tcn_SSL_password_callback(char *, int, int, void *);
 DH         *tcn_SSL_dh_get_tmp_param(int);

--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include "tcn.h"
+#include "ssl_private.h"
+#include "sslsession.h"
+
+
+TCN_IMPLEMENT_CALL(jlong, SSLSession, getTime)(TCN_STDARGS, jlong session)
+{
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+
+    TCN_CHECK_NULL(session_, session, 0);
+
+    return SSL_SESSION_get_time(session_);
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSLSession, getTimeout)(TCN_STDARGS, jlong session)
+{
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+
+    TCN_CHECK_NULL(session_, session, 0);
+
+    return SSL_SESSION_get_timeout(session_);
+}
+
+TCN_IMPLEMENT_CALL(jlong, SSLSession, setTimeout)(TCN_STDARGS, jlong session, jlong seconds)
+{ 
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+
+    TCN_CHECK_NULL(session_, session, 0);
+
+    return SSL_SESSION_set_timeout(session_, seconds);
+}
+
+TCN_IMPLEMENT_CALL(jbyteArray, SSLSession, getSessionId)(TCN_STDARGS, jlong session)
+{
+    unsigned int len;
+    const unsigned char *session_id = NULL;
+    jbyteArray bArray = NULL;
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+
+    TCN_CHECK_NULL(session_, session, NULL);
+
+    session_id = SSL_SESSION_get_id(session_, &len);
+    if (len == 0 || session_id == NULL) {
+        return NULL;
+    }
+    
+    if ((bArray = (*e)->NewByteArray(e, len)) == NULL) {
+        return NULL;
+    }
+    (*e)->SetByteArrayRegion(e, bArray, 0, len, (jbyte*) session_id);
+    return bArray;
+}
+
+TCN_IMPLEMENT_CALL(void, SSLSession, upRef)(TCN_STDARGS, jlong session) {
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+
+    TCN_CHECK_NULL(session_, session, /* void */);
+
+    SSL_SESSION_up_ref(session_);
+}
+
+TCN_IMPLEMENT_CALL(void, SSLSession, free)(TCN_STDARGS, jlong session) {
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+
+    TCN_CHECK_NULL(session_, session, /* void */);
+
+    SSL_SESSION_free(session_);
+}
+
+TCN_IMPLEMENT_CALL(jboolean, SSLSession, shouldBeSingleUse)(TCN_STDARGS, jlong session) {
+// Only supported by BoringSSL atm
+#ifdef OPENSSL_IS_BORINGSSL
+    SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
+    TCN_CHECK_NULL(session_, session, JNI_FALSE);
+    return SSL_SESSION_should_be_single_use(session_) == 0 ? JNI_FALSE : JNI_TRUE;
+#else 
+    return JNI_FALSE;
+#endif // OPENSSL_IS_BORINGSSL
+}
+
+// JNI Method Registration Table Begin
+static const JNINativeMethod method_table[] = {
+  { TCN_METHOD_TABLE_ENTRY(getTime, (J)J, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(getTimeout, (J)J, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(setTimeout, (JJ)J, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(getSessionId, (J)[B, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(free, (J)V, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(upRef, (J)V, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(shouldBeSingleUse, (J)Z, SSLSession) }
+};
+
+static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
+
+// JNI Method Registration Table End
+
+jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+    if (netty_internal_tcnative_util_register_natives(env,
+             packagePrefix,
+             "io/netty/internal/tcnative/SSLSession",
+             method_table, method_table_size) != 0) {
+        return JNI_ERR;
+    }
+    return TCN_JNI_VERSION;
+}
+
+void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env) { }

--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -66,12 +66,12 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSLSession, getSessionId)(TCN_STDARGS, jlong sess
     return bArray;
 }
 
-TCN_IMPLEMENT_CALL(void, SSLSession, upRef)(TCN_STDARGS, jlong session) {
+TCN_IMPLEMENT_CALL(jboolean, SSLSession, upRef)(TCN_STDARGS, jlong session) {
     SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
 
-    TCN_CHECK_NULL(session_, session, /* void */);
+    TCN_CHECK_NULL(session_, session, JNI_FALSE);
 
-    SSL_SESSION_up_ref(session_);
+    return SSL_SESSION_up_ref(session_) == 1 ? JNI_TRUE : JNI_FALSE;
 }
 
 TCN_IMPLEMENT_CALL(void, SSLSession, free)(TCN_STDARGS, jlong session) {
@@ -100,7 +100,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(setTimeout, (JJ)J, SSLSession) },
   { TCN_METHOD_TABLE_ENTRY(getSessionId, (J)[B, SSLSession) },
   { TCN_METHOD_TABLE_ENTRY(free, (J)V, SSLSession) },
-  { TCN_METHOD_TABLE_ENTRY(upRef, (J)V, SSLSession) },
+  { TCN_METHOD_TABLE_ENTRY(upRef, (J)Z, SSLSession) },
   { TCN_METHOD_TABLE_ENTRY(shouldBeSingleUse, (J)Z, SSLSession) }
 };
 

--- a/openssl-dynamic/src/main/c/sslsession.h
+++ b/openssl-dynamic/src/main/c/sslsession.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_TCNATIVE_SSLSESSION_H_
+#define NETTY_TCNATIVE_SSLSESSION_H_
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
+void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env);
+#endif /* NETTY_TCNATIVE_SSLSESSION_H_ */

--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -168,8 +168,9 @@ const char* tcn_SSL_cipher_authentication_method(const SSL_CIPHER* cipher){
  * SSL_get_ex_new_index() is called, so we _must_ do this at startup.
  */
 static int tcn_SSL_app_state_idx = -1;
+static int tcn_SSL_CTX_app_state_idx = -1;
 
-void tcn_SSL_init_app_state_idx()
+void tcn_init_app_state_idx()
 {
     int i;
 
@@ -177,6 +178,13 @@ void tcn_SSL_init_app_state_idx()
         /* we _do_ need to call this two times */
         for (i = 0; i <= 1; i++) {
             tcn_SSL_app_state_idx = SSL_get_ex_new_index(0, "tcn_ssl_state_t*", NULL, NULL, NULL);
+        }
+    }
+
+    if (tcn_SSL_CTX_app_state_idx == -1) {
+        /* we _do_ need to call this two times */
+        for (i = 0; i <= 1; i++) {
+            tcn_SSL_CTX_app_state_idx = SSL_CTX_get_ex_new_index(0, "tcn_ssl_ctxt_t*", NULL, NULL, NULL);
         }
     }
 }
@@ -191,6 +199,18 @@ void tcn_SSL_set_app_state(SSL *ssl, void *arg)
     SSL_set_ex_data(ssl, tcn_SSL_app_state_idx, (char *)arg);
     return;
 }
+
+void *tcn_SSL_CTX_get_app_state(const SSL_CTX *ctx)
+{
+    return (void *)SSL_CTX_get_ex_data(ctx, tcn_SSL_CTX_app_state_idx);
+}
+
+void tcn_SSL_CTX_set_app_state(SSL_CTX *ctx, void *arg)
+{
+    SSL_CTX_set_ex_data(ctx, tcn_SSL_CTX_app_state_idx, (char *)arg);
+    return;
+}
+
 
 int tcn_SSL_password_callback(char *buf, int bufsiz, int verify,
                           void *cb)

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -48,10 +48,12 @@ final class NativeStaticallyReferencedJniMethods {
      */
     static native int sslOpNoCompression();
 
-    /* Only support OFF and SERVER for now */
     static native int sslSessCacheOff();
     static native int sslSessCacheServer();
-
+    static native int sslSessCacheClient();
+    static native int sslSessCacheNoInternalLookup();
+    static native int sslSessCacheNoInternalStore();
+    
     static native int sslStConnect();
     static native int sslStAccept();
 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -81,6 +81,9 @@ public final class SSL {
 
     public static final long SSL_SESS_CACHE_OFF = sslSessCacheOff();
     public static final long SSL_SESS_CACHE_SERVER = sslSessCacheServer();
+    public static final long SSL_SESS_CACHE_CLIENT = sslSessCacheClient();
+    public static final long SSL_SESS_CACHE_NO_INTERNAL_LOOKUP = sslSessCacheNoInternalLookup();
+    public static final long SSL_SESS_CACHE_NO_INTERNAL_STORE = sslSessCacheNoInternalStore();
 
     public static final int SSL_SELECTOR_FAILURE_NO_ADVERTISE = 0;
     public static final int SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL = 1;
@@ -839,4 +842,31 @@ public final class SSL {
      * @return the task to run.
      */
     public static native Runnable getTask(long ssl);
+
+    /**
+     * Return {@code true} if the SSL_SESSION was reused. 
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_session_reused.html">SSL_session_reused</a>.
+     * 
+     * @param ssl the SSL instance (SSL *)
+     * @return {@code true} if the SSL_SESSION was reused, {@code false} otherwise.
+     */
+    public static native boolean isSessionReused(long ssl);
+
+    /**
+     * Sets the {@code SSL_SESSION} that should be used for {@code SSL}.
+     * @param ssl the SSL instance (SSL *)
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     * @return {@code true} if successful, {@code false} otherwise. 
+     */
+    public static native boolean setSession(long ssl, long session);
+
+
+    /**
+     * Returns the {@code SSL_SESSION} that is used for {@code SSL}.
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_get_session.html">SSL_get_session</a>.
+     * 
+     * @param ssl the SSL instance (SSL *)
+     * @return the SSL_SESSION instance (SSL_SESSION *) used
+     */
+    public static native long getSession(long ssl);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -623,4 +623,12 @@ public final class SSLContext {
      * @param method method to use for the given context.
      */
     public static native void setPrivateKeyMethod(long ctx, SSLPrivateKeyMethod method);
+
+    /**
+     * Set the {@link SSLSessionCache} that will be used if session caching is enabled.
+     * 
+     * @param ctx context to use.
+     * @param cache cache to use for the given context.
+     */
+    public static native void setSSLSessionCache(long ctx, SSLSessionCache cache);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSession.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSession.java
@@ -59,8 +59,9 @@ public final class SSLSession {
      * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_up_ref.html">SSL_SESSION_up_ref</a>.
      *
      * @param session the SSL_SESSION instance (SSL_SESSION *)
+     * @return {@code true} if successful, {@code false} otherwise. 
      */
-    public static native void upRef(long session);
+    public static native boolean upRef(long session);
 
      /**
      * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_free.html">SSL_SESSION_free</a>.

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSession.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSession.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Methods to operate on a {@code SSL_SESSION}.
+ */
+public final class SSLSession {
+
+    private SSLSession() { }
+    
+    /**
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_get_time.html">SSL_SESSION_get_time</a>.
+     *
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     * @return returns the time at which the session was established. The time is given in seconds since the Epoch
+     */
+    public static native long getTime(long session);
+
+    /**
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_get_timeout.html">SSL_SESSION_get_timeout</a>.
+     *
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     * @return returns the timeout for the session. The time is given in seconds since the Epoch
+     */
+    public static native long getTimeout(long session);
+
+    /**
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_set_timeout.html">SSL_SESSION_set_timeout</a>.
+     * 
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     * @param seconds timeout in seconds
+     * @return returns the timeout for the session before this call. The time is given in seconds since the Epoch
+     */
+    public static native long setTimeout(long session, long seconds);
+
+    /**
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_get_id.html">SSL_SESSION_get_id</a>.
+     *
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     * @return the session id as byte array representation obtained via SSL_SESSION_get_id.
+     */
+    public static native byte[] getSessionId(long session);
+
+    /**
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_up_ref.html">SSL_SESSION_up_ref</a>.
+     *
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     */
+    public static native void upRef(long session);
+
+     /**
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_free.html">SSL_SESSION_free</a>.
+     *
+     * @param session the SSL_SESSION instance (SSL_SESSION *)
+     */
+    public static native void free(long session);
+
+    /**
+     * Will return {@code true} if the session should only re-used once.
+     * See <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_SESSION_should_be_single_use">SSL_SESSION_should_be_single_use</a>. 
+     * @param session
+     * @return {@code true} if the session should be re-used once only, {@code false} otherwise.
+     */
+    public static native boolean shouldBeSingleUse(long session);
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSessionCache.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSessionCache.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Allows to implement a custom external {@code SSL_SESSION} cache.
+ * 
+ * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_sess_set_get_cb.html">SSL_CTX_sess_set_get_cb.html</a>
+ * and {a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_session_cache_mode.html">SSL_CTX_set_session_cache_mode</a>.
+ */
+public interface SSLSessionCache {
+
+    /**
+     * Returns {@code true} if the cache takes ownership of the {@code SSL_SESSION} and will call {@code SSL_SESSION_free} once it should be destroyed,
+     * {@code false} otherwise.
+     *
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_sess_set_new_cb.html">SSL_CTX_sess_set_new_cb</a>.
+     * 
+     * @param ssl {@code SSL*} 
+     * @param sslSession {@code SSL_SESSION*}
+     * @return {@code true} if session ownership was transfered, {@code false} if not. 
+     */
+    boolean sessionCreated(long ssl, long sslSession);
+
+    /**
+     * Called once a {@code SSL_SESSION} should be retrieved for the given {@code SSL} and with the given session ID.
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_sess_set_get_cb.html">SSL_CTX_sess_set_get_cb</a>.
+     * If the session is shared you need to call {@link SSLSession#upRef(long)} explicit in this callback and explicit free all {@code SSL_SESSION}s
+     * once the cache is destroyed via {@link SSLSession#free(long)}.
+     * 
+     * @param sslCtx {code SSL_CTX*}
+     * @param sslSession {@code SSL_SESSION*}
+     * @return the {@link SSL_SESSION} or {@code -1} if none was found in the cache.
+     */
+    long getSession(long ssl, byte[] sessionId);
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSessionCache.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSessionCache.java
@@ -42,7 +42,7 @@ public interface SSLSessionCache {
      * once the cache is destroyed via {@link SSLSession#free(long)}.
      * 
      * @param sslCtx {code SSL_CTX*}
-     * @param sslSession {@code SSL_SESSION*}
+     * @param sessionId the session id
      * @return the {@link SSL_SESSION} or {@code -1} if none was found in the cache.
      */
     long getSession(long sslCtx, byte[] sessionId);

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSessionCache.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLSessionCache.java
@@ -45,5 +45,5 @@ public interface SSLSessionCache {
      * @param sslSession {@code SSL_SESSION*}
      * @return the {@link SSL_SESSION} or {@code -1} if none was found in the cache.
      */
-    long getSession(long ssl, byte[] sessionId);
+    long getSession(long sslCtx, byte[] sessionId);
 }


### PR DESCRIPTION
…e able to re-use SSL_SESSION on the client side as well.

Motivation:

While OpenSSL / BoringSSL / LibreSSL maintain an internal cache for the SSL_SESSIONs on the serverside it needs an external cache for the SSL_SESSION when we want to re-use these on the client side.

Modifications:

- Add SSLSessionCache interface that can be implemented and so provide an external cache
- Add SSLSession class which contains native method definitions to deal with SSL_SESSION

Result:

Be able to cache SSL_SESSION via an external cache implementation and so reuse SSL_SESSION on the client side as well