### PR TITLE
Fix compile error on windows

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -239,7 +239,7 @@ static char* netty_internal_tcnative_util_rstrstr(char* s1rbegin, const char* s1
 
 #ifdef _WIN32
 static char* netty_internal_tcnative_util_rstrchar(char* s1rbegin, const char* s1rend, const char c2) {
-    if (s1rbegin == NULL || s1rend == NULL || s2 == NULL) {
+    if (s1rbegin == NULL || s1rend == NULL || c2 == NULL) {
         // Return NULL if any of the parameters is NULL to not risk a segfault
         return NULL;
     }


### PR DESCRIPTION
Motivation:

We did use the incorrect parameter name and so compilation on windows failed

Modifications:

Use correct name

Result:

Compilation on windows works again