### PR TITLE
Unload certificateVerifierTask_class

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2808,6 +2808,7 @@ error:
 void netty_internal_tcnative_SSLContext_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, sslTask_class);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateCallbackTask_class);
+    NETTY_JNI_UTIL_UNLOAD_CLASS(env, certificateVerifierTask_class);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, sslPrivateKeyMethodTask_class);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, sslPrivateKeyMethodSignTask_class);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, sslPrivateKeyMethodDecryptTask_class);


### PR DESCRIPTION
Motivation:

We did miss to unload the certificateVerifierTask_class. While this is not a big problem we should still do ensure the class is not referenced anymore

Modifications:

Unload class

Result:

Ensure all native loaded classes are unload