### PR TITLE
Only use ifdef if we don't use BoringSSL

### DIFF
--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -74,7 +74,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLSession, upRef)(TCN_STDARGS, jlong session) {
     TCN_CHECK_NULL(session_, session, JNI_FALSE);
 
     // Only supported with GCC
-    #if defined(__GNUC__) || defined(__GNUG__)
+    #if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
         if (!SSL_SESSION_up_ref) {
             return JNI_FALSE;
         }


### PR DESCRIPTION
Motivation:

We should use the weak linking test if we not use BoringSSL. This is a followup of b7522ff6f95fce61509d776dbbfdc57780c0e372

Modifications:

Check if BoringSSL is used

Result:

Compiles against BoringSSL on macos