### PR TITLE
Use m2 repositry cache

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,6 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-${{ matrix.setup }}-m2-repository-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
@@ -77,6 +85,14 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v1
         with:
           args: install ninja nasm
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
         run: mvn --file pom.xml -pl boringssl-static clean package

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: stage-snapshot-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            stage-snapshot-${{ matrix.setup }}-m2-repository-cache-
+
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
         env:
@@ -85,6 +93,14 @@ jobs:
         with:
           args: install ninja nasm
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: stage-snapshot-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            stage-snapshot-windows-m2-repository-cache-
+
       - name: Build netty-tcnative-boringssl-static
         run: mvn --file pom.xml -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
 
@@ -106,17 +122,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-
-      # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: deploy-staging-cache-m2-repository
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-deploy-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-deploy-${{ env.cache-name }}-
-            ${{ runner.os }}-deploy-
 
       # Setup some env to re-use later.
       - name: Prepare enviroment variables
@@ -160,6 +165,15 @@ jobs:
           cp -r ~/debian7-x86_64-local-staging/deferred/* ~/local-staging/deferred/
           cat ~/centos6-x86_64-local-staging/deferred/.index >>  ~/local-staging/deferred/.index
           cp -r ~/centos6-x86_64-local-staging/deferred/* ~/local-staging/deferred/
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: deploy-staged-snapshot-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-stage-snapshot-m2-repository-cache-
+
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,6 +35,14 @@ jobs:
           restore-keys: |
             pr-${{ matrix.setup }}-docker-cache-
 
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-pr-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-pr-${{ matrix.setup }}-m2-repository-cache-
+
       - name: Build docker image
         run: docker-compose ${{ matrix.docker-compose-build }}
 
@@ -73,6 +81,14 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v1
         with:
           args: install ninja nasm
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: build-pr-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            build-pr-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
         run: mvn --file pom.xml -pl boringssl-static clean package

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -31,14 +31,11 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v2
-        env:
-          cache-name: release-cache-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: prepare-release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            prepare-release-cache-m2-repository-
 
       - name: Prepare release with Maven
         run: |
@@ -94,6 +91,14 @@ jobs:
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: stage-release-linux-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            stage-release-linux-${{ matrix.setup }}-m2-repository-cache-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -191,14 +196,11 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v2
-        env:
-          cache-name: staging-release-cache-windows-m2-repository
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: staging-release-cache-windows-m2-repository-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
+            staging-release-cache-windows-m2-repository-
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:
@@ -284,6 +286,15 @@ jobs:
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
         run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/centos7-aarch64-local-staging/staging ~/debian7-x86_64-local-staging/staging ~/centos6-x86_64-local-staging/staging
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: deploy-staged-release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-staged-release-cache-m2-repository-
+
 
       - uses: s4u/maven-settings-action@v2.2.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,14 +33,11 @@ jobs:
 
     # Cache .m2/repository
     - uses: actions/cache@v2
-      env:
-        cache-name: ${{ matrix.language }}-cache-m2-repository
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-analyze-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        key: analyze-${{ matrix.language }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-analyze-${{ env.cache-name }}-
-          ${{ runner.os }}-analyze-
+          analyze-${{ matrix.language }}-cache-m2-repository-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/docker/docker-compose.arch.yaml
+++ b/docker/docker-compose.arch.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code
     working_dir: /code
 

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -13,6 +13,7 @@ services:
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.gnupg:/root/.gnupg:delegated
       - ..:/code:delegated
     working_dir: /code
@@ -30,6 +31,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "mvn -Pstage -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
@@ -42,6 +44,7 @@ services:
       - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
@@ -52,6 +55,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
     command: /bin/bash -cl "mvn clean deploy -DskipTests=true -DaprSourceDir=/root/workspace/apr-source -DaprHome=/root/workspace/apr -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl -DopensslSourceDir=/root/workspace/openssl-source -DopensslHome=/root/workspace/openssl -DlibresslSourceDir=/root/workspace/libressl-source -DlibresslHome=/root/workspace/libressl"
@@ -61,6 +65,8 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/.gitconfig:/root/.gitconfig:delegated
       - ~/.gitignore:/root/.gitignore:delegated
       - ..:/code:delegated

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.gitconfig:/root/.gitconfig:delegated
       - ~/.gitignore:/root/.gitignore:delegated
       - ..:/code:delegated
@@ -43,6 +44,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
     command: /bin/bash -cl "pushd ./openssl-dynamic && mvn clean deploy -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && popd && pushd ./boringssl-static && mvn clean deploy -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl -DskipTests && popd"
@@ -52,6 +54,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "pushd ./openssl-dynamic && mvn -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true && popd && pushd ./boringssl-static && mvn -Plinux-aarch64 -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
@@ -64,6 +67,7 @@ services:
       - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code:delegated
     working_dir: /code
 
@@ -26,6 +27,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
     command: /bin/bash -cl "mvn -pl openssl-dynamic clean deploy -DskipTests=true"
@@ -39,6 +41,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
     command: /bin/bash -cl "mvn -Pstage -pl openssl-dynamic clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
@@ -51,6 +54,7 @@ services:
       - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
+      - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code

--- a/docker/docker-compose.opensuse.yaml
+++ b/docker/docker-compose.opensuse.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
+      - ~/.m2/repository:/root/.m2/repository
       - ..:/code
     working_dir: /code
 


### PR DESCRIPTION
Motivation:

We should try to cache the maven dependencies and so reduce the likelyness of build failures due connections failures

Modifications:

- Adjust workflows to use the cache
- Adjust docker / docker-compose config to use the cache

Result:

More stable build