### PR TITLE
Let's use gcc10 when cross-compiling for LSE support

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -545,8 +545,8 @@
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
                           <arg value="-DCMAKE_SYSTEM_NAME=Linux" />
                           <arg value="-DCMAKE_SYSTEM_PROCESSOR=aarch64" />
-                          <arg value="-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc" />
-                          <arg value="-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++" />
+                          <arg value="-DCMAKE_C_COMPILER=aarch64-none-linux-gnu-gcc" />
+                          <arg value="-DCMAKE_CXX_COMPILER=aarch64-none-linux-gnu-g++" />
                           <arg value="-GNinja" />
                           <arg value="${boringsslSourceDir}" />
                         </exec>
@@ -586,7 +586,7 @@
                         <equals arg1="${strip.skip}" arg2="false" />
                       </and>
                       <then>
-                        <exec executable="aarch64-linux-gnu-strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
+                        <exec executable="aarch64-none-linux-gnu-strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
                           <arg value="--strip-debug" />
                           <arg value="libnetty_tcnative.so" />
                         </exec>
@@ -657,6 +657,7 @@
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslSourceDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>
+                    <configureArg>CC=aarch64-none-linux-gnu-gcc</configureArg>
                   </configureArgs>
                 </configuration>
               </execution>

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,9 +1,8 @@
 FROM centos:7.6.1810
 
-ARG gcc_version=4.9-2016.02
+ARG gcc_version=10.2-2020.11
 ARG openssl_version=1_1_1d
 ARG apr_version=1.6.5
-
 ENV SOURCE_DIR /root/source
 ENV WORKSPACE_DIR /root/workspace
 ENV PROJECT_DIR /root/workspace/project
@@ -23,11 +22,11 @@ RUN  set -x && \
 RUN yum install -y java-1.8.0-openjdk-devel golang
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
 
-# Install aarch64 gcc 4.9 toolchain
+# Install aarch64 gcc 10.2 toolchain
 RUN set -x && \
-  wget https://releases.linaro.org/components/toolchain/binaries/$GCC_VERSION/aarch64-linux-gnu/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz && \
-  tar xvf gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz
-ENV PATH="/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu/bin:${PATH}"
+  wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
+  tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz
+ENV PATH="/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 
 # Install CMake
 RUN yum install -y cmake3 && ln -s /usr/bin/cmake3 /usr/bin/cmake
@@ -37,7 +36,7 @@ RUN set -x && \
   wget https://downloads.apache.org//apr/apr-$APR_VERSION.tar.gz && \
   tar xvf apr-$APR_VERSION.tar.gz && \
   pushd apr-$APR_VERSION && \
-  CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --disable-shared --prefix=/opt/apr-$APR_VERSION-static --host=aarch64-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
+  CC=aarch64-none-linux-gnu-gcc CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --disable-shared --prefix=/opt/apr-$APR_VERSION-static --host=aarch64-none-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
   make || true && \
   pushd tools && \
   gcc -Wall -O2 -DCROSS_COMPILE gen_test_char.c -s -o gen_test_char && \
@@ -50,7 +49,7 @@ RUN set -x && \
   wget https://downloads.apache.org//apr/apr-$APR_VERSION.tar.gz && \
   tar xvf apr-$APR_VERSION.tar.gz && \
   pushd apr-$APR_VERSION && \
-  CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --prefix=/opt/apr-$APR_VERSION-share --host=aarch64-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
+  CC=aarch64-none-linux-gnu-gcc CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ./configure --prefix=/opt/apr-$APR_VERSION-share --host=aarch64-none-linux-gnu ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8 && \
   make || true && \
   pushd tools && \
   gcc -Wall -O2 -DCROSS_COMPILE gen_test_char.c -s -o gen_test_char && \
@@ -63,7 +62,7 @@ RUN set -x && \
   wget https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz && \
   tar xvf OpenSSL_$OPENSSL_VERSION.tar.gz && \
   pushd openssl-OpenSSL_$OPENSSL_VERSION && \
-  ./Configure linux-aarch64 --cross-compile-prefix=aarch64-linux-gnu- --prefix=/opt/openssl-$OPENSSL_VERSION-share shared && \
+  ./Configure linux-aarch64 --cross-compile-prefix=aarch64-none-linux-gnu- --prefix=/opt/openssl-$OPENSSL_VERSION-share shared && \
   make && make install && \
   popd
 

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -8,8 +8,8 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.cross_compile_aarch64
       args:
-        gcc_version: "4.9-2016.02"
-        apr_version: "1.6.5"
+        gcc_version: "10.2-2020.11"
+        apr_version: "1.7.0"
         openssl_version: "1_1_1d"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -332,6 +332,7 @@
                     <configureArg>--with-apr=${aprArmHome}</configureArg>
                     <configureArg>--with-ssl=${opensslArmHome}</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>
+                    <configureArg>CC=aarch64-none-linux-gnu-gcc</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>


### PR DESCRIPTION
Motivation:

LSE (https://mysqlonarm.github.io/ARM-LSE-and-MySQL/) can have a huge performance difference. Let's ensure we use a compiler that can support it.

Modifications:

Update to gcc10 when cross-compiling as it supports LSE and enables it by default

Result:

More optimized builds for aarch64