### PR TITLE
Include os / arch / classifier informations in native library name (#…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -282,6 +282,17 @@
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                       <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                     </copy>
+                    
+                    <!-- linux / osx -->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+                    <!-- windows-->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
 
                     <!-- Copy license material for attribution-->
                     <copy file="../NOTICE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
@@ -348,6 +359,8 @@
         <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
         <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
         <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch64.jar</nativeJarFile>
+        <jniClassifier>${os.detected.name}-aarch64</jniClassifier>
+        <jniArch>aarch64</jniArch>
       </properties>
 
       <build>
@@ -608,6 +621,17 @@
                       <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                     </copy>
 
+                    <!-- linux / osx -->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+                    <!-- windows-->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+
                     <!-- Copy license material for attribution-->
                     <copy file="../NOTICE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
                     <copy file="../LICENSE.txt" todir="${nativeJarWorkdir}/META-INF/"/>
@@ -769,19 +793,15 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-aarch_64/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_aarch_64.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/windows-${uberArch}/META-INF/native" />
-                      <globmapper from="netty_tcnative.*" to="netty_tcnative_windows_${uberArch}.*" />
                     </copy>
                   </target>
                 </configuration>
@@ -891,11 +911,9 @@
                     <mkdir dir="${nativeDir}" />
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_osx_${uberArch}.*" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_linux_${uberArch}.*" />
                     </copy>
                   </target>
                 </configuration>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -87,7 +87,13 @@
           </execution>
         </executions>
       </plugin>
-
+     <!--
+        Set the classifier property based on the settings of the os-detector-plugin.
+        Fedora-based systems use a different soname for OpenSSL than other linux distributions.
+        Use a custom classifier ending in "-fedora" when building on fedora-based systems.
+        Systems based on SUSE or Arch Linux build their OpenSSL library a bit differently and also
+        require a custom classifier: "-suse" and "-arch".
+      -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
@@ -107,8 +113,38 @@
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                   <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                 </copy>
+                <!-- linux / osx -->
+                <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                  <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                  <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                </move>
+                <!-- windows-->
+                <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                  <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                  <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                </move>
+                 
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+                <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
+                <condition property="classifier" value="${jniClassifier}-fedora">
+                  <isset property="os.detected.release.like.fedora" />
+                </condition>
+                <condition property="classifier" value="${jniClassifier}-suse">
+                  <isset property="os.detected.release.like.suse" />
+                </condition>
+                <condition property="classifier" value="${jniClassifier}-arch">
+                  <isset property="os.detected.release.like.arch" />
+                </condition>
+                <condition property="classifier" value="${jniClassifier}">
+                  <not>
+                    <or>
+                      <isset property="os.detected.release.like.fedora" />
+                      <isset property="os.detected.release.like.suse" />
+                      <isset property="os.detected.release.like.arch" />
+                    </or>
+                  </not>
+                </condition>
+                <attachartifact file="${nativeJarFile}" classifier="${classifier}" type="jar" />
               </target>
             </configuration>
           </execution>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -78,18 +78,29 @@
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                   <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                 </copy>
+                <!-- linux / osx -->
+                <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                  <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                  <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                </move>
+                <!-- windows-->
+                <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                  <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                  <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                </move>
+                 
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                 <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
-                <condition property="classifier" value="${os.detected.classifier}-fedora">
+                <condition property="classifier" value="${jniClassifier}-fedora">
                   <isset property="os.detected.release.like.fedora" />
                 </condition>
-                <condition property="classifier" value="${os.detected.classifier}-suse">
+                <condition property="classifier" value="${jniClassifier}-suse">
                   <isset property="os.detected.release.like.suse" />
                 </condition>
-                <condition property="classifier" value="${os.detected.classifier}-arch">
+                <condition property="classifier" value="${jniClassifier}-arch">
                   <isset property="os.detected.release.like.arch" />
                 </condition>
-                <condition property="classifier" value="${os.detected.classifier}">
+                <condition property="classifier" value="${jniClassifier}">
                   <not>
                     <or>
                       <isset property="os.detected.release.like.fedora" />
@@ -225,6 +236,8 @@
 
       <properties>
         <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch64.jar</nativeJarFile>
+        <jniClassifier>${os.detected.name}-aarch64</jniClassifier>
+        <jniArch>aarch64</jniArch>
       </properties>
 
       <build>
@@ -292,51 +305,6 @@
                     </requireProperty>
                   </rules>
                   <ignoreCache>true</ignoreCache>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <!-- Build the additional JAR that contains the native library. -->
-              <execution>
-                <id>native-jar</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target>
-                    <copy todir="${nativeJarWorkdir}">
-                      <zipfileset src="${defaultJarFile}" />
-                    </copy>
-                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
-                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
-                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
-                    </copy>
-                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                    <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
-                    <condition property="classifier" value="${os.detected.name}-aarch64-fedora">
-                      <isset property="os.detected.release.like.fedora" />
-                    </condition>
-                    <condition property="classifier" value="${os.detected.name}-aarch64-suse">
-                      <isset property="os.detected.release.like.suse" />
-                    </condition>
-                    <condition property="classifier" value="${os.detected.name}-aarch64-arch">
-                      <isset property="os.detected.release.like.arch" />
-                    </condition>
-                    <condition property="classifier" value="${os.detected.name}-aarch64">
-                      <not>
-                        <or>
-                          <isset property="os.detected.release.like.fedora" />
-                          <isset property="os.detected.release.like.suse" />
-                          <isset property="os.detected.release.like.arch" />
-                        </or>
-                      </not>
-                    </condition>
-                    <attachartifact file="${nativeJarFile}" classifier="${classifier}" type="jar" />
-                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -85,6 +85,13 @@
         </executions>
       </plugin>
 
+           <!--
+        Set the classifier property based on the settings of the os-detector-plugin.
+        Fedora-based systems use a different soname for OpenSSL than other linux distributions.
+        Use a custom classifier ending in "-fedora" when building on fedora-based systems.
+        Systems based on SUSE or Arch Linux build their OpenSSL library a bit differently and also
+        require a custom classifier: "-suse" and "-arch".
+      -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
@@ -104,8 +111,38 @@
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                   <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                 </copy>
+                <!-- linux / osx -->
+                <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                  <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                  <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                </move>
+                <!-- windows-->
+                <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                  <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                  <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                </move>
+                 
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+                <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
+                <condition property="classifier" value="${jniClassifier}-fedora">
+                  <isset property="os.detected.release.like.fedora" />
+                </condition>
+                <condition property="classifier" value="${jniClassifier}-suse">
+                  <isset property="os.detected.release.like.suse" />
+                </condition>
+                <condition property="classifier" value="${jniClassifier}-arch">
+                  <isset property="os.detected.release.like.arch" />
+                </condition>
+                <condition property="classifier" value="${jniClassifier}">
+                  <not>
+                    <or>
+                      <isset property="os.detected.release.like.fedora" />
+                      <isset property="os.detected.release.like.suse" />
+                      <isset property="os.detected.release.like.arch" />
+                    </or>
+                  </not>
+                </condition>
+                <attachartifact file="${nativeJarFile}" classifier="${classifier}" type="jar" />
               </target>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <macOsxDeploymentTarget>MACOSX_DEPLOYMENT_TARGET=10.9</macOsxDeploymentTarget>
     <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9</cmakeOsxDeploymentTarget>
+    <jniArch>${os.detected.arch}</jniArch>
+    <jniClassifier>${os.detected.name}_${os.detected.arch}</jniClassifier>
   </properties>
 
   <build>
@@ -251,15 +253,15 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <condition property="tcnative.snippet" value="libnetty_tcnative.so;osname=linux">
+                <condition property="tcnative.snippet" value="libnetty_tcnative_${os.detected.name}_${os.detected.arch}.so;osname=linux">
                   <equals arg1="${os.detected.name}" arg2="linux" />
                 </condition>
                 <!-- In OSGi specification, the alias of Windows family is win32, case insensitive -->
-                <condition property="tcnative.snippet" value="netty_tcnative.dll;osname=win32">
+                <condition property="tcnative.snippet" value="netty_tcnative_${os.detected.name}_${os.detected.arch}.dll;osname=win32">
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
                 <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
-                <condition property="tcnative.snippet" value="libnetty_tcnative.jnilib;osname=macosx;">
+                <condition property="tcnative.snippet" value="libnetty_tcnative_${os.detected.name}_${os.detected.arch}.jnilib;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=${os.detected.arch}" />


### PR DESCRIPTION
…557)

Motivation:

We should better include the os / arch / classifier informations in the native library name. This way it is possible to have more then one on the classpath without any problems.

Modifications:

Adjust build scripts to include extra informations in the library name

Result:

Fixes https://github.com/netty/netty-tcnative/issues/555