### PR TITLE
Skip extra work when generating uber jars

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -741,6 +741,12 @@
         <libDir>${project.build.directory}/lib</libDir>
         <nativeDir>${project.build.outputDirectory}/META-INF/native</nativeDir>
         <skipTests>true</skipTests>
+        <!--
+          As we just re-package we don't want to do any extra steps that are needed for static compilation or
+          building the native lib itself.
+        -->
+        <linkStatic>false</linkStatic>
+        <compileLibrary>false</compileLibrary>
         <uberArch>${os.detected.arch}</uberArch>
       </properties>
 
@@ -890,6 +896,12 @@
         <libDir>${project.build.directory}/lib</libDir>
         <nativeDir>${project.build.outputDirectory}/META-INF/native</nativeDir>
         <skipTests>true</skipTests>
+        <!--
+          As we just re-package we don't want to do any extra steps that are needed for static compilation or
+          building the native lib itself.
+        -->
+        <linkStatic>false</linkStatic>
+        <compileLibrary>false</compileLibrary>
         <uberArch>${os.detected.arch}</uberArch>
       </properties>
 


### PR DESCRIPTION
Motivation:

When we generate the uber jars we should skip any extra work that is only needed while compiling the native lib itself.

Modifications:

Set related properties to false and so skip the steps.

Result:

Don't do extra work that is not required during building the uber jars