### PR TITLE
Allow to set renegiotion mode when BoringSSL is used

### DIFF
--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -559,6 +559,47 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcs1Md
     return SSL_SIGN_RSA_PKCS1_MD5_SHA1;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateNever)(TCN_STDARGS) {
+#ifdef OPENSSL_IS_BORINGSSL
+    return (jint) ssl_renegotiate_never;
+#else
+    return 0;
+#endif
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateOnce)(TCN_STDARGS) {
+#ifdef OPENSSL_IS_BORINGSSL
+    return (jint) ssl_renegotiate_once;
+#else
+    return 0;
+#endif
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateFreely)(TCN_STDARGS) {
+#ifdef OPENSSL_IS_BORINGSSL
+    return (jint) ssl_renegotiate_freely;
+#else
+    return 0;
+#endif
+}
+
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateIgnore)(TCN_STDARGS) {
+#ifdef OPENSSL_IS_BORINGSSL
+    return (jint) ssl_renegotiate_ignore;
+#else
+    return 0;
+#endif
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateExplicit)(TCN_STDARGS) {
+#ifdef OPENSSL_IS_BORINGSSL
+    return (jint) ssl_renegotiate_explicit;
+#else
+    return 0;
+#endif
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpCipherServerPreference, ()I, NativeStaticallyReferencedJniMethods) },
@@ -679,7 +720,13 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslSignRsaPssRsaeSha384, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSignRsaPssRsaeSha512, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSignEd25519, ()I, NativeStaticallyReferencedJniMethods) },
-  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcs1Md5Sha1, ()I, NativeStaticallyReferencedJniMethods) }
+  { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcs1Md5Sha1, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateNever, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateOnce, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateFreely, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateIgnore, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateExplicit, ()I, NativeStaticallyReferencedJniMethods) }
+
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2624,6 +2624,17 @@ complete:
 #endif // defined(OPENSSL_IS_BORINGSSL) || defined(LIBRESSL_VERSION_NUMBER)
 }
 
+TCN_IMPLEMENT_CALL(void, SSL, setRenegotiateMode)(TCN_STDARGS, jlong ssl, jint mode) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    TCN_CHECK_NULL(ssl_, ssl, /* void */);
+#ifndef OPENSSL_IS_BORINGSSL
+    tcn_Throw(e, "Not supported");
+#else
+    SSL_set_renegotiate_mode(ssl_, (enum ssl_renegotiate_mode_t) mode);
+#endif
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(bioLengthByteBuffer, (J)I, SSL) },
@@ -2698,7 +2709,8 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getServerRandom, (J)[B, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getTask, (J)Ljava/lang/Runnable;, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getSession, (J)J, SSL) },
-  { TCN_METHOD_TABLE_ENTRY(isSessionReused, (J)Z, SSL) }
+  { TCN_METHOD_TABLE_ENTRY(isSessionReused, (J)Z, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setRenegotiateMode, (JI)V, SSL) }
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -166,4 +166,10 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslSignRsaPssRsaeSha512();
     static native int sslSignEd25519();
     static native int sslSignRsaPkcs1Md5Sha1();
+
+    static native int sslRenegotiateNever();
+    static native int sslRenegotiateOnce();
+    static native int sslRenegotiateFreely();
+    static native int sslRenegotiateIgnore();
+    static native int sslRenegotiateExplicit();
 }

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -110,6 +110,12 @@ public final class SSL {
     public static final int X509_CHECK_FLAG_NO_PARTIAL_WILD_CARDS = x509CheckFlagNoPartialWildCards();
     public static final int X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS = x509CheckFlagMultiLabelWildCards();
 
+    public static final int SSL_RENEGOTIATE_NEVER = sslRenegotiateNever();
+    public static final int SSL_RENEGOTIATE_ONCE = sslRenegotiateOnce();
+    public static final int SSL_RENEGOTIATE_FREELY = sslRenegotiateFreely();
+    public static final int SSL_RENEGOTIATE_IGNORE = sslRenegotiateIgnore();
+    public static final int SSL_RENEGOTIATE_EXPLICIT = sslRenegotiateExplicit();
+
     /* Return OpenSSL version number */
     public static native int version();
 
@@ -887,4 +893,15 @@ public final class SSL {
      * @return the SSL_SESSION instance (SSL_SESSION *) used
      */
     public static native long getSession(long ssl);
+
+    /**
+     * Allow to set the renegotiation mode that is used. This is only support by {@code BoringSSL}.
+     *
+     * See <a href="https://boringssl.googlesource.com/boringssl/+/refs/heads/master/include/openssl/ssl.h#4081">
+     *     SSL_set_renegotiate_mode</a>..
+     * @param ssl the SSL instance (SSL *)
+     * @param mode  the mode.
+     * @throws Exception thrown if some error happens.
+     */
+    public static native void setRenegotiateMode(long ssl, int mode) throws Exception;
 }


### PR DESCRIPTION
Motivation:

renegiotion is not supported by BoringSSL by default but sometimes when using on the client-side you might want to support it for CLIENT-AUTH.
See also https://github.com/apple/swift-nio-ssl/pull/111

Modifications:

Add native / java code to be able to enable support

Result:

Part of https://github.com/netty/netty/issues/11529