### PR TITLE
Use netty-jni-util via maven central

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -69,25 +69,33 @@
 
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack netty-jni-util files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>io.netty</includeGroupIds>
+                  <includeArtifactIds>netty-jni-util</includeArtifactIds>
+                  <classifier>sources</classifier>
+                  <outputDirectory>${jniUtilIncludeDir}</outputDirectory>
+                  <includes>**.h,**.c</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <!-- Download the BoringSSL source -->
           <plugin>
             <artifactId>maven-scm-plugin</artifactId>
             <executions>
-              <execution>
-                <id>get-netty-jni-util</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>checkout</goal>
-                </goals>
-                <configuration>
-                  <checkoutDirectory>${jniUtilCheckoutDir}</checkoutDirectory>
-                  <connectionType>developerConnection</connectionType>
-                  <developerConnectionUrl>scm:git:https://github.com/netty/netty-jni-util.git</developerConnectionUrl>
-                  <scmVersion>${jniUtilVersion}</scmVersion>
-                  <scmVersionType>tag</scmVersionType>
-                  <skipCheckoutIfExists>true</skipCheckoutIfExists>
-                </configuration>
-              </execution>
               <execution>
                 <id>get-boringssl</id>
                 <phase>generate-sources</phase>
@@ -437,25 +445,33 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack netty-jni-util files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>io.netty</includeGroupIds>
+                  <includeArtifactIds>netty-jni-util</includeArtifactIds>
+                  <classifier>sources</classifier>
+                  <outputDirectory>${jniUtilIncludeDir}</outputDirectory>
+                  <includes>**.h,**.c</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <!-- Download the BoringSSL source -->
           <plugin>
             <artifactId>maven-scm-plugin</artifactId>
             <executions>
-              <execution>
-                <id>get-netty-jni-util</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>checkout</goal>
-                </goals>
-                <configuration>
-                  <checkoutDirectory>${jniUtilCheckoutDir}</checkoutDirectory>
-                  <connectionType>developerConnection</connectionType>
-                  <developerConnectionUrl>scm:git:https://github.com/netty/netty-jni-util.git</developerConnectionUrl>
-                  <scmVersion>${jniUtilVersion}</scmVersion>
-                  <scmVersionType>tag</scmVersionType>
-                  <skipCheckoutIfExists>true</skipCheckoutIfExists>
-                </configuration>
-              </execution>
               <execution>
                 <id>get-boringssl</id>
                 <phase>generate-sources</phase>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -91,22 +91,24 @@
 
        <!-- Download the netty-jni-util source -->
       <plugin>
-        <artifactId>maven-scm-plugin</artifactId>
-        <version>1.11.2</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
+          <!-- unpack netty-jni-util files -->
           <execution>
-            <id>get-netty-jni-util</id>
+            <id>unpack</id>
             <phase>generate-sources</phase>
             <goals>
-              <goal>checkout</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <checkoutDirectory>${jniUtilCheckoutDir}</checkoutDirectory>
-              <connectionType>developerConnection</connectionType>
-              <developerConnectionUrl>scm:git:https://github.com/netty/netty-jni-util.git</developerConnectionUrl>
-              <scmVersion>${jniUtilVersion}</scmVersion>
-              <scmVersionType>tag</scmVersionType>
-              <skipCheckoutIfExists>true</skipCheckoutIfExists>
+              <includeGroupIds>io.netty</includeGroupIds>
+              <includeArtifactIds>netty-jni-util</includeArtifactIds>
+              <classifier>sources</classifier>
+              <outputDirectory>${jniUtilIncludeDir}</outputDirectory>
+              <includes>**.h,**.c</includes>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
         </executions>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -56,22 +56,24 @@
     <plugins>
      <!-- Download the netty-jni-util source -->
       <plugin>
-        <artifactId>maven-scm-plugin</artifactId>
-        <version>1.11.2</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
+          <!-- unpack netty-jni-util files -->
           <execution>
-            <id>get-netty-jni-util</id>
+            <id>unpack</id>
             <phase>generate-sources</phase>
             <goals>
-              <goal>checkout</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <checkoutDirectory>${jniUtilCheckoutDir}</checkoutDirectory>
-              <connectionType>developerConnection</connectionType>
-              <developerConnectionUrl>scm:git:https://github.com/netty/netty-jni-util.git</developerConnectionUrl>
-              <scmVersion>${jniUtilVersion}</scmVersion>
-              <scmVersionType>tag</scmVersionType>
-              <skipCheckoutIfExists>true</skipCheckoutIfExists>
+              <includeGroupIds>io.netty</includeGroupIds>
+              <includeArtifactIds>netty-jni-util</includeArtifactIds>
+              <classifier>sources</classifier>
+              <outputDirectory>${jniUtilIncludeDir}</outputDirectory>
+              <includes>**.h,**.c</includes>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
         </executions>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -87,27 +87,29 @@
       </plugin>
       <!-- Download the netty-jni-util source -->
       <plugin>
-        <artifactId>maven-scm-plugin</artifactId>
-        <version>1.11.2</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
+          <!-- unpack netty-jni-util files -->
           <execution>
-            <id>get-netty-jni-util</id>
+            <id>unpack</id>
             <phase>generate-sources</phase>
             <goals>
-              <goal>checkout</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <checkoutDirectory>${jniUtilCheckoutDir}</checkoutDirectory>
-              <connectionType>developerConnection</connectionType>
-              <developerConnectionUrl>scm:git:https://github.com/netty/netty-jni-util.git</developerConnectionUrl>
-              <scmVersion>${jniUtilVersion}</scmVersion>
-              <scmVersionType>tag</scmVersionType>
-              <skipCheckoutIfExists>true</skipCheckoutIfExists>
+              <includeGroupIds>io.netty</includeGroupIds>
+              <includeArtifactIds>netty-jni-util</includeArtifactIds>
+              <classifier>sources</classifier>
+              <outputDirectory>${jniUtilIncludeDir}</outputDirectory>
+              <includes>**.h,**.c</includes>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
         </executions>
       </plugin>
-           <!--
+      <!--
         Set the classifier property based on the settings of the os-detector-plugin.
         Fedora-based systems use a different soname for OpenSSL than other linux distributions.
         Use a custom classifier ending in "-fedora" when building on fedora-based systems.

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,8 @@
     <jniClassifier>${os.detected.name}-${os.detected.arch}</jniClassifier>
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
-    <jniUtilCheckoutDir>${project.build.directory}/netty-jni-util</jniUtilCheckoutDir>
-    <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/src/c</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.1</jniUtilVersion>
+    <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
+    <jniUtilVersion>0.0.2.Final</jniUtilVersion>
   </properties>
 
   <build>
@@ -375,6 +374,13 @@
   </build>
 
   <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-jni-util</artifactId>
+      <version>${jniUtilVersion}</version>
+      <classifier>sources</classifier>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-build-common</artifactId>


### PR DESCRIPTION
Motivation:

netty-jni-util is now also hosted on maven central. Let's use it

Modifications:

Adjust plugins to just unpack netty-jni-util and use it

Result:

Be able to use what is in the maven cache for netty-jni-util