### PR TITLE
Ensure we include hs_err* files when build failed

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,7 +62,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-${{ matrix.setup }}-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log
 
 
   build-windows:
@@ -104,4 +106,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-windows-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,7 +59,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-pr-${{ matrix.setup }}-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log
 
   build-pr-windows:
     runs-on: windows-2016
@@ -100,4 +102,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-pr-windows-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log


### PR DESCRIPTION
Motivation:

We the build failed we should ensure we also include hs_err* files as it may have failed due a native crash

Modifications:

Adjust path matching to include hs_err as well

Result:

Easier to debug native crashes