### PR TITLE
Override configuration of dependency plugin in the uber generation

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -715,7 +715,7 @@
                 <goals>
                   <goal>unpack</goal>
                 </goals>
-                <configuration>
+                <configuration combine.self="override">
                   <artifactItems>
                     <!-- Unpack just the native libraries -->
                     <artifactItem>
@@ -862,7 +862,7 @@
                 <goals>
                   <goal>unpack</goal>
                 </goals>
-                <configuration>
+                <configuration combine.self="override">
                   <artifactItems>
                     <!-- Unpack just the native libraries (windows excluded as we not publish snapshots for it yet) -->
                     <artifactItem>


### PR DESCRIPTION
Motivation:

We need to override the configuration as otherwise we may use something which is defined in the parent pom and is not valid for our use-case

Modifications:

Add override

Result:

Correct maven config