### PR TITLE
Use APR 1.6.5 on windows as 1.7.0 doesnt compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,14 @@
           <family>windows</family>
         </os>
       </activation>
+      <properties>
+        <!--
+          We use APR 1.6.5 on windows as 1.7.0 doesn't compile anymore on the platforms we support
+          See also https://programmersought.com/article/94732742066/
+        -->
+        <aprVersion>1.6.5</aprVersion>
+        <aprSha256>70dcf9102066a2ff2ffc47e93c289c8e54c95d8dda23b503f9e61bb0cbd2d105</aprSha256>
+      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Motivation:

We need to use APR 1.6.5 on windows as 1.7.0 doesn't compile on the platforms we support

Modifications:

Use APR 1.6.5 on windows

Result:

Be able to compile on windows again