### PR TITLE
Also add license files when cross-compile

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -282,6 +282,8 @@
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                       <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                     </copy>
+
+                    <!-- Copy license material for attribution-->
                     <copy file="../NOTICE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
                     <copy file="../LICENSE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
                     <copy todir="${nativeJarWorkdir}/META-INF/license">
@@ -605,6 +607,14 @@
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                       <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                     </copy>
+
+                    <!-- Copy license material for attribution-->
+                    <copy file="../NOTICE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
+                    <copy file="../LICENSE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
+                    <copy todir="${nativeJarWorkdir}/META-INF/license">
+                      <fileset dir="../license"/>
+                    </copy>
+
                     <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                     <attachartifact file="${nativeJarFile}" classifier="${os.detected.name}-aarch64" type="jar" />
                   </target>


### PR DESCRIPTION
Motivation:

a76e8101fae9e7dadbf5c869fc14990cfa2a3117 added the license files etc for BoringSSL to ensure we do the right thing in terms of attribution. That said we missed to add the same build config for cross-compiling

Modifications:

Add configuration for copy license when cross-compiling

Result:

Correctly do attribution