### PR TITLE
Add support for mac m1

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -1196,7 +1196,6 @@
                   <libDirectory>${nativeLibOnlyDir}</libDirectory>
                   <forceAutogen>${forceAutogen}</forceAutogen>
                   <forceConfigure>${forceConfigure}</forceConfigure>
-                  <windowsBuildTool>msbuild</windowsBuildTool>
                   <!-- <verbose>true</verbose> -->
                   <configureArgs>
                     <configureArg>--with-ssl=no</configureArg>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -733,6 +733,14 @@
                       <groupId>io.netty</groupId>
                       <artifactId>netty-tcnative-boringssl-static</artifactId>
                       <version>${project.version}</version>
+                      <classifier>osx-aarch_64</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${unpackDir}/osx-aarch_64</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>io.netty</groupId>
+                      <artifactId>netty-tcnative-boringssl-static</artifactId>
+                      <version>${project.version}</version>
                       <classifier>linux-${uberArch}</classifier>
                       <type>jar</type>
                       <outputDirectory>${unpackDir}/linux-${uberArch}</outputDirectory>
@@ -785,6 +793,9 @@
                       <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
+                      <fileset dir="${unpackDir}/osx-aarch_64/META-INF/native" />
+                    </copy>
+                    <copy todir="${nativeDir}" flatten="true">
                       <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
                     </copy>
                     <copy todir="${nativeDir}" flatten="true">
@@ -825,6 +836,7 @@
                     <Export-Package>io.netty.internal.tcnative.*</Export-Package>
                     <Bundle-NativeCode>
                       META-INF/native/libnetty_tcnative_osx_${uberArch}.jnilib;osname=macos;osname=macosx;processor=${uberArch},
+                      META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib;osname=macos;osname=macosx;processor=aarch_64,
                       META-INF/native/libnetty_tcnative_linux_${uberArch}.so;osname=linux;processor=${uberArch},
                       META-INF/native/libnetty_tcnative_linux_aarch_64.so;osname=linux;processor=aarch_64,
                       META-INF/native/netty_tcnative_windows_${uberArch}.dll;osname=win32;processor=${uberArch}
@@ -955,6 +967,248 @@
                       META-INF/native/netty_tcnative_windows_${uberArch}.dll;osname=win32;processor=${uberArch}
                     </Bundle-NativeCode>
                   </instructions>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- Profile to cross-compile for mac m1 -->
+    <profile>
+      <id>osx-m1-cross-compile</id>
+
+      <properties>
+        <linkStatic>true</linkStatic>
+        <osxCrossCompile>true</osxCrossCompile>
+        <macOsxDeploymentTarget/>
+        <cmakeOsxDeploymentTarget/>
+        <cflags>-target arm64-apple-macos11 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3</cflags>
+        <cppflags>-target arm64-apple-macos11 -DHAVE_OPENSSL -I${boringsslSourceDir}/include</cppflags>
+        <ldflags>-arch arm64 -L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-aarch_64.jar</nativeJarFile>
+        <nativeLibOsParts>${os.detected.name}_aarch_64</nativeLibOsParts>
+        <jniClassifier>${os.detected.name}-aarch_64</jniClassifier>
+        <jniArch>aarch_64</jniArch>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Download the BoringSSL source -->
+          <plugin>
+            <artifactId>maven-scm-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>get-boringssl</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>checkout</goal>
+                </goals>
+                <configuration>
+                  <checkoutDirectory>${boringsslSourceDir}</checkoutDirectory>
+                  <connectionType>developerConnection</connectionType>
+                  <developerConnectionUrl>scm:git:${boringsslRepository}</developerConnectionUrl>
+                  <scmVersion>${boringsslBranch}</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
+                  <skipCheckoutIfExists>true</skipCheckoutIfExists>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${generatedSourcesDir}/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Add the commit ID and branch to the manifest. -->
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+              <instructions>
+                <Apr-Version>${aprVersion}</Apr-Version>
+                <BoringSSL-Revision>${boringsslCommitSha}</BoringSSL-Revision>
+                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+              </instructions>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+
+              <!-- Only deploy to Maven Central if on centos (fedora). -->
+              <execution>
+                <id>skip-deploy</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="maven.deploy.skip" value="false" else="true">
+                      <isset property="os.detected.release.like.fedora" />
+                    </condition>
+                  </target>
+                </configuration>
+              </execution>
+
+              <!-- Build the BoringSSL static libs -->
+              <execution>
+                <id>build-boringssl</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                    <property environment="env" />
+                    <if>
+                      <available file="${boringsslHome}" />
+                      <then>
+                        <echo message="BoringSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Building BoringSSL" />
+
+                        <!-- Use the known SHA of the commit -->
+                        <exec executable="git" failonerror="true" dir="${boringsslSourceDir}" resolveexecutable="true">
+                          <arg value="checkout" />
+                          <arg value="${boringsslCommitSha}" />
+                        </exec>
+
+                        <mkdir dir="${boringsslHome}" />
+
+                        <!-- On *nix, add ASM flags to disable executable stack -->
+                        <property name="cmakeAsmFlags" value="-Wa,--noexecstack -target arm64-apple-macos11" />
+                        <!-- Use -DOPENSSL_C11_ATOMIC so we replace most of the locking code with atomics-->
+                        <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -target arm64-apple-macos11 -DOPENSSL_C11_ATOMIC" />
+                        <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -target arm64-apple-macos11 -Wno-error=range-loop-analysis" />
+
+                        <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="-DCMAKE_SYSTEM_PROCESSOR=arm64" />
+                          <arg value="-DCMAKE_OSX_ARCHITECTURES=arm64" />
+                          <arg value="${cmakeOsxDeploymentTarget}" />
+                          <arg value="-GNinja" />
+                          <arg value="${boringsslSourceDir}" />
+                        </exec>
+                        <if>
+                          <!-- may be called ninja-build or ninja -->
+                          <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                          <available file="ninja-build" filepath="${env.PATH}" />
+                          <then>
+                            <property name="ninjaExecutable" value="ninja-build" />
+                          </then>
+                          <else>
+                            <property name="ninjaExecutable" value="ninja" />
+                          </else>
+                        </if>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                    </copy>
+
+                    <!-- linux / osx -->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+                    <!-- windows-->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+
+                    <!-- Copy license material for attribution-->
+                    <copy file="../NOTICE.txt" todir="${nativeJarWorkdir}/META-INF/" />
+                    <copy file="../LICENSE.txt" todir="${nativeJarWorkdir}/META-INF/" />
+                    <copy todir="${nativeJarWorkdir}/META-INF/license">
+                      <fileset dir="../license" />
+                    </copy>
+
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Configure the distribution statically linked against OpenSSL and APR -->
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <name>netty_tcnative</name>
+                  <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
+                  <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
+                  <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                  <forceAutogen>${forceAutogen}</forceAutogen>
+                  <forceConfigure>${forceConfigure}</forceConfigure>
+                  <windowsBuildTool>msbuild</windowsBuildTool>
+                  <!-- <verbose>true</verbose> -->
+                  <configureArgs>
+                    <configureArg>--with-ssl=no</configureArg>
+                    <configureArg>--with-apr=${aprHome}</configureArg>
+                    <configureArg>--with-static-libs</configureArg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>--host=aarch64-apple-darwin</configureArg>
+                    <configureArg>${macOsxDeploymentTarget}</configureArg>
+                    <configureArg>CFLAGS=${cflags}</configureArg>
+                    <configureArg>CPPFLAGS=${cppflags}</configureArg>
+                    <configureArg>LDFLAGS=${ldflags}</configureArg>
+                  </configureArgs>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <aprPatchFileSha256>8754b8089d0eb53a7c4fd435c9a9300560b675a8ff2c32315a5e9303408447fe</aprPatchFileSha256>
     <archBits>64</archBits>
     <linkStatic>false</linkStatic>
+    <osxCrossCompile>false</osxCrossCompile>
     <sslHome>${project.build.directory}/ssl</sslHome>
     <msvcSslIncludeDirs>${sslHome}/include</msvcSslIncludeDirs>
     <msvcSslLibDirs>${sslHome}/lib</msvcSslLibDirs>
@@ -620,13 +621,42 @@
                           </then>
                         </if>
 
-                        <exec executable="configure" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
-                          <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ${macOsxDeploymentTarget}" />
-                        </exec>
-                        <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
-                        <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
-                          <arg line="install" />
-                        </exec>
+                        <if>
+                          <equals arg1="${osxCrossCompile}" arg2="true" />
+                          <then>
+                            <!--
++                             We need to set some extra variables as otherwise the configure of apr will fail when trying to cross-compile.
++                             See https://stackoverflow.com/a/1605497/1074097
++                           -->
+                            <exec executable="configure" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                              <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC -target arm64-apple-macos11' --host=aarch64-apple-darwin ${macOsxDeploymentTarget} ac_cv_file__dev_zero=yes apr_cv_process_shared_works=yes apr_cv_mutex_robust_shared=no apr_cv_tcp_nodelay_with_cork=yes ${macOsxDeploymentTarget}" />
+                            </exec>
+                            <!--
+                              Make will fail when it tries to use the gen_test_char program.
+                              We work around this by compile gen_test_char separate, execute and than rerun make.
+                              See https://stackoverflow.com/a/56262330/1074097
+                            -->
+                            <exec executable="make" failonerror="false" dir="${aprSourceDir}" resolveexecutable="true" />
+                            <exec executable="gcc" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                              <arg line="-Wall -O2 -DCROSS_COMPILE tools/gen_test_char.c -o tools/gen_test_char" />
+                            </exec>
+                            <exec executable="tools/gen_test_char" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" output="${aprSourceDir}/include/private/apr_escape_test_char.h"/>
+                            <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
+                            <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                              <arg line="install" />
+                            </exec>
+                          </then>
+                          <else>
+                            <exec executable="configure" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                              <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ${macOsxDeploymentTarget}" />
+                            </exec>
+                            <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
+                            <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                              <arg line="install" />
+                            </exec>
+                          </else>
+                        </if>
+
                       </else>
                     </if>
                   </target>

--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -26,6 +26,7 @@ git checkout "$2"
 export JAVA_HOME="$JAVA8_HOME"
 
 ./mvnw -Psonatype-oss-release -am -pl openssl-dynamic,boringssl-static clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
+./mvnw -Psonatype-oss-release,osx-m1-cross-compile -am -pl boringssl-static clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 ./mvnw -Psonatype-oss-release,uber-staging -pl boringssl-static clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 ./mvnw org.sonatype.plugins:nexus-staging-maven-plugin:rc-close org.sonatype.plugins:nexus-staging-maven-plugin:rc-release -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
 


### PR DESCRIPTION
Motivation:

We should support m1 as more and more users are switching to it.

Modifications:

- Add profile for boringssl-static to cross compile for m1
- Adjust finish release script to also include m1

Result:

Mac M1 is supported