### PR TITLE
Use aarch_64 in a consistent way

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -376,9 +376,11 @@
         <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
         <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
         <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
-        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch64.jar</nativeJarFile>
-        <jniClassifier>${os.detected.name}-aarch64</jniClassifier>
-        <jniArch>aarch64</jniArch>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch_64.jar</nativeJarFile>
+        <nativeLibOsParts>${os.detected.name}_aarch_64</nativeLibOsParts>
+        <jniClassifier>${os.detected.name}-aarch_64</jniClassifier>
+        <jniArch>aarch_64</jniArch>
       </properties>
 
       <build>
@@ -673,7 +675,7 @@
                     </copy>
 
                     <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
-                    <attachartifact file="${nativeJarFile}" classifier="${os.detected.name}-aarch64" type="jar" />
+                    <attachartifact file="${nativeJarFile}" classifier="${os.detected.name}-aarch_64" type="jar" />
                   </target>
                 </configuration>
               </execution>
@@ -784,9 +786,9 @@
                       <groupId>io.netty</groupId>
                       <artifactId>netty-tcnative-boringssl-static</artifactId>
                       <version>${project.version}</version>
-                      <classifier>linux-aarch64</classifier>
+                      <classifier>linux-aarch_64</classifier>
                       <type>jar</type>
-                      <outputDirectory>${unpackDir}/linux-aarch64</outputDirectory>
+                      <outputDirectory>${unpackDir}/linux-aarch_64</outputDirectory>
                     </artifactItem>
                     <artifactItem>
                       <groupId>io.netty</groupId>
@@ -831,7 +833,7 @@
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/linux-aarch64/META-INF/native" />
+                      <fileset dir="${unpackDir}/linux-aarch_64/META-INF/native" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/windows-${uberArch}/META-INF/native" />
@@ -869,7 +871,7 @@
                     <Bundle-NativeCode>
                       META-INF/native/libnetty_tcnative_osx_${uberArch}.jnilib;osname=macos;osname=macosx;processor=${uberArch},
                       META-INF/native/libnetty_tcnative_linux_${uberArch}.so;osname=linux;processor=${uberArch},
-                      META-INF/native/libnetty_tcnative_linux_aarch64.so;osname=linux;processor=aarch64,
+                      META-INF/native/libnetty_tcnative_linux_aarch_64.so;osname=linux;processor=aarch_64,
                       META-INF/native/netty_tcnative_windows_${uberArch}.dll;osname=win32;processor=${uberArch}
                     </Bundle-NativeCode>
                   </instructions>

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -8,12 +8,15 @@ ENV GCC_VERSION $gcc_version
 ENV OPENSSL_VERSION $openssl_version
 ENV APR_VERSION $apr_version
 
+# We want to have git 2.x for the maven scm plugin and also for boringssl
+RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
+
 # Install requirements
 RUN  set -x && \
   yum -y install epel-release && \
   yum -y install wget tar git make autoconf automake libtool openssl-devel ninja-build gcc-c++
 
-# Install Java and Golang
+# Install Java
 RUN yum install -y java-1.8.0-openjdk-devel golang
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,7 @@ docker-compose -f docker/docker-compose.opensuse.yaml -f docker/docker-compose.o
 ## centos7 with java8 for aarch64 cross compile
 
 ```
-docker-compose -f docker/docker-compose.centos.yaml run cross-compile-aarch64
+docker-compose -f docker/docker-compose.centos.yaml run cross-compile-aarch64-build
 ```
 
 etc, etc

--- a/docker/docker-compose.centos.yaml
+++ b/docker/docker-compose.centos.yaml
@@ -45,7 +45,20 @@ services:
         apr_version: "1.6.5"
         openssl_version: "1_1_1d"
 
-  cross-compile-aarch64:
+  cross-compile-aarch64-shell:
+    image: netty-tcnative-centos:cross_compile_aarch64
+    depends_on: [cross-compile-aarch64-runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2:/root/.m2:delegated
+      - ~/.gitconfig:/root/.gitconfig:delegated
+      - ~/.gitignore:/root/.gitignore:delegated
+      - ..:/code:delegated
+    working_dir: /code
+    entrypoint: /bin/bash
+
+  cross-compile-aarch64-build:
     image: netty-tcnative-centos:cross_compile_aarch64
     depends_on: [cross-compile-aarch64-runtime-setup]
     volumes:

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -259,9 +259,11 @@
       <id>linux-aarch64</id>
 
       <properties>
-        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch64.jar</nativeJarFile>
-        <jniClassifier>${os.detected.name}-aarch64</jniClassifier>
-        <jniArch>aarch64</jniArch>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch_64.jar</nativeJarFile>
+        <jniClassifier>${os.detected.name}-aarch_64</jniClassifier>
+        <nativeLibOsParts>${os.detected.name}_aarch_64</nativeLibOsParts>
+        <jniArch>aarch_64</jniArch>
       </properties>
 
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.classifier}.jar</nativeJarFile>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <nativeJarWorkdir>${project.build.directory}/native-jar-work</nativeJarWorkdir>
+    <nativeLibOsParts>${os.detected.name}_${os.detected.arch}</nativeLibOsParts>
     <aprVersion>1.7.0</aprVersion>
     <aprSha256>48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2</aprSha256>
     <boringsslBranch>chromium-stable</boringsslBranch>
@@ -297,15 +298,15 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <condition property="tcnative.snippet" value="libnetty_tcnative_${os.detected.name}_${os.detected.arch}.so;osname=linux">
+                <condition property="tcnative.snippet" value="libnetty_tcnative_${nativeLibOsParts}.so;osname=linux">
                   <equals arg1="${os.detected.name}" arg2="linux" />
                 </condition>
                 <!-- In OSGi specification, the alias of Windows family is win32, case insensitive -->
-                <condition property="tcnative.snippet" value="netty_tcnative_${os.detected.name}_${os.detected.arch}.dll;osname=win32">
+                <condition property="tcnative.snippet" value="netty_tcnative_${nativeLibOsParts}.dll;osname=win32">
                   <equals arg1="${os.detected.name}" arg2="windows" />
                 </condition>
                 <!-- In OSGi specification, the alias of OSX family is macos or macosx, case insensitive -->
-                <condition property="tcnative.snippet" value="libnetty_tcnative_${os.detected.name}_${os.detected.arch}.jnilib;osname=macosx;">
+                <condition property="tcnative.snippet" value="libnetty_tcnative_${nativeLibOsParts}.jnilib;osname=macosx;">
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=${os.detected.arch}" />


### PR DESCRIPTION
Motivation:

We should use aarch_64 in our classifier / jni libname on aarch64 as os.detected.arch uses the name. Being non consistent (especially across our different projects) already gave us a lot of trouble in the past.
Let's fix this once for all.

Beside this I also noticed that the MANIFEST file entries were not correctly generated for aarch64

Modifications:

- Use aarch_64
- Fix MANIFEST entries
- Make docker files consistent and update to latest git to be able to build boringssl

Result:

More consistent classifier usage on aarch64