### PR TITLE
Use https to download apr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
                         <echo message="Downloading APR" />
 
                         <property name="aprArchiveFile" value="apr-${aprVersion}-win32-src.zip" />
-                        <get src="http://archive.apache.org/dist/apr/${aprArchiveFile}" dest="${project.build.directory}/${aprArchiveFile}" verbose="on" />
+                        <get src="https://archive.apache.org/dist/apr/${aprArchiveFile}" dest="${project.build.directory}/${aprArchiveFile}" verbose="on" />
                         <unzip src="${project.build.directory}/${aprArchiveFile}" dest="${project.build.directory}" />
                         <condition property="windowsRelease" value="Win32 Release" else="x64 Release">
                           <equals arg1="${archBits}" arg2="32" />
@@ -590,7 +590,7 @@
 
                         <property name="aprTarGzFile" value="apr-${aprVersion}.tar.gz" />
                         <property name="aprTarFile" value="apr-${aprVersion}.tar" />
-                        <get src="http://archive.apache.org/dist/apr/${aprTarGzFile}" dest="${project.build.directory}/${aprTarGzFile}" verbose="on" />
+                        <get src="https://archive.apache.org/dist/apr/${aprTarGzFile}" dest="${project.build.directory}/${aprTarGzFile}" verbose="on" />
                         <checksum file="${project.build.directory}/${aprTarGzFile}" algorithm="SHA-256" property="${aprSha256}" verifyProperty="isEqual" />
                         <gunzip src="${project.build.directory}/${aprTarGzFile}" dest="${project.build.directory}" />
                         <!-- Use the tar command (rather than the untar ant task) in order to preserve file permissions. -->


### PR DESCRIPTION
Motivation:

We should use https to download dependencies.

Modifications:

Switch to https when downloading apr

Result:

Fixes https://github.com/netty/netty-tcnative/issues/667