### PR TITLE
Add missing return statement

### DIFF
--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -78,7 +78,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLSession, upRef)(TCN_STDARGS, jlong session) {
     return SSL_SESSION_up_ref(session_) == 1 ? JNI_TRUE : JNI_FALSE;
 #else
     // Older versions of OpenSSL don't expose SSL_SESSION_up_ref
-    CRYPTO_add(&session_->references, 1, CRYPTO_LOCK_SSL_SESSION);
+    return CRYPTO_add(&session_->references, 1, CRYPTO_LOCK_SSL_SESSION) >= 1 ? JNI_TRUE: JNI_FALSE;
 #endif // OPENSSL_VERSION_NUMBER >= 0x10100000L
 }
 


### PR DESCRIPTION
Motivation:

We did miss to add a return statement when an openssl version < 1.1.x was used.

Modifications:

Add missing return statement.

Result:

Correctly handle the reference count