### PR TITLE
Correctly deploy artifacts that are build on different archs

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -11,92 +11,118 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-centos6-x86_64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: s4u/maven-settings-action@v2.2.0
-        with:
-          servers: |
-            [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
 
+  stage-snapshot:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - setup: centos6-x86_64
+            docker-compose-build: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run stage-snapshot"
+          - setup: debian7-x86_64
+            docker-compose-build: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build"
+            docker-compose-run: "-f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run stage-snapshot"
+          - setup: centos7-aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-stage-snapshot"
+
+    name: stage-snapshot-${{ matrix.setup }}
+    steps:
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.8
+        env:
+          docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
         with:
-          key: deploy-centos6-x86_64-docker-cache-{hash}
+          key: ${{ runner.os }}-staging-${{ env.docker-cache-name }}-{hash}
           restore-keys: |
-            deploy-centos6-x86_64-docker-cache-
+            ${{ runner.os }}-staging-${{ env.docker-cache-name }}-
+
+      - name: Create local staging directory
+        run: mkdir -p ~/local-staging
 
       - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml build
+        run: docker-compose ${{ matrix.docker-compose-build }}
 
-      - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.centos-6.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
+      - name: Stage snapshots to local staging directory
+        run: docker-compose ${{ matrix.docker-compose-run }}
 
-  deploy-debian7-x86_64:
-    runs-on: ubuntu-latest
-    # Skip for now until we figured out how to deploy SNAPSHOTS with the te same timestamps
-    if: ${{ false }}
+      - name: Upload local staging directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.setup }}-local-staging
+          path: ~/local-staging
+          if-no-files-found: error
+
+  deploy-staged-snapshots:
+    runs-on: ubuntu-18.04
+    # Wait until we have staged everything
+    needs: stage-snapshot
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        env:
+          cache-name: deploy-staging-cache-m2-repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-deploy-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-deploy-${{ env.cache-name }}-
+            ${{ runner.os }}-deploy-
+
+      # Setup some env to re-use later.
+      - name: Prepare enviroment variables
+        run: |
+          echo "LOCAL_STAGING_DIR=$HOME/local-staging" >> $GITHUB_ENV
+
+      # Hardcode the staging artifacts that need to be downloaded.
+      # These must match the matrix setups. There is currently no way to pull this out of the config.
+      - name: Download centos7-aarch64 staging directory
+        uses: actions/download-artifact@v2
+        with:
+          name: centos7-aarch64-local-staging
+          path: ~/centos7-aarch64-local-staging
+
+      - name: Download debian7-x86_64 staging directory
+        uses: actions/download-artifact@v2
+        with:
+          name: debian7-x86_64-local-staging
+          path: ~/debian7-x86_64-local-staging
+
+      - name: Download centos6-x86_64 staging directory
+        uses: actions/download-artifact@v2
+        with:
+          name: centos6-x86_64-local-staging
+          path: ~/centos6-x86_64-local-staging
+
+      - name: Merge staging repositories
+        run: |
+          mkdir -p ~/local-staging/deferred
+          cat ~/centos7-aarch64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/centos7-aarch64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/debian7-x86_64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/debian7-x86_64-local-staging/deferred/* ~/local-staging/deferred/
+          cat ~/centos6-x86_64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
+          cp -r ~/centos6-x86_64-local-staging/deferred/* ~/local-staging/deferred/
+
       - uses: s4u/maven-settings-action@v2.2.0
         with:
           servers: |
             [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+              "id": "sonatype-nexus-snapshots",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
             }]
 
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: deploy-debian7-x86_64-docker-cache-{hash}
-          restore-keys: |
-            deploy-debian7-x86_64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml build
-
-      # only deploy the dynamic artifact as the static is deployed via centos.
-      - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.debian.yaml -f docker/docker-compose.debian-7.18.yaml run deploy-dynamic-only
-
-
-  deploy-centos7-aarch64:
-    runs-on: ubuntu-latest
-    # Skip for now until we figured out how to deploy SNAPSHOTS with the te same timestamps
-    if: ${{ false }}
-    steps:
-      - uses: s4u/maven-settings-action@v2.2.0
-        with:
-          servers: |
-            [{
-                "id": "sonatype-nexus-snapshots",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
-
-      - uses: actions/checkout@v2
-
-      # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.8
-        continue-on-error: true
-        with:
-          key: deploy-centos7-aarch64-docker-cache-{hash}
-          restore-keys: |
-            deploy-centos7-aarch64-docker-cache-
-
-      - name: Build docker image
-        run: docker-compose -f docker/docker-compose.centos-7.yaml build
-
-      - name: Deploy project snapshot to sonatype
-        run: docker-compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-deploy
+      - name: Deploy local staged artifacts
+        run: mvn -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -18,5 +18,8 @@ services:
   deploy:
     image: netty-tcnative-centos:centos-6-1.8
 
+  stage-snapshot:
+    image: netty-tcnative-centos:centos-6-1.8
+
   shell:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -25,6 +25,15 @@ services:
     <<: *common
     command: /bin/bash -cl "mvn clean package -DaprSourceDir=/root/workspace/apr-source -DaprHome=/root/workspace/apr -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl -DopensslSourceDir=/root/workspace/openssl-source -DopensslHome=/root/workspace/openssl -DlibresslSourceDir=/root/workspace/libressl-source -DlibresslHome=/root/workspace/libressl"
 
+  stage-snapshot:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "mvn clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
   deploy:
     <<: *common
     volumes:

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -46,3 +46,12 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
     command: /bin/bash -cl "pushd ./openssl-dynamic && mvn clean deploy -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && popd && pushd ./boringssl-static && mvn clean deploy -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl -DskipTests && popd"
+
+  cross-compile-aarch64-stage-snapshot:
+    <<: *cross-compile-aarch64-common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "pushd ./openssl-dynamic && mvn -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true && popd && pushd ./boringssl-static && mvn -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -12,6 +12,9 @@ services:
   deploy-dynamic-only:
     image: netty-tcnative-debian:debian-7-1.8
 
+  stage-snapshot:
+    image: netty-tcnative-debian:debian-7-1.8
+
   build-dynamic-only:
     image: netty-tcnative-debian:debian-7-1.8
 

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -34,6 +34,15 @@ services:
     <<: *common
     command: /bin/bash -cl "mvn -pl openssl-dynamic clean package"
 
+  stage-snapshot:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/local-staging:/root/local-staging
+      - ..:/code
+    command: /bin/bash -cl "mvn -pl openssl-dynamic clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+
   shell:
     <<: *common
     volumes:


### PR DESCRIPTION
Motivation:

We need to take special care when deploying snapshots as we need to generate the jars in multiple steps

Modifications:

- Use the nexus staging pluging to stage jars locally in multiple steps
- Add extra job that will merge these staged jars and deploy these

Result:

Related to netty/netty#10887