### PR TITLE
Only try to increment reference count if function is present

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -451,6 +451,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
     extern void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param, unsigned int flags) __attribute__((weak));
     extern int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param, const char *name, size_t namelen) __attribute__((weak));
     extern int SSL_CTX_set_num_tickets(SSL_CTX *ctx, size_t num_tickets) __attribute__((weak));
+    extern int SSL_SESSION_up_ref(SSL_SESSION *session) __attribute__((weak));
 #endif // OPENSSL_IS_BORINGSSL
 
     extern int SSL_get_sigalgs(SSL *s, int idx, int *psign, int *phash, int *psignhash, unsigned char *rsig, unsigned char *rhash) __attribute__((weak));


### PR DESCRIPTION
Motivation:

If we did compile on older versions of openssl we tried to adjust the reference count of the SSLSession by directly accessing the field in the struct and increment it. While this sounded like a perfect workaround it turns out that this can cause all kind of problems and so also segfaults in general. Depending on how the openssl library was compile on the system we will have different layout of the struct and so can't really depend on a specific layout.

Modifications:

- Use weak linking if possible to detect on runtime of the SSLSession_up_ref function is present when using OpenSSL
- If the function is not present just return JNI_FALSE as we couldn't increment the reference count and so the user need to handle it. Which in our use-case in netty means that we can't cache the session.

Result:

No more segfaults when using dynamic linked OpenSSL version