### PR TITLE
Use maven cachen when running analyze job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,17 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    # Cache .m2/repository
+    - uses: actions/cache@v2
+      env:
+        cache-name: ${{ matrix.language }}-cache-m2-repository
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-analyze-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-analyze-${{ env.cache-name }}-
+          ${{ runner.os }}-analyze-
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
Motivation:

To prevent failures to problems while downloading dependencies we shoud cache these

Modifications:

Add maven cache

Result:

No more failures due problems while downloading dependencies