### PR TITLE
Use consistent naming for jobs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -56,7 +56,7 @@ jobs:
 
   build-windows:
     runs-on: windows-2016
-    name: windows-86_64
+    name: windows-x86_64
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -60,7 +60,7 @@ jobs:
 
   stage-snapshot-windows:
     runs-on: windows-2016
-    name: windows-86_64
+    name: stage-snapshot-windows-x86_64
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,7 +52,7 @@ jobs:
 
   build-pr-windows:
     runs-on: windows-2016
-    name: windows-86_64
+    name: windows-x86_64
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Motivation:

Let's use consistent naming for the workflow jobs

Modifications:

Make naming consistent

Result:

Consistent naming