### PR TITLE
Fix classifier naming bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <macOsxDeploymentTarget>MACOSX_DEPLOYMENT_TARGET=10.9</macOsxDeploymentTarget>
     <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9</cmakeOsxDeploymentTarget>
     <jniArch>${os.detected.arch}</jniArch>
-    <jniClassifier>${os.detected.name}_${os.detected.arch}</jniClassifier>
+    <jniClassifier>${os.detected.name}-${os.detected.arch}</jniClassifier>
   </properties>
 
   <build>


### PR DESCRIPTION
Motivation:

9cd9f45bd4941581705ace76c7713b0c1b84f640 introduced a regression which lead to wrong naming of the classifier

Modifications:

Fix naming

Result:

Correct classifier used for openssl-dynamic