### PR TITLE
Fix OSGI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,27 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+                <manifestEntries>
+                  <Automatic-Module-Name>io.netty.internal.tcnative</Automatic-Module-Name>
+                </manifestEntries>
+                <index>true</index>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Override the parent POM's configuration -->
       <plugin>
         <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Motivation:

ef6dd68503eaefdad800a7b905a1ad21a7e1408f did break OSGI support as we did not correctly include the generated MANIFEST

Modifications:

Fix configuration of plugins to include the correct MANIFEST file which has all the entries for OSGI

Result:

Fixes https://github.com/netty/netty-tcnative/issues/657