### PR TITLE
Hardcode BoringSSL commit sha to use

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -91,24 +91,6 @@
             </executions>
           </plugin>
 
-          <!-- Determine the commit ID of the source code. -->
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>buildnumber-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>create</goal>
-                </goals>
-                <configuration>
-                  <scmDirectory>${boringsslSourceDir}</scmDirectory>
-                  <buildNumberPropertyName>boringsslBuildNumber</buildNumberPropertyName>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
@@ -134,7 +116,7 @@
             <configuration>
               <instructions>
                 <Apr-Version>${aprVersion}</Apr-Version>
-                <BoringSSL-Revision>${boringsslBuildNumber}</BoringSSL-Revision>
+                <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
                 <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
               </instructions>
             </configuration>
@@ -180,6 +162,12 @@
                       </then>
                       <else>
                         <echo message="Building BoringSSL" />
+
+                        <!-- Use the known SHA of the commit -->
+                        <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
+                          <arg value="checkout" />
+                          <arg value="${boringsslCommitSha}" />
+                        </exec>
 
                         <mkdir dir="${boringsslHome}" />
 
@@ -444,24 +432,6 @@
             </executions>
           </plugin>
 
-          <!-- Determine the commit ID of the source code. -->
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>buildnumber-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>create</goal>
-                </goals>
-                <configuration>
-                  <scmDirectory>${boringsslSourceDir}</scmDirectory>
-                  <buildNumberPropertyName>boringsslBuildNumber</buildNumberPropertyName>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
@@ -487,7 +457,7 @@
             <configuration>
               <instructions>
                 <Apr-Version>${aprVersion}</Apr-Version>
-                <BoringSSL-Revision>${boringsslBuildNumber}</BoringSSL-Revision>
+                <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
                 <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
               </instructions>
             </configuration>
@@ -533,6 +503,12 @@
                       </then>
                       <else>
                         <echo message="Building BoringSSL" />
+
+                        <!-- Use the known SHA of the commit -->
+                        <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
+                          <arg value="checkout" />
+                          <arg value="${boringsslCommitSha}" />
+                        </exec>
 
                         <mkdir dir="${boringsslHome}" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
     <aprVersion>1.7.0</aprVersion>
     <aprSha256>48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2</aprSha256>
     <boringsslBranch>chromium-stable</boringsslBranch>
+    <!--
+      See https://boringssl.googlesource.com/boringssl/+/refs/heads/chromium-stable for the latest commit
+    -->
+    <boringsslCommitSha>3743aafdacff2f7b083615a043a37101f740fa53</boringsslCommitSha>
     <libresslVersion>3.1.4</libresslVersion>
     <!--
       See https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/SHA256 for the SHA256 signature


### PR DESCRIPTION
Motivation:

We should hardcode the BoringSSL commit sha so we know when we need to rebuild our docker images.

Modifications:

Hard code the commit SHA and ensure we use it

Result:

GitHub workflows will automatically re-compile BoringSSL when needed