### PR TITLE
Use matrix for job configurations

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,8 +11,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-centos6-x86_64:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - setup: centos6-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build"
+          - setup: debian7-x86_64
+            docker-compose-build: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build-dynamic-only"
+          - setup: centos7-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build"
+
+    name: ${{ matrix.setup }}
     steps:
       - uses: actions/checkout@v2
 
@@ -20,69 +34,19 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: build-centos6-x86_64-docker-cache-{hash}
+          key: build-${{ matrix.setup }}-docker-cache-{hash}
           restore-keys: |
-            build-centos6-x86_64-docker-cache-
+            build-${{ matrix.setup }}-docker-cache-
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
       - name: Build project
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
+        run: docker-compose ${{ matrix.docker-compose-run }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: target
-          path: "**/target/"
-
-  build-debian7-x86_64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: build-debian7-x86_64-docker-cache-{hash}
-          restore-keys: |
-            build-debian7-x86_64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build
-
-      - name: Build project
-        run: docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build-dynamic-only
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target
-          path: "**/target/"
-
-  build-centos7-aarch64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: build-centos7-aarch64-docker-cache-{hash}
-          restore-keys: |
-            build-centos7-aarch64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml build
-
-      - name: Build project
-        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target
+          name: build-${{ matrix.setup }}-target
           path: "**/target/"
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,8 +8,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-centos6-x86_64:
+  build-pr:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - setup: centos6-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build"
+          - setup: build-debian7-x86_64
+            docker-compose-build: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build-dynamic-only"
+          - setup: build-centos7-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build"
+
+    name: ${{ matrix.setup }}
     steps:
       - uses: actions/checkout@v2
 
@@ -17,69 +31,18 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
         with:
-          key: pr-centos6-x86_64-docker-cache-{hash}
+          key: pr-${{ matrix.setup }}-docker-cache-{hash}
           restore-keys: |
-            pr-centos6-x86_64-docker-cache-
+            pr-${{ matrix.setup }}-docker-cache-
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
       - name: Build project
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build
+        run: docker-compose ${{ matrix.docker-compose-run }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: target
+          name: pr-${{ matrix.setup }}-target
           path: "**/target/"
-
-  build-debian7-x86_64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: pr-debian7-x86_64-docker-cache-{hash}
-          restore-keys: |
-            pr-debian7-x86_64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build
-
-      - name: Build project
-        run: docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build-dynamic-only
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target
-          path: "**/target/"
-
-  build-centos7-aarch64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: pr-centos7-aarch64-docker-cache-{hash}
-          restore-keys: |
-            pr-centos7-aarch64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml build
-
-      - name: Build project
-        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
-        with:
-          name: target
-          path: "**/target/"
-

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,10 +16,10 @@ jobs:
           - setup: centos6-x86_64
             docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run build"
-          - setup: build-debian7-x86_64
+          - setup: debian7-x86_64
             docker-compose-build: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build"
             docker-compose-run: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run build-dynamic-only"
-          - setup: build-centos7-aarch64
+          - setup: centos7-aarch64
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build"
 


### PR DESCRIPTION
    Motivation:

    We can use the matrix feature to define our jobs. This reduces a lot of config

    Modification:

    Use job matrix

    Result:

    Easier to maintain