### PR TITLE
Compile BoringSSL with -DOPENSSL_C11_ATOMIC when possible to reduce l…

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -196,7 +196,8 @@
                             <then>
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                              <!-- Use -DOPENSSL_C11_ATOMIC so we replace most of the locking code with atomics-->
+                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                               <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                             </then>
@@ -204,7 +205,8 @@
                           <else>
                             <!-- On *nix, add ASM flags to disable executable stack -->
                             <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                            <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                            <!-- Use -DOPENSSL_C11_ATOMIC so we replace most of the locking code with atomics-->
+                            <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
                             <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
                           </else>
                         </if>
@@ -545,7 +547,7 @@
                             <then>
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                               <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                             </then>
@@ -553,7 +555,7 @@
                           <else>
                             <!-- On *nix, add ASM flags to disable executable stack -->
                             <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                            <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                            <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer" />
                             <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
                           </else>
                         </if>

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -45,6 +45,13 @@ RUN wget -q http://linuxsoft.cern.ch/cern/scl/slc6-scl.repo && mv slc6-scl.repo 
 RUN yum install -y devtoolset-3-gcc-c++
 RUN echo 'source /opt/rh/devtoolset-3/enable' >> ~/.bashrc
 
+# This is workaround to be able to compile boringssl with -DOPENSSL_C11_ATOMIC as while we use a recent gcc installation it still needs some
+# help to define static_assert(...) as otherwise the compilation will fail due the system installed assert.h which missed this definition. 
+run mkdir ~/.include
+run echo '#include "/usr/include/assert.h"' >>  ~/.include/assert.h
+run echo '#define static_assert _Static_assert'  >>  ~/.include/assert.h
+run echo 'export C_INCLUDE_PATH="$HOME/.include/"' >>  ~/.bashrc
+
 RUN rm -rf $SOURCE_DIR
 
 ARG java_version=1.8


### PR DESCRIPTION
…ocking overhead

Motivation:

While investigating some performance problems during handshakes we noticed that a lot of time was spend in native code that does locking. All of this can be replaced by atomics when BoringSSL is compiled with -DOPENSSL_C11_ATOMIC.

Modifications:

- Adjust centos docker file to be able to compile BoringSSL with -DOPENSSL_C11_ATOMIC
- Add -DOPENSSL_C11_ATOMIC when compiling BoringSSL

Result:

Less overhead while doing reference counting in BoringSSL (which mostly happens during handshakes)

Co-authored-by: Scott Mitchell <scott_mitchell@apple.com>