### PR TITLE
Run apt-get update before trying to install dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     #    uses a compiled language
 
     - name: Install tools / libraries 
-      run: sudo apt-get -y install autoconf automake libtool make tar libapr1-dev libssl-dev cmake perl ninja-build
+      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar libapr1-dev libssl-dev cmake perl ninja-build
 
     - name: Build project
       run: ./mvnw clean package -DskipTests=true


### PR DESCRIPTION
Motivation:

We need to run apt-get update before trying to install dependencies as otherwise we may see 404 errors

Modifications:

run apt-get update

Result:

No more failures due 404