### PR TITLE
Replace c code that translate to wireformat to java

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -117,8 +117,6 @@
 
 #define SSL_TO_APR_ERROR(X)         (APR_OS_START_USERERR + 1000 + X)
 
-#define MAX_ALPN_NPN_PROTO_SIZE 65535
-
 extern const char* TCN_UNKNOWN_AUTH_METHOD;
 
 /* ECC: make sure we have at least 1.0.0 */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -942,7 +942,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos0)(TCN_STDARGS, jlong ctx, jbyt
     }
 }
 
-TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos0)(TCN_STDARGS, jlong ctx, jobjectArray alpn_protos,
+TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos0)(TCN_STDARGS, jlong ctx, jbyteArray alpn_protos,
         jint selectorFailureBehavior)
 {
     // Only supported with GCC

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -548,12 +548,10 @@ public final class SSLContext {
         } catch (IOException e) {
             throw new IllegalStateException(e);
         } finally {
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ignore) {
-                    // ignore
-                }
+            try {
+                out.close();
+            } catch (IOException ignore) {
+                // ignore
             }
         }
     }


### PR DESCRIPTION
Motivation:

We can just do the conversation to wireformat in the java layer which allows us to remove some c code...

Modifications:

Replace the c code with the java code

Result:

Less c code FTW.