### PR TITLE
Fix compilation error on aarch64

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -532,7 +532,7 @@
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
                               <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
-                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                             </then>
                           </elseif>
                           <else>


### PR DESCRIPTION
Motivation:

We need to specify '-Wno-error=shadow' on aarch to be able to compile boringssl

Modifications:

Add -Wno-error=shadow

Result:

Be able to cross-compile again