### PR TITLE
Include os / arch / classifier informations in native library name

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -270,7 +270,7 @@
                       <then>
                         <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
                           <arg value="--strip-debug" />
-                          <arg value="libnetty_tcnative.so" />
+                          <arg value="lib${nativeLibName}.so" />
                         </exec>
                       </then>
                     </if>
@@ -303,7 +303,7 @@
                 </goals>
                 <phase>compile</phase>
                 <configuration>
-                  <name>netty_tcnative</name>
+                  <name>${nativeLibName}</name>
                   <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
                   <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
@@ -587,7 +587,7 @@
                       <then>
                         <exec executable="aarch64-linux-gnu-strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
                           <arg value="--strip-debug" />
-                          <arg value="libnetty_tcnative.so" />
+                          <arg value="lib${nativeLibName}.so" />
                         </exec>
                       </then>
                     </if>
@@ -620,7 +620,7 @@
                 </goals>
                 <phase>compile</phase>
                 <configuration>
-                  <name>netty_tcnative</name>
+                  <name>${nativeLibName}</name>
                   <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
                   <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
@@ -753,19 +753,19 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_*" to="libnetty_tcnative_osx_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-aarch_64/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_aarch_64.*" />
+                      <globmapper from="libnetty_tcnative_*" to="libnetty_tcnative_linux_aarch_64.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/windows-${uberArch}/META-INF/native" />
-                      <globmapper from="netty_tcnative.*" to="netty_tcnative_windows_${uberArch}.*" />
+                      <globmapper from="netty_tcnative_*" to="netty_tcnative_windows_${uberArch}.*" />
                     </copy>
                   </target>
                 </configuration>
@@ -875,11 +875,11 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_*" to="libnetty_tcnative_osx_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
+                      <globmapper from="libnetty_tcnative_*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                   </target>
                 </configuration>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -128,7 +128,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <name>netty_tcnative</name>
+              <name>${nativeLibName}</name>
               <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
               <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -113,7 +113,7 @@
           <execution>
             <id>build-native-lib</id>
             <configuration>
-              <name>netty_tcnative</name>
+              <name>${nativeLibName}</name>
               <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>
               <forceAutogen>${forceAutogen}</forceAutogen>
@@ -198,7 +198,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_tcnative</name>
+                  <name>${nativeLibName}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>
@@ -350,7 +350,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_tcnative</name>
+                  <name>${nativeLibName}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>

--- a/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
+++ b/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
@@ -33,9 +33,8 @@ public abstract class AbstractNativeTest {
         if (directories == null || directories.length != 1) {
             throw new IllegalStateException("Could not find platform specific native directory");
         }
-        String libName = System.mapLibraryName("netty_tcnative")
-                // Fix the filename (this is needed for macOS).
-                .replace(".dylib", ".jnilib");
+    
+        String libName = directories[0].getAbsoluteFile().list()[0];
         String libPath = directories[0].getAbsoluteFile() + File.separator + libName;
         System.load(libPath);
         Library.initialize();

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -125,7 +125,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <name>netty_tcnative</name>
+              <name>${nativeLibName}</name>
               <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
               <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
               <libDirectory>${nativeLibOnlyDir}</libDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,40 @@
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
+          <!-- Generate the native lib name used by hawtjni -->
+          <execution>
+            <id>generate_name</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
+                <condition property="nativeLibName" value="netty_tcnative_${os.detected.name}_${os.detected.arch}_fedora">
+                  <isset property="os.detected.release.like.fedora" />
+                </condition>
+                <condition property="nativeLibName" value="netty_tcnative_${os.detected.name}_${os.detected.arch}_suse">
+                  <isset property="os.detected.release.like.suse" />
+                </condition>
+                <condition property="nativeLibName" value="netty_tcnative_${os.detected.name}_${os.detected.arch}_arch">
+                  <isset property="os.detected.release.like.arch" />
+                </condition>
+                <condition property="nativeLibName" value="netty_tcnative_${os.detected.name}_${os.detected.arch}">
+                  <not>
+                    <or>
+                      <isset property="os.detected.release.like.fedora" />
+                      <isset property="os.detected.release.like.suse" />
+                      <isset property="os.detected.release.like.arch" />
+                    </or>
+                  </not>
+                </condition>
+                <echo message = "HERE ${nativeLibName}" />
+              </target>
+            </configuration>
+          </execution>
+
           <!-- Generate the source for a statically-linked modules by copying from the template -->
           <execution>
             <id>copy-src</id>
@@ -251,15 +285,15 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <condition property="tcnative.snippet" value="libnetty_tcnative.so;osname=linux">
+                <condition property="tcnative.snippet" value="lib${nativeLibName}.so;osname=linux">
                   <equals arg1="${os.detected.name}" arg2="linux" />
                 </condition>
                 <!-- In OSGi specification, the alias of Windows family is win32, case insensitive -->
-                <condition property="tcnative.snippet" value="netty_tcnative.dll;osname=win32">
+                <condition property="tcnative.snippet" value="${nativeLibName}.dll;osname=win32">
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
                 <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
-                <condition property="tcnative.snippet" value="libnetty_tcnative.jnilib;osname=macosx;">
+                <condition property="tcnative.snippet" value="lib${nativeLibName}.jnilib;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=${os.detected.arch}" />


### PR DESCRIPTION
Motivation:

We should better include the os / arch / classifier informations in the native library name. This way it is possible to have more then one on the classpath without any problems.

Modifications:

Adjust build scripts to include extra informations in the library name

Result:

Fixes https://github.com/netty/netty-tcnative/issues/555