### PR TITLE
Only include Bundle-NativeCode in MANIFEST if native code is included

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -294,6 +294,12 @@
                       <fileset dir="../license" />
                     </copy>
 
+
+                    <!-- Append the Bundle-NativeCode section -->
+                    <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                      <attribute name="Bundle-NativeCode" value="${tcnativeManifest}"/>
+                    </manifest>
+
                     <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                     <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
                   </target>
@@ -622,6 +628,11 @@
                     <copy todir="${nativeJarWorkdir}/META-INF/license">
                       <fileset dir="../license" />
                     </copy>
+
+                    <!-- Append the Bundle-NativeCode section -->
+                    <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                      <attribute name="Bundle-NativeCode" value="${tcnativeManifest}"/>
+                    </manifest>
 
                     <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                     <attachartifact file="${nativeJarFile}" classifier="${os.detected.name}-aarch_64" type="jar" />
@@ -1170,6 +1181,11 @@
                     <copy todir="${nativeJarWorkdir}/META-INF/license">
                       <fileset dir="../license" />
                     </copy>
+
+                    <!-- Append the Bundle-NativeCode section -->
+                    <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                      <attribute name="Bundle-NativeCode" value="${tcnativeManifest}"/>
+                    </manifest>
 
                     <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                     <attachartifact file="${nativeJarFile}" classifier="${os.detected.name}-aarch_64" type="jar" />

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -125,7 +125,12 @@
                   <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
                   <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
                 </move>
-                 
+
+                <!-- Append the Bundle-NativeCode section -->
+                <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                  <attribute name="Bundle-NativeCode" value="${tcnativeManifest}"/>
+                </manifest>
+
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                 <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
                 <condition property="classifier" value="${jniClassifier}-fedora">

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -90,7 +90,12 @@
                   <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
                   <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
                 </move>
-                 
+
+                <!-- Append the Bundle-NativeCode section -->
+                <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                  <attribute name="Bundle-NativeCode" value="${tcnativeManifest}"/>
+                </manifest>
+
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                 <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
                 <condition property="classifier" value="${jniClassifier}-fedora">

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -122,7 +122,12 @@
                   <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
                   <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
                 </move>
-                 
+
+                <!-- Append the Bundle-NativeCode section -->
+                <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                  <attribute name="Bundle-NativeCode" value="${tcnativeManifest}"/>
+                </manifest>
+
                 <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
                 <!-- Adjust the classifier used for different OS distributions which provide differently-built openSSL libraries -->
                 <condition property="classifier" value="${jniClassifier}-fedora">

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,6 @@
               </supportedProjectTypes>
               <instructions>
                 <Export-Package>io.netty.internal.tcnative.*</Export-Package>
-                <Bundle-NativeCode>${tcnativeManifest}</Bundle-NativeCode>
               </instructions>
             </configuration>
           </execution>


### PR DESCRIPTION
Motivation:

At the moment we even include the Bundle-NativeCode in the MANIFEST for th jars without classifier. This result in OSGI errors when depend on these.

Modifications:

Only add the Bundle-NativeCode when we actual include a native lib in the jar

Result:

Be able to use jars without classifiers with OSGI