### PR TITLE
Introduce the ability to run key-signing in an fully async fashion.

### DIFF
--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/AsyncSSLPrivateKeyMethod.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/AsyncSSLPrivateKeyMethod.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Allows to customize private key signing / decrypt (when using RSA).
+ */
+public interface AsyncSSLPrivateKeyMethod {
+    int SSL_SIGN_RSA_PKCS1_SHA1 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha1();
+    int SSL_SIGN_RSA_PKCS1_SHA256 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha256();
+    int SSL_SIGN_RSA_PKCS1_SHA384 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha384();
+    int SSL_SIGN_RSA_PKCS1_SHA512 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcsSha512();
+    int SSL_SIGN_ECDSA_SHA1 = NativeStaticallyReferencedJniMethods.sslSignEcdsaPkcsSha1();
+    int SSL_SIGN_ECDSA_SECP256R1_SHA256 = NativeStaticallyReferencedJniMethods.sslSignEcdsaSecp256r1Sha256();
+    int SSL_SIGN_ECDSA_SECP384R1_SHA384 = NativeStaticallyReferencedJniMethods.sslSignEcdsaSecp384r1Sha384();
+    int SSL_SIGN_ECDSA_SECP521R1_SHA512 = NativeStaticallyReferencedJniMethods.sslSignEcdsaSecp521r1Sha512();
+    int SSL_SIGN_RSA_PSS_RSAE_SHA256 = NativeStaticallyReferencedJniMethods.sslSignRsaPssRsaeSha256();
+    int SSL_SIGN_RSA_PSS_RSAE_SHA384 = NativeStaticallyReferencedJniMethods.sslSignRsaPssRsaeSha384();
+    int SSL_SIGN_RSA_PSS_RSAE_SHA512 = NativeStaticallyReferencedJniMethods.sslSignRsaPssRsaeSha512();
+    int SSL_SIGN_ED25519 = NativeStaticallyReferencedJniMethods.sslSignEd25519();
+    int SSL_SIGN_RSA_PKCS1_MD5_SHA1 = NativeStaticallyReferencedJniMethods.sslSignRsaPkcs1Md5Sha1();
+
+    /**
+     * Sign the input with given EC key and notify {@link ResultCallback} with the signed bytes.
+     *
+     * @param ssl                   the SSL instance
+     * @param signatureAlgorithm    the algorithm to use for signing
+     * @param input                 the input itself
+     * @param resultCallback        the callback that will be notified once the operation completes
+     */
+    void sign(long ssl, int signatureAlgorithm, byte[] input, ResultCallback<byte[]> resultCallback);
+
+    /**
+     * Decrypts the input with the given RSA key and notify {@link ResultCallback} with the decrypted bytes.
+     *
+     * @param ssl                   the SSL instance
+     * @param input                 the input which should be decrypted
+     * @param resultCallback        the callback that will be notified once the operation completes
+     */
+    void decrypt(long ssl, byte[] input, ResultCallback<byte[]> resultCallback);
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/AsyncSSLPrivateKeyMethodAdapter.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/AsyncSSLPrivateKeyMethodAdapter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+final class AsyncSSLPrivateKeyMethodAdapter implements AsyncSSLPrivateKeyMethod {
+    private final SSLPrivateKeyMethod method;
+
+    AsyncSSLPrivateKeyMethodAdapter(SSLPrivateKeyMethod method) {
+        if (method == null) {
+            throw new NullPointerException("method");
+        }
+        this.method = method;
+    }
+
+    @Override
+    public void sign(long ssl, int signatureAlgorithm, byte[] input, ResultCallback<byte[]> resultCallback) {
+        final byte[] result;
+        try {
+            result = method.sign(ssl, signatureAlgorithm, input);
+        } catch (Throwable cause) {
+            resultCallback.onError(ssl, cause);
+            return;
+        }
+        resultCallback.onSuccess(ssl, result);
+    }
+
+    @Override
+    public void decrypt(long ssl, byte[] input, ResultCallback<byte[]> resultCallback) {
+        final byte[] result;
+        try {
+            result = method.decrypt(ssl, input);
+        } catch (Throwable cause) {
+            resultCallback.onError(ssl, cause);
+            return;
+        }
+        resultCallback.onSuccess(ssl, result);
+    }
+}

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/AsyncTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/AsyncTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,19 +15,13 @@
  */
 package io.netty.internal.tcnative;
 
-final class SSLPrivateKeyMethodDecryptTask extends SSLPrivateKeyMethodTask {
+public interface AsyncTask extends Runnable {
 
-    private final byte[] input;
-
-    SSLPrivateKeyMethodDecryptTask(long ssl, byte[] input, AsyncSSLPrivateKeyMethod method) {
-        super(ssl, method);
-        // It's OK to not clone the arrays as we create these in JNI and not reuse.
-        this.input = input;
-    }
-
-    @Override
-    protected void runTask(long ssl, AsyncSSLPrivateKeyMethod method,
-                           ResultCallback<byte[]> resultCallback) {
-        method.decrypt(ssl, input, resultCallback);
-    }
+    /**
+     * Run this {@link AsyncTask} in an async fashion. Which means it will be run and completed at some point.
+     * Once it is done the {@link Runnable} is called
+     *
+     * @param completeCallback  The {@link Runnable} that is run once the task was run and completed.
+     */
+    void runAsync(Runnable completeCallback);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallbackTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateCallbackTask.java
@@ -35,15 +35,15 @@ final class CertificateCallbackTask extends SSLTask {
 
     // See https://www.openssl.org/docs/man1.0.2/man3/SSL_set_cert_cb.html.
     @Override
-    protected int runTask(long ssl) {
+    protected void runTask(long ssl, TaskCallback taskCallback) {
         try {
             callback.handle(ssl, keyTypeBytes, asn1DerEncodedPrincipals);
-            return 1;
+            taskCallback.onResult(ssl, 1);
         } catch (Exception e) {
             // Just catch the exception and return 0 to fail the handshake.
             // The problem is that rethrowing here is really "useless" as we will process it as part of an openssl
             // c callback which needs to return 0 for an error to abort the handshake.
-            return 0;
+            taskCallback.onResult(ssl, 0);
         }
     }
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateVerifierTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/CertificateVerifierTask.java
@@ -32,7 +32,8 @@ final class CertificateVerifierTask extends SSLTask {
     }
 
     @Override
-    protected int runTask(long ssl) {
-        return verifier.verify(ssl, x509, authAlgorithm);
+    protected void runTask(long ssl, TaskCallback callback) {
+        int result = verifier.verify(ssl, x509, authAlgorithm);
+        callback.onResult(ssl, result);
     }
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/ResultCallback.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/ResultCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,19 +15,25 @@
  */
 package io.netty.internal.tcnative;
 
-final class SSLPrivateKeyMethodDecryptTask extends SSLPrivateKeyMethodTask {
+/**
+ * Callback that is called once an operation completed.
+ *
+ * @param <T>   The result type.
+ */
+public interface ResultCallback<T> {
+    /**
+     * Called when the operation completes with the given result.
+     *
+     * @param ssl       the SSL instance (SSL *)
+     * @param result    the result.
+     */
+    void onSuccess(long ssl, T result);
 
-    private final byte[] input;
-
-    SSLPrivateKeyMethodDecryptTask(long ssl, byte[] input, AsyncSSLPrivateKeyMethod method) {
-        super(ssl, method);
-        // It's OK to not clone the arrays as we create these in JNI and not reuse.
-        this.input = input;
-    }
-
-    @Override
-    protected void runTask(long ssl, AsyncSSLPrivateKeyMethod method,
-                           ResultCallback<byte[]> resultCallback) {
-        method.decrypt(ssl, input, resultCallback);
-    }
+    /**
+     * Called when the operation completes with an error.
+     *
+     * @param ssl       the SSL instance (SSL *)
+     * @param cause     the error.
+     */
+    void onError(long ssl, Throwable cause);
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -835,13 +835,27 @@ public final class SSL {
     public static native byte[] getClientRandom(long ssl);
 
     /**
-     * Return the {@link Runnable} thats needs to be run as an operation returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
+     * Return the {@link Runnable} that needs to be run as an operation returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
      * After the task was run we should retry the operations that returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
      *
      * @param ssl the SSL instance (SSL *)
      * @return the task to run.
      */
     public static native Runnable getTask(long ssl);
+
+
+    /**
+     * Return the {@link AsyncTask} that needs to be run as an operation did signal that a task needs to be completed
+     * before we can retry it.
+     *
+     * After the task was run we should retry the operation that did signal back that a task needed to be run.
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @return the task to run.
+     */
+    public static AsyncTask getAsyncTask(long ssl) {
+        return (AsyncTask) getTask(ssl);
+    }
 
     /**
      * Return {@code true} if the SSL_SESSION was reused. 

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -835,14 +835,19 @@ public final class SSL {
     public static native byte[] getClientRandom(long ssl);
 
     /**
-     * Return the {@link Runnable} that needs to be run as an operation returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
-     * After the task was run we should retry the operations that returned {@link #SSL_ERROR_WANT_X509_LOOKUP}.
+     * Return the {@link Runnable} that needs to be run as an operation did signal that a task needs to be completed
+     * before we can retry the previous action.
+     *
+     * After the task was run we should retry the operation that did signal back that a task needed to be run.
+     *
+     *
+     * The {@link Runnable} may also implement {@link AsyncTask} which allows for fully asynchronous execution if
+     * {@link AsyncTask#runAsync(Runnable)} is used.
      *
      * @param ssl the SSL instance (SSL *)
      * @return the task to run.
      */
     public static native Runnable getTask(long ssl);
-
 
     /**
      * Return the {@link AsyncTask} that needs to be run as an operation did signal that a task needs to be completed

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -663,7 +663,7 @@ public final class SSLContext {
     }
 
     /**
-     * Set the {@link AsyncSSLPrivateKeyMethod} to use for the given {@link SSLContext}.
+     * Sets the {@link AsyncSSLPrivateKeyMethod} to use for the given {@link SSLContext}.
      * This allows to offload private key operations if needed.
      *
      * This method is currently only supported when {@code BoringSSL} is used.

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -649,7 +649,8 @@ public final class SSLContext {
     public static native void setUseTasks(long ctx, boolean useTasks);
 
     /**
-     * Set the {@link SSLPrivateKeyMethod} to use for the given {@link SSLContext}. This allows to offload privatekey operations
+     * Set the {@link SSLPrivateKeyMethod} to use for the given {@link SSLContext}.
+     * This allows to offload private key operations
      * if needed.
      *
      * This method is currently only supported when {@code BoringSSL} is used.
@@ -657,7 +658,24 @@ public final class SSLContext {
      * @param ctx context to use
      * @param method method to use for the given context.
      */
-    public static native void setPrivateKeyMethod(long ctx, SSLPrivateKeyMethod method);
+    public static void setPrivateKeyMethod(long ctx, final SSLPrivateKeyMethod method) {
+        setPrivateKeyMethod(ctx, new AsyncSSLPrivateKeyMethodAdapter(method));
+    }
+
+    /**
+     * Set the {@link AsyncSSLPrivateKeyMethod} to use for the given {@link SSLContext}.
+     * This allows to offload private key operations if needed.
+     *
+     * This method is currently only supported when {@code BoringSSL} is used.
+     *
+     * @param ctx context to use
+     * @param method method to use for the given context.
+     */
+    public static void setPrivateKeyMethod(long ctx, AsyncSSLPrivateKeyMethod method) {
+        setPrivateKeyMethod0(ctx, method);
+    }
+
+    private static native void setPrivateKeyMethod0(long ctx, AsyncSSLPrivateKeyMethod method);
 
     /**
      * Set the {@link SSLSessionCache} that will be used if session caching is enabled.

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask.java
@@ -19,7 +19,7 @@ final class SSLPrivateKeyMethodSignTask extends SSLPrivateKeyMethodTask {
     private final int signatureAlgorithm;
     private final byte[] digest;
 
-    SSLPrivateKeyMethodSignTask(long ssl, int signatureAlgorithm, byte[] digest, SSLPrivateKeyMethod method) {
+    SSLPrivateKeyMethodSignTask(long ssl, int signatureAlgorithm, byte[] digest, AsyncSSLPrivateKeyMethod method) {
         super(ssl, method);
         this.signatureAlgorithm = signatureAlgorithm;
         // It's OK to not clone the arrays as we create these in JNI and not reuse.
@@ -27,7 +27,8 @@ final class SSLPrivateKeyMethodSignTask extends SSLPrivateKeyMethodTask {
     }
 
     @Override
-    protected byte[] runTask(long ssl, SSLPrivateKeyMethod method) throws Exception {
-        return method.sign(ssl, signatureAlgorithm, digest);
+    protected void runTask(long ssl, AsyncSSLPrivateKeyMethod method,
+                           ResultCallback<byte[]> resultCallback) {
+        method.sign(ssl, signatureAlgorithm, digest, resultCallback);
     }
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodTask.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLPrivateKeyMethodTask.java
@@ -15,7 +15,7 @@
  */
 package io.netty.internal.tcnative;
 
-abstract class SSLPrivateKeyMethodTask extends SSLTask {
+abstract class SSLPrivateKeyMethodTask extends SSLTask implements AsyncTask {
     private static final byte[] EMPTY = new byte[0];
     private final AsyncSSLPrivateKeyMethod method;
 
@@ -25,6 +25,12 @@ abstract class SSLPrivateKeyMethodTask extends SSLTask {
     SSLPrivateKeyMethodTask(long ssl, AsyncSSLPrivateKeyMethod method) {
         super(ssl);
         this.method = method;
+    }
+
+
+    @Override
+    public final void runAsync(final Runnable completeCallback) {
+        run(completeCallback);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Sometimes we may want to run tasks in a fully async fashion. For example if we need to do a network operation to full fill the task.

This commit only makes use of the real async support for key-signing but we could also do the same for other tasks.

Modifications:

- Add AsyncTask that allows to run a task in an async fashion and notify the callback once done.
- Add AsyncSSLPrivateKeyMethod that makes use of the AsyncTask and so allow for a fully async implementation for key signing.

Result:

More flexible