### PR TITLE
Add support for SSL_CTX_set_num_tickets

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -448,6 +448,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
     extern X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl) __attribute__((weak));
     extern void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param, unsigned int flags) __attribute__((weak));
     extern int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param, const char *name, size_t namelen) __attribute__((weak));
+    extern int SSL_CTX_set_num_tickets(SSL_CTX *ctx, size_t num_tickets) __attribute__((weak));
 #endif // OPENSSL_IS_BORINGSSL
 
     extern int SSL_get_sigalgs(SSL *s, int idx, int *psign, int *phash, int *psignhash, unsigned char *rsig, unsigned char *rhash) __attribute__((weak));

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -860,7 +860,6 @@ public final class SSL {
      */
     public static native boolean setSession(long ssl, long session);
 
-
     /**
      * Returns the {@code SSL_SESSION} that is used for {@code SSL}.
      * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_get_session.html">SSL_get_session</a>.

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -631,4 +631,14 @@ public final class SSLContext {
      * @param cache cache to use for the given context.
      */
     public static native void setSSLSessionCache(long ctx, SSLSessionCache cache);
+
+    /**
+     * Set the number of TLSv1.3 session tickets that will be sent to the client after a full handshake.
+     * 
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_num_tickets.html">SSL_CTX_set_num_tickets</a> for more details.
+     * @param ctx context to use
+     * @param tickets the number of tickets
+     * @return {@code true} if successful, {@code false} otherwise.
+     */
+    public static native boolean setNumTickets(long ctx, int tickets);
 }


### PR DESCRIPTION
Motivation:

Sometimes its useful to be able to adjust the number of used tickets for TLSv1.3. OpenSSL exposes some API for it.

Modifications:

Expose SSL_CTX_set_num_tickets via SSLContext

Result:

Be able to control te number of tickets to send when using TLSv1.3