### PR TITLE
Unregister all previous registered native methods if loading of nativ…

### DIFF
--- a/openssl-dynamic/src/main/c/bb.c
+++ b/openssl-dynamic/src/main/c/bb.c
@@ -32,6 +32,8 @@
 #include "tcn.h"
 #include "bb.h"
 
+#define BUFFER_CLASSNAME "io/netty/internal/tcnative/Buffer"
+
 TCN_IMPLEMENT_CALL(jlong, Buffer, address)(TCN_STDARGS, jobject bb)
 {
     return P2J((*e)->GetDirectBufferAddress(e, bb));
@@ -52,12 +54,12 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 // JNI Method Registration Table End
 
 jint netty_internal_tcnative_Buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
-    if (netty_internal_tcnative_util_register_natives(env, packagePrefix, "io/netty/internal/tcnative/Buffer", method_table, method_table_size) != 0) {
+    if (netty_internal_tcnative_util_register_natives(env, packagePrefix, BUFFER_CLASSNAME, method_table, method_table_size) != 0) {
         return JNI_ERR;
     }
     return TCN_JNI_VERSION;
 }
 
 void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/Buffer");
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, BUFFER_CLASSNAME);
  }

--- a/openssl-dynamic/src/main/c/bb.c
+++ b/openssl-dynamic/src/main/c/bb.c
@@ -58,4 +58,6 @@ jint netty_internal_tcnative_Buffer_JNI_OnLoad(JNIEnv* env, const char* packageP
     return TCN_JNI_VERSION;
 }
 
-void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env) { }
+void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/Buffer");
+ }

--- a/openssl-dynamic/src/main/c/bb.h
+++ b/openssl-dynamic/src/main/c/bb.h
@@ -18,5 +18,5 @@
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
 jint netty_internal_tcnative_Buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
-void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env);
+void netty_internal_tcnative_Buffer_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
 #endif /* NETTY_TCNATIVE_BB_H_ */

--- a/openssl-dynamic/src/main/c/error.c
+++ b/openssl-dynamic/src/main/c/error.c
@@ -91,7 +91,7 @@ error:
     return JNI_ERR;
 }
 
-void netty_internal_tcnative_Error_JNI_OnUnLoad(JNIEnv* env) {
+void netty_internal_tcnative_Error_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
      TCN_UNLOAD_CLASS(env, exceptionClass);
      TCN_UNLOAD_CLASS(env, nullPointerExceptionClass);
      TCN_UNLOAD_CLASS(env, illegalArgumentExceptionClass);

--- a/openssl-dynamic/src/main/c/error.h
+++ b/openssl-dynamic/src/main/c/error.h
@@ -18,5 +18,5 @@
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
 jint netty_internal_tcnative_Error_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
-void netty_internal_tcnative_Error_JNI_OnUnLoad(JNIEnv* env);
+void netty_internal_tcnative_Error_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
 #endif /* NETTY_TCNATIVE_ERROR_H_ */

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -392,7 +392,9 @@ error:
     if (tcn_global_pool != NULL) {
         TCN_UNLOAD_CLASS(env, jString_class);
         apr_terminate();
+        tcn_global_pool = NULL;
     }
+
     TCN_UNLOAD_CLASS(env, byteArrayClass);
 
     netty_internal_tcnative_util_unregister_natives(env, packagePrefix, LIBRARY_CLASSNAME);
@@ -423,6 +425,7 @@ static void netty_internal_tcnative_Library_JNI_OnUnLoad(JNIEnv* env, const char
     if (tcn_global_pool != NULL) {
         TCN_UNLOAD_CLASS(env, jString_class);
         apr_terminate();
+        tcn_global_pool = NULL;
     }
 
     TCN_UNLOAD_CLASS(env, byteArrayClass);
@@ -647,6 +650,7 @@ static jint JNI_OnLoad_netty_tcnative0(JavaVM* vm, void* reserved) {
     jint ret = netty_internal_tcnative_Library_JNI_OnLoad(env, packagePrefix);
     if (ret == JNI_ERR) {
         free(packagePrefix);
+        staticPackagePrefix = NULL;
     } else {
         // This will be freed when we unload.
         staticPackagePrefix = packagePrefix;

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -28,6 +28,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#define LIBRARY_CLASSNAME "io/netty/internal/tcnative/Library"
+
 #ifndef _WIN32
 // It's important to have #define _GNU_SOURCE before any other include as otherwise it will not work.
 // See http://stackoverflow.com/questions/7296963/gnu-source-and-use-gnu
@@ -324,7 +327,7 @@ static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* 
     int sslOnLoadCalled = 0;
     int contextOnLoadCalled = 0;
 
-    if (netty_internal_tcnative_util_register_natives(env, packagePrefix, "io/netty/internal/tcnative/Library", method_table, method_table_size) != 0) {
+    if (netty_internal_tcnative_util_register_natives(env, packagePrefix, LIBRARY_CLASSNAME, method_table, method_table_size) != 0) {
         goto error;
     }
 
@@ -392,7 +395,7 @@ error:
     }
     TCN_UNLOAD_CLASS(env, byteArrayClass);
 
-    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/Library");
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, LIBRARY_CLASSNAME);
 
     // Call unload methods if needed to ensure we correctly release any resources.
     if (errorOnLoadCalled == 1) {

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -18,6 +18,8 @@
 #include "ssl_private.h"
 #include "native_constants.h"
 
+#define NATIVE_CONSTANTS_CLASSNAME "io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods"
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpCipherServerPreference)(TCN_STDARGS) {
     return SSL_OP_CIPHER_SERVER_PREFERENCE;
 }
@@ -686,7 +688,7 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_internal_tcnative_util_register_natives(env,
              packagePrefix,
-             "io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods",
+             NATIVE_CONSTANTS_CLASSNAME,
              method_table, method_table_size) != 0) {
         return JNI_ERR;
     }
@@ -694,6 +696,5 @@ jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNI
 }
 
 void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    netty_internal_tcnative_util_unregister_natives(env, packagePrefix,
-             "io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods");
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, NATIVE_CONSTANTS_CLASSNAME);
  }

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -693,4 +693,7 @@ jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNI
     return TCN_JNI_VERSION;
 }
 
-void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env) { }
+void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix,
+             "io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods");
+ }

--- a/openssl-dynamic/src/main/c/native_constants.h
+++ b/openssl-dynamic/src/main/c/native_constants.h
@@ -18,5 +18,5 @@
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
 jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
-void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env);
+void netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
 #endif /* NETTY_TCNATIVE_NATIVE_CONSTANTS_H_ */

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -45,6 +45,8 @@
 #include "ssl_private.h"
 #include "ssl.h"
 
+#define SSL_CLASSNAME  "io/netty/internal/tcnative/SSL"
+
 static int ssl_initialized = 0;
 extern apr_pool_t *tcn_global_pool;
 
@@ -2706,7 +2708,7 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_internal_tcnative_util_register_natives(env,
              packagePrefix,
-             "io/netty/internal/tcnative/SSL",
+             SSL_CLASSNAME,
              method_table, method_table_size) != 0) {
         return JNI_ERR;
     }
@@ -2714,5 +2716,5 @@ jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePref
 }
 
 void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/SSL");
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, SSL_CLASSNAME);
 }

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2713,4 +2713,6 @@ jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePref
     return TCN_JNI_VERSION;
 }
 
-void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env) { }
+void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/SSL");
+}

--- a/openssl-dynamic/src/main/c/ssl.h
+++ b/openssl-dynamic/src/main/c/ssl.h
@@ -18,5 +18,5 @@
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
 jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
-void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env);
+void netty_internal_tcnative_SSL_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
 #endif /* NETTY_TCNATIVE_SSL_H_ */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include "sslcontext.h"
 
+#define SSLCONTEXT_CLASSNAME "io/netty/internal/tcnative/SSLContext"
 
 static jclass    sslTask_class;
 static jfieldID  sslTask_returnValue;
@@ -2844,7 +2845,7 @@ jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* pack
     }
     if (netty_internal_tcnative_util_register_natives(env,
             packagePrefix,
-            "io/netty/internal/tcnative/SSLContext",
+            SSLCONTEXT_CLASSNAME,
             dynamicMethods,
             dynamicMethodsTableSize()) != 0) {
         goto error;
@@ -2907,5 +2908,5 @@ void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env, const char* pa
     TCN_UNLOAD_CLASS(env, sslPrivateKeyMethodSignTask_class);
     TCN_UNLOAD_CLASS(env, sslPrivateKeyMethodDecryptTask_class);
 
-    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/SSLContext");
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, SSLCONTEXT_CLASSNAME);
 }

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2900,10 +2900,12 @@ error:
     return JNI_ERR;
 }
 
-void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env) {
+void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
     TCN_UNLOAD_CLASS(env, sslTask_class);
     TCN_UNLOAD_CLASS(env, certificateCallbackTask_class);
     TCN_UNLOAD_CLASS(env, sslPrivateKeyMethodTask_class);
     TCN_UNLOAD_CLASS(env, sslPrivateKeyMethodSignTask_class);
     TCN_UNLOAD_CLASS(env, sslPrivateKeyMethodDecryptTask_class);
+
+    netty_internal_tcnative_util_unregister_natives(env, packagePrefix, "io/netty/internal/tcnative/SSLContext");
 }

--- a/openssl-dynamic/src/main/c/sslcontext.h
+++ b/openssl-dynamic/src/main/c/sslcontext.h
@@ -18,5 +18,5 @@
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
 jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
-void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env);
+void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
 #endif /* NETTY_TCNATIVE_SSLCONTEXT_H_ */

--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -17,6 +17,8 @@
 #include "ssl_private.h"
 #include "sslsession.h"
 
+#define SSLSESSION_CLASSNAME "io/netty/internal/tcnative/SSLSession"
+
 
 TCN_IMPLEMENT_CALL(jlong, SSLSession, getTime)(TCN_STDARGS, jlong session)
 {
@@ -117,7 +119,7 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_internal_tcnative_util_register_natives(env,
              packagePrefix,
-             "io/netty/internal/tcnative/SSLSession",
+             SSLSESSION_CLASSNAME,
              method_table, method_table_size) != 0) {
         return JNI_ERR;
     }
@@ -125,5 +127,5 @@ jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* pack
 }
 
 void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
-    netty_internal_tcnative_util_unregister_natives(env,packagePrefix, "io/netty/internal/tcnative/SSLSession");
+    netty_internal_tcnative_util_unregister_natives(env,packagePrefix, SSLSESSION_CLASSNAME);
 }

--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -124,4 +124,6 @@ jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* pack
     return TCN_JNI_VERSION;
 }
 
-void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env) { }
+void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty_internal_tcnative_util_unregister_natives(env,packagePrefix, "io/netty/internal/tcnative/SSLSession");
+}

--- a/openssl-dynamic/src/main/c/sslsession.h
+++ b/openssl-dynamic/src/main/c/sslsession.h
@@ -18,5 +18,5 @@
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
 jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* packagePrefix);
-void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env);
+void netty_internal_tcnative_SSLSession_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix);
 #endif /* NETTY_TCNATIVE_SSLSESSION_H_ */

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -206,4 +206,6 @@ char* netty_internal_tcnative_util_prepend(const char* prefix, const char* str);
  */
 jint netty_internal_tcnative_util_register_natives(JNIEnv* env, const char* packagePrefix, const char* className, const JNINativeMethod* methods, jint numMethods);
 
+jint netty_internal_tcnative_util_unregister_natives(JNIEnv* env, const char* packagePrefix, const char* className);
+
 #endif /* TCN_H */

--- a/openssl-dynamic/src/main/c/tcn.h
+++ b/openssl-dynamic/src/main/c/tcn.h
@@ -144,7 +144,10 @@ jstring         tcn_new_stringn(JNIEnv *, const char *, size_t);
     TCN_END_MACRO
 
 #define TCN_UNLOAD_CLASS(E, C)                      \
-        (*(E))->DeleteGlobalRef((E), (C))
+    TCN_BEGIN_MACRO                                 \
+        (*(E))->DeleteGlobalRef((E), (C));          \
+        C = NULL;                                   \
+    TCN_END_MACRO
 
 #define TCN_GET_METHOD(E, C, M, N, S, R)            \
     TCN_BEGIN_MACRO                                 \


### PR DESCRIPTION
…e lib fails

Motivation:

It's important to unload all previous registered native methods when there is a failure during loading the native lib. Failing to do so may lead to an "invalid state" and so may segfault the JVM when trying to call a native method that was previous loaded.

This was observed when two versions of netty-tcnative were on the classpath which had different requirements in terms of linking.

Something like this was reported in he hs log:

```
Instructions: (pc=0x0000000116413bf0)
0x0000000116413bd0:
[error occurred during error reporting (printing registers, top of stack, instructions near pc), id 0xb]

Register to memory mapping:

RAX=0x0000000116413bf0 is an unknown value
RBX={method} {0x000000011422e708} 'aprMajorVersion' '()I' in 'io/netty/internal/tcnative/Library'
RCX=0x000000000000000a is an unknown value
RDX=0x000000000000000a is an unknown value
```

Modifications:

- Unregister previous registered native methods on failure
- Unregister previous registered native methods on on unload of the native lib

Result:

No more segfault caused by invalid state when loading of the native lib fails in between. In this case the user will receive an error now like:

```
Caused by: java.lang.IllegalArgumentException: Failed to load any of the given libraries: [netty_tcnative_osx_x86_64, netty_tcnative_x86_64, netty_tcnative]
	at io.netty.util.internal.NativeLibraryLoader.loadFirstAvailable(NativeLibraryLoader.java:104)
	at io.netty.handler.ssl.OpenSsl.loadTcNative(OpenSsl.java:590)
	at io.netty.handler.ssl.OpenSsl.<clinit>(OpenSsl.java:136)
	... 1 more
	Suppressed: java.lang.NoSuchMethodError: Method io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods.sslSessCacheClient()I not found
		at java.lang.ClassLoader$NativeLibrary.load(Native Method)
		at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1934)
		at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1817)
		at java.lang.Runtime.load0(Runtime.java:809)
		at java.lang.System.load(System.java:1088)
		at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:36)
		at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:351)
		at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:205)
		at io.netty.util.internal.NativeLibraryLoader.loadFirstAvailable(NativeLibraryLoader.java:96)
		... 3 more
```