### PR TITLE
Allow to override the repository url of boringssl

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -50,6 +50,9 @@
   <properties>
     <boringsslSourceDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslSourceDir>
     <boringsslHome>${boringsslSourceDir}/build</boringsslHome>
+    <boringsslSourceDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslSourceDir>
+    <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
+    <boringsslBranch>chromium-stable</boringsslBranch>
     <linkStatic>true</linkStatic>
     <compileLibrary>true</compileLibrary>
     <msvcSslIncludeDirs>${boringsslSourceDir}/include</msvcSslIncludeDirs>
@@ -82,7 +85,7 @@
                 <configuration>
                   <checkoutDirectory>${boringsslSourceDir}</checkoutDirectory>
                   <connectionType>developerConnection</connectionType>
-                  <developerConnectionUrl>scm:git:https://boringssl.googlesource.com/boringssl</developerConnectionUrl>
+                  <developerConnectionUrl>scm:git:${boringsslRepository}</developerConnectionUrl>
                   <scmVersion>${boringsslBranch}</scmVersion>
                   <scmVersionType>branch</scmVersionType>
                   <skipCheckoutIfExists>true</skipCheckoutIfExists>


### PR DESCRIPTION
Motivation:

Sometimes users want to use their own custom fork of boringssl. At the moment for this a modification of pom.xml is needed.

Modifications:

Allow to override the repository url for boringssl via -D...

Result:

Be able to use a custom fork of boringssl more easily