### PR TITLE
Use MAVEN_OPTS to setup timeouts for dependency downloads (#280)

### DIFF
--- a/.github/scripts/release_rollback.ps1
+++ b/.github/scripts/release_rollback.ps1
@@ -7,5 +7,5 @@ $url = "git@github.com:" + $repository + ".git"
 git remote set-url origin $url
 git fetch
 git checkout $branch
-mvn -B --file pom.xml release:rollback
+./mvnw.cmd -B --file pom.xml release:rollback
 git push origin :$tag

--- a/.github/scripts/release_rollback.sh
+++ b/.github/scripts/release_rollback.sh
@@ -10,5 +10,5 @@ TAG=$(grep scm.tag= "$1" | cut -d'=' -f2)
 git remote set-url origin git@github.com:"$2".git
 git fetch
 git checkout "$3"
-mvn -B --file pom.xml release:rollback
+./mvnw -B --file pom.xml release:rollback
 git push origin :"$TAG"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -95,7 +98,7 @@ jobs:
             build-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
-        run: mvn --file pom.xml -Pci -pl boringssl-static clean package
+        run: ./mvnw.cmd --file pom.xml -pl boringssl-static clean package
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
 
   stage-snapshot:
@@ -102,7 +105,7 @@ jobs:
             stage-snapshot-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
-        run: mvn --file pom.xml -Pci -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
+        run: ./mvnw.cmd --file pom.xml -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v2
@@ -185,4 +188,4 @@ jobs:
             }]
 
       - name: Deploy local staged artifacts
-        run: mvn -B --file pom.xml -Pci org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   build-pr:
     runs-on: ubuntu-latest
@@ -91,7 +94,7 @@ jobs:
             build-pr-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
-        run: mvn --file pom.xml -Pci -pl boringssl-static clean package
+        run: ./mvnw.cmd --file pom.xml -pl boringssl-static clean package
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -5,6 +5,9 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   prepare-release:
     runs-on: ubuntu-18.04
@@ -39,8 +42,8 @@ jobs:
 
       - name: Prepare release with Maven
         run: |
-          mvn -B --file pom.xml -Pci release:prepare -DpreparationGoals=clean  -DskipTests=true
-          mvn -Pci clean
+          ./mvnw -B --file pom.xml release:prepare -DpreparationGoals=clean  -DskipTests=true
+          ./mvnw clean
 
       - name: Checkout tag
         run: ./.github/scripts/release_checkout_tag.sh release.properties
@@ -213,7 +216,7 @@ jobs:
 
       - name: Stage release to local staging directory
         working-directory: prepare-release-workspace
-        run: mvn --file pom.xml -Pci, stage -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
+        run: ./mvnw --file pom.xml -Pstage -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v2
@@ -308,7 +311,7 @@ jobs:
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: mvn -B --file pom.xml -Pci  org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,8 @@ on:
     branches: [main]
   schedule:
     - cron: '0 19 * * 5'
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   analyze:
@@ -65,7 +67,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar libapr1-dev libssl-dev cmake perl ninja-build
 
     - name: Build project
-      run: ./mvnw -Pci clean package -DskipTests=true
+      run: ./mvnw clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-  <servers>
-    <server>
-      <id>sonatype-nexus-snapshots</id>
-      <username>${env.SANOTYPE_USER}</username>
-      <password>${env.SANOTYPE_PASSWORD}</password>
-    </server>
-  </servers>
-</settings>

--- a/docker/docker-compose.arch.yaml
+++ b/docker/docker-compose.arch.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty-tcnative-arch:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty-tcnative-centos:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.m2/repository:/root/.m2/repository
@@ -38,10 +43,6 @@ services:
 
   stage-release:
     <<: *common
-    environment:
-      - GPG_KEYNAME
-      - GPG_PASSPHRASE
-      - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2/repository:/root/.m2/repository

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -15,6 +15,11 @@ services:
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     image: netty-tcnative-centos:cross_compile_aarch64
     depends_on: [cross-compile-aarch64-runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated
@@ -61,10 +66,6 @@ services:
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
-    environment:
-      - GPG_KEYNAME
-      - GPG_PASSPHRASE
-      - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2/repository:/root/.m2/repository

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty-tcnative-debian:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated

--- a/docker/docker-compose.opensuse.yaml
+++ b/docker/docker-compose.opensuse.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty-tcnative-opensuse:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/pom.xml
+++ b/pom.xml
@@ -428,15 +428,6 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>ci</id>
-      <properties>
-        <http.keepAlive>false</http.keepAlive>
-        <maven.wagon.http.pool>false</maven.wagon.http.pool>
-        <maven.wagon.httpconnectionManager.ttlSeconds>120</maven.wagon.httpconnectionManager.ttlSeconds>
-      </properties>
-    </profile>
-
-    <profile>
       <id>disable-autogen-windows</id>
       <activation>
         <os>


### PR DESCRIPTION
Motivation:

Just use MAVEN_OPTS to setup all the timeouts etc for dependency downloads. This way we at least can be sure these are applied.

Modifications:

- Use MAVEN_OPTS
- Remove ci profile
- Remove unused settings.xml file
- Always use ./mvnw

Result:

Build stability improvements