### PR TITLE
Fix several build issues for JDK 16

### DIFF
--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -218,7 +218,7 @@
                   <forceConfigure>${forceConfigure}</forceConfigure>
                   <configureArgs>
                     <configureArg>${macOsxDeploymentTarget}</configureArg>
-                    <configureArg>--with-apr=/usr/local/opt/apr/libexec/</configureArg>
+                    <configureArg>--with-apr=/opt/homebrew/opt/apr/libexec/</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <checkstyle.skip>true</checkstyle.skip>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <netty.build.version>29</netty.build.version>
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <forceAutogen>false</forceAutogen>
@@ -230,7 +230,7 @@
      <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.14.3</version>
+        <version>0.15.3</version>
         <configuration>
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>


### PR DESCRIPTION
- Needed to bump minimum source/target versions for compiler (1.6 no
  longer supported).
- Needed to bump version of japicmp which fixes
  https://github.com/siom79/japicmp/issues/275 for JDK 16.
- Needed to adjust apr path for brew dependency on Mac.