### PR TITLE
Use -DOPENSSL_C11_ATOMIC when cross-compile for linux aarch64

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -528,7 +528,8 @@
                             <then>
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer" />
+                              <!-- Use -DOPENSSL_C11_ATOMIC so we replace most of the locking code with atomics-->
+                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -DOPENSSL_C11_ATOMIC" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
                               <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                             </then>


### PR DESCRIPTION
Motivation:

Using -DOPENSSL_C11_ATOMIC brings a big performance boost. We should use it

Modifications:

- Add -DOPENSSL_C11_ATOMIC when compiling BoringSSL for linux aarch64

Result:

Less locking overhead on linux aarch64