### PR TITLE
Upgrade to OpenSSL 1.1.1i

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     -->
     <libresslSha256>414c149c9963983f805a081db5bd3aec146b5f82d529bb63875ac941b25dcbb6</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>h</opensslPatchVersion>
+    <opensslPatchVersion>i</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9</opensslSha256>
+    <opensslSha256>e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprSourceDir>${project.build.directory}/apr-source</aprSourceDir>
     <aprPatchFile>r1871981-macos11.patch</aprPatchFile>


### PR DESCRIPTION
A new version of OpenSSL is out (1.1.1i) and we should upgrade to it.