### PR TITLE
Preload classes so we can't see a classloader deadlock

### DIFF
--- a/openssl-dynamic/src/main/c/bb.c
+++ b/openssl-dynamic/src/main/c/bb.c
@@ -53,6 +53,8 @@ static const JNINativeMethod method_table[] = {
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 jint netty_internal_tcnative_Buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_jni_util_register_natives(env, packagePrefix, BUFFER_CLASSNAME, method_table, method_table_size) != 0) {
         return JNI_ERR;

--- a/openssl-dynamic/src/main/c/error.c
+++ b/openssl-dynamic/src/main/c/error.c
@@ -80,8 +80,9 @@ void tcn_throwOutOfMemoryError(JNIEnv* env, const char *msg)
     (*env)->ThrowNew(env, oomeClass, msg);
 }
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 jint netty_internal_tcnative_Error_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
-
     NETTY_JNI_UTIL_LOAD_CLASS(env, exceptionClass, "java/lang/Exception", error);
     NETTY_JNI_UTIL_LOAD_CLASS(env, nullPointerExceptionClass, "java/lang/NullPointerException", error);
     NETTY_JNI_UTIL_LOAD_CLASS(env, illegalArgumentExceptionClass, "java/lang/IllegalArgumentException", error);

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -148,6 +148,8 @@ static const JNINativeMethod method_table[] = {
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int errorOnLoadCalled = 0;
     int bufferOnLoadCalled = 0;

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -685,6 +685,8 @@ static const JNINativeMethod method_table[] = {
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 jint netty_internal_tcnative_NativeStaticallyReferencedJniMethods_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_jni_util_register_natives(env,
              packagePrefix,

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2705,6 +2705,8 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 jint netty_internal_tcnative_SSL_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_jni_util_register_natives(env,
              packagePrefix,

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2740,6 +2740,8 @@ error:
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 jint netty_internal_tcnative_SSLContext_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     char* name = NULL;
     char* combinedName = NULL;

--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -122,6 +122,8 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Library to reflect that.
 jint netty_internal_tcnative_SSLSession_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_jni_util_register_natives(env,
              packagePrefix,


### PR DESCRIPTION
Motivation:

It turns out it is quite easy to cause a classloader deadlock in more recent java updates if you cause classloading while you are in native code. Because of this we should just workaround this issue by pre-load all the classes that needs to be accessed in the OnLoad function.

See https://github.com/netty/netty/issues/11209

Modifications:

Preload all classes that would otherwise be loaded by native OnLoad functions.

Result:

No more deadlocks possible.