### PR TITLE
Update java patch versions

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-252"
+        java_version : "adopt@1.8.0-265"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "adopt@1.8.0-252"
+        java_version : "adopt@1.8.0-265"
 
   build:
     image: netty-tcnative-debian:debian-7-1.8

--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-252"
+        java_version : "adopt@1.8.0-265"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should use the latest patch releases when building via docker

Modifications:

Update all java versions to the latest patch release

Result:

Use latest releases