### PR TITLE
Correctly include sslsession.c when building on windows

### DIFF
--- a/openssl-dynamic/src/main/native-package/vs2010.vcxproj
+++ b/openssl-dynamic/src/main/native-package/vs2010.vcxproj
@@ -192,6 +192,7 @@
     <ClCompile Include=".\src\native_constants.c" />
     <ClCompile Include=".\src\ssl.c" />
     <ClCompile Include=".\src\sslcontext.c" />
+    <ClCompile Include=".\src\sslsession.c" />
     <ClCompile Include=".\src\sslutils.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vs2010.vcxproj.static.template
+++ b/vs2010.vcxproj.static.template
@@ -192,6 +192,7 @@
     <ClCompile Include=".\src\native_constants.c" />
     <ClCompile Include=".\src\ssl.c" />
     <ClCompile Include=".\src\sslcontext.c" />
+    <ClCompile Include=".\src\sslsession.c" />
     <ClCompile Include=".\src\sslutils.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Motivation:

5d39363563bd8aa8ce3b6c2e7ee4155bd126e305 added a new c file but missed to include it in the build configuration for windows

Modifications:

Add sslsession.c to build configuration

Result:

Be able to build on windows again