### PR TITLE
Bump OpenSSL version to 1.1.1k

### DIFF
--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -10,7 +10,7 @@ services:
       args:
         gcc_version: "10.2-2020.11"
         apr_version: "1.7.0"
-        openssl_version: "1_1_1d"
+        openssl_version: "1_1_1k"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     image: netty-tcnative-centos:cross_compile_aarch64

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,9 @@
     -->
     <libresslSha256>414c149c9963983f805a081db5bd3aec146b5f82d529bb63875ac941b25dcbb6</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>j</opensslPatchVersion>
+    <opensslPatchVersion>k</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf</opensslSha256>
+    <opensslSha256>892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprSourceDir>${project.build.directory}/apr-source</aprSourceDir>
     <aprPatchFile>r1871981-macos11.patch</aprPatchFile>


### PR DESCRIPTION
Motivation:

OpenSSL versions between 1.1.1h and 1.1.1j are vulnerable to
[CVE-2021-3450][1] and all 1.1.1 versions are vulnerable to
[CVE-2021-3449][2].

More in the OpenSSL security advisory, [here][3].

Modifications:

Update openssl-static to use the latest released version of OpenSSL,
1.1.1k.

Bump the version of OpenSSL used in the CentOS Docker container.

Result:

Artifacts of openssl-static that are no longer vulnerable to
CVE-2021-3449 and CVE-2021-3450.

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3450
[2]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449
[3]: https://www.openssl.org/news/secadv/20210325.txt

Signed-off-by: Nick Travers <n.e.travers@gmail.com>