### PR TITLE
Only use SSL_SESSION_up_ref when supported by used openssl version

### DIFF
--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -71,7 +71,13 @@ TCN_IMPLEMENT_CALL(jboolean, SSLSession, upRef)(TCN_STDARGS, jlong session) {
 
     TCN_CHECK_NULL(session_, session, JNI_FALSE);
 
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     return SSL_SESSION_up_ref(session_) == 1 ? JNI_TRUE : JNI_FALSE;
+#else
+    // Older versions of OpenSSL don't expose SSL_SESSION_up_ref
+    CRYPTO_add(&session_->references, 1, CRYPTO_LOCK_SSL_SESSION);
+#endif // OPENSSL_VERSION_NUMBER >= 0x10100000L
 }
 
 TCN_IMPLEMENT_CALL(void, SSLSession, free)(TCN_STDARGS, jlong session) {


### PR DESCRIPTION
Motivation:

SSL_SESSION_up_ref was only added to openssl >= 1.1.0 before this we have to manually increment the reference count.

Modifications:

Manually increment reference count when an old version of openssl is used

Result:

Be able to compile against openssl < 1.1.0