### PR TITLE
Allow to set the curves used

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -461,6 +461,9 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 #ifdef OPENSSL_IS_BORINGSSL
 #define tcn_SSL_CTX_set1_curves_list(ctx, s) SSL_CTX_set1_curves_list(ctx, s)
 #else
+#ifndef SSL_CTRL_SET_GROUPS_LIST
+#define SSL_CTRL_SET_GROUPS_LIST                92
+#endif // SSL_CTRL_SET_GROUPS_LIST
 #define tcn_SSL_CTX_set1_curves_list(ctx, s) SSL_CTX_ctrl(ctx, SSL_CTRL_SET_GROUPS_LIST, 0, (char *)(s))
 #endif // OPENSSL_IS_BORINGSSL
 

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -456,7 +456,12 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 
     extern int SSL_get_sigalgs(SSL *s, int idx, int *psign, int *phash, int *psignhash, unsigned char *rsig, unsigned char *rhash) __attribute__((weak));
     extern void SSL_CTX_set_cert_cb(SSL_CTX *c, int (*cert_cb)(SSL *ssl, void *arg), void *arg) __attribute__((weak));
-    extern int SSL_CTX_set1_curves_list(SSL_CTX *ctx, char* curves) __attribute__((weak));
 #endif
+
+#ifdef OPENSSL_IS_BORINGSSL
+#define tcn_SSL_CTX_set1_curves_list(ctx, s) SSL_CTX_set1_curves_list(ctx, s)
+#else
+#define tcn_SSL_CTX_set1_curves_list(ctx, s) SSL_CTX_ctrl(ctx, SSL_CTRL_SET_GROUPS_LIST, 0, (char *)(s))
+#endif // OPENSSL_IS_BORINGSSL
 
 #endif /* SSL_PRIVATE_H */

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -456,6 +456,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 
     extern int SSL_get_sigalgs(SSL *s, int idx, int *psign, int *phash, int *psignhash, unsigned char *rsig, unsigned char *rhash) __attribute__((weak));
     extern void SSL_CTX_set_cert_cb(SSL_CTX *c, int (*cert_cb)(SSL *ssl, void *arg), void *arg) __attribute__((weak));
+    extern int SSL_CTX_set1_curves_list(SSL_CTX *ctx, char* curves) __attribute__((weak));
 #endif
 
 #endif /* SSL_PRIVATE_H */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2631,6 +2631,22 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setUseTasks)(TCN_STDARGS, jlong ctx, jboole
     c->use_tasks = useTasks == JNI_TRUE ? 1 : 0;
 }
 
+
+TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCurvesList0)(TCN_STDARGS, jlong ctx, jstring curves) {
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    TCN_CHECK_NULL(c, ctx, JNI_FALSE);
+
+    if (curves == NULL) {
+        return JNI_FALSE;
+    }
+    const char *nativeString = (*e)->GetStringUTFChars(e, curves, 0);
+    int ret = SSL_CTX_set1_curves_list(c->ctx, nativeString);
+    (*e)->ReleaseStringUTFChars(e, curves, nativeString);
+
+    return ret == 1 ? JNI_TRUE : JNI_FALSE;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(make, (II)J, SSLContext) },
@@ -2687,7 +2703,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(disableOcsp, (J)V, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(getSslCtx, (J)J, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(setUseTasks, (JZ)V, SSLContext) },
-  { TCN_METHOD_TABLE_ENTRY(setNumTickets, (JI)Z, SSLContext) }
+  { TCN_METHOD_TABLE_ENTRY(setNumTickets, (JI)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setCurvesList0, (JLjava/lang/String;)Z, SSLContext) }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2640,24 +2640,11 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCurvesList0)(TCN_STDARGS, jlong ctx,
     if (curves == NULL) {
         return JNI_FALSE;
     }
-
-// Only supported with GCC
-#if defined(__GNUC__) || defined(__GNUG__)
-    if (!SSL_CTX_set1_curves_list) {
-        return JNI_FALSE;
-    }
-#endif
-
-// We can only support it when either use openssl version >= 1.0.2 or GCC as this way we can use weak linking
-#if OPENSSL_VERSION_NUMBER >= 0x10102000L  || defined(__GNUC__) || defined(__GNUG__)
     const char *nativeString = (*e)->GetStringUTFChars(e, curves, 0);
-    int ret = SSL_CTX_set1_curves_list(c->ctx, nativeString);
+    int ret = tcn_SSL_CTX_set1_curves_list(c->ctx, nativeString);
     (*e)->ReleaseStringUTFChars(e, curves, nativeString);
 
     return ret == 1 ? JNI_TRUE : JNI_FALSE;
-#else
-    return JNI_FALSE;
-#endif
 }
 
 // JNI Method Registration Table Begin

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2640,11 +2640,24 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCurvesList0)(TCN_STDARGS, jlong ctx,
     if (curves == NULL) {
         return JNI_FALSE;
     }
+
+// Only supported with GCC
+#if defined(__GNUC__) || defined(__GNUG__)
+    if (!SSL_CTX_set1_curves_list) {
+        return JNI_FALSE;
+    }
+#endif
+
+// We can only support it when either use openssl version >= 1.0.2 or GCC as this way we can use weak linking
+#if OPENSSL_VERSION_NUMBER >= 0x10102000L  || defined(__GNUC__) || defined(__GNUG__)
     const char *nativeString = (*e)->GetStringUTFChars(e, curves, 0);
     int ret = SSL_CTX_set1_curves_list(c->ctx, nativeString);
     (*e)->ReleaseStringUTFChars(e, curves, nativeString);
 
     return ret == 1 ? JNI_TRUE : JNI_FALSE;
+#else
+    return JNI_FALSE;
+#endif
 }
 
 // JNI Method Registration Table Begin

--- a/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-dynamic/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -694,4 +694,31 @@ public final class SSLContext {
      * @return {@code true} if successful, {@code false} otherwise.
      */
     public static native boolean setNumTickets(long ctx, int tickets);
+
+    /**
+     * Sets the curves to use.
+     *
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set1_curves_list.html">SSL_CTX_set1_curves_list</a>.
+     * @param ctx context to use
+     * @param curves the curves to use.
+     * @return {@code true} if successful, {@code false} otherwise.
+     */
+    public static boolean setCurvesList(long ctx, String... curves) {
+        if (curves == null) {
+            throw new NullPointerException("curves");
+        }
+        if (curves.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String curve: curves) {
+            sb.append(curve);
+            // Curves are separated by : as explained in the manpage.
+            sb.append(':');
+        }
+        sb.setLength(sb.length() - 1);
+        return setCurvesList0(ctx, sb.toString());
+    }
+
+    private static native boolean setCurvesList0(long ctx, String curves);
 }


### PR DESCRIPTION
Motivation:

Sometimes it is useful to restrict the curves that are used.

Modifications:

Expose SSL_CTX_set1_curves_list via JNI

Result:

Be able to configure the curves that are used for a context