### PR TITLE
Update to latest openssl version for static build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
     -->
     <libresslSha256>414c149c9963983f805a081db5bd3aec146b5f82d529bb63875ac941b25dcbb6</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>g</opensslPatchVersion>
+    <opensslPatchVersion>h</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46</opensslSha256>
+    <opensslSha256>5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprBuildDir>${project.build.directory}/apr-${aprVersion}</aprBuildDir>
     <archBits>64</archBits>


### PR DESCRIPTION
Motivation:

openssl 1.1.1h was released so we should use it for the static build

Modifications:

Update openssl version

Result:

Use latest openssl version for static build