### PR TITLE
Let's split up some work in different workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,44 +13,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-centos6-x86_64:
     runs-on: ubuntu-latest
     steps:
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: Create Cache Key
-        id: cache-key
-        run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
-        shell: bash
-
-      - uses: s4u/maven-settings-action@v2.2.0
-        with:
-          servers: |
-            [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
-
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          key: build-centos6-x86_64-docker-cache-{hash}
           restore-keys: |
-            docker-cache-${{ steps.cache-key.outputs.key }}-
+            build-centos6-x86_64-docker-cache-
 
       - name: Build docker image
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
 
       - name: Build project
         run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
-     
-      - name: Deploy project snapshot to sonatype
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy project
+
+on:
+  push:
+    branches: [ main ]
+
+  schedule:
+    - cron: '30 3 * * 1'  # At 03:30 on Monday, every Monday.
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy-centos6-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: s4u/maven-settings-action@v2.2.0
+        with:
+          servers: |
+            [{
+                "id": "sonatype-nexus-snapshots",
+                "username": "${{ secrets.SONATYPE_USERNAME }}",
+                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - uses: actions/checkout@v2
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
+        with:
+          key: deploy-centos6-x86_64-docker-cache-{hash}
+          restore-keys: |
+            deploy-centos6-x86_64-docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+
+      - name: Deploy project snapshot to sonatype
+        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: target
+          path: target/ # or path/to/artifact


### PR DESCRIPTION
Motivation:

We should split up work to different workflows as it also make it easier to run the seperatly and also makes it easier to control things

Modifications:

Split build and deploy to different workflows

Result:

Easier to configure jobs