### PR TITLE
Remove caching in docker image

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -87,7 +87,6 @@ COPY ./boringssl-static/pom.xml $PROJECT_DIR/boringssl-static/pom.xml
 COPY ./libressl-static/pom.xml $PROJECT_DIR/libressl-static/pom.xml
 COPY ./openssl-dynamic/pom.xml $PROJECT_DIR/openssl-dynamic/pom.xml
 COPY ./openssl-static/pom.xml $PROJECT_DIR/openssl-static/pom.xml
-COPY ./openssl-classes/pom.xml $PROJECT_DIR/openssl-classes/pom.xml
 COPY ./pom.xml $PROJECT_DIR/pom.xml
 
 # Pre-build apr

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -87,10 +87,8 @@ COPY ./boringssl-static/pom.xml $PROJECT_DIR/boringssl-static/pom.xml
 COPY ./libressl-static/pom.xml $PROJECT_DIR/libressl-static/pom.xml
 COPY ./openssl-dynamic/pom.xml $PROJECT_DIR/openssl-dynamic/pom.xml
 COPY ./openssl-static/pom.xml $PROJECT_DIR/openssl-static/pom.xml
+COPY ./openssl-classes/pom.xml $PROJECT_DIR/openssl-classes/pom.xml
 COPY ./pom.xml $PROJECT_DIR/pom.xml
-
-# Download dependencies
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline checkstyle:check animal-sniffer:check surefire:test -ntp'
 
 # Pre-build apr
 RUN /bin/bash -c 'source $HOME/.bashrc && mvn antrun:run@source-apr-linux-mac antrun:run@build-apr-linux-mac -DaprSourceDir=$WORKSPACE_DIR/apr-source -DaprHome=$WORKSPACE_DIR/apr -DlinkStatic=true'

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -82,7 +82,6 @@ COPY ./boringssl-static/pom.xml $PROJECT_DIR/boringssl-static/pom.xml
 COPY ./libressl-static/pom.xml $PROJECT_DIR/libressl-static/pom.xml
 COPY ./openssl-dynamic/pom.xml $PROJECT_DIR/openssl-dynamic/pom.xml
 COPY ./openssl-static/pom.xml $PROJECT_DIR/openssl-static/pom.xml
-COPY ./openssl-classes/pom.xml $PROJECT_DIR/openssl-classes/pom.xml
 COPY ./pom.xml $PROJECT_DIR/pom.xml
 
 # Pre-build boringssl

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -82,10 +82,8 @@ COPY ./boringssl-static/pom.xml $PROJECT_DIR/boringssl-static/pom.xml
 COPY ./libressl-static/pom.xml $PROJECT_DIR/libressl-static/pom.xml
 COPY ./openssl-dynamic/pom.xml $PROJECT_DIR/openssl-dynamic/pom.xml
 COPY ./openssl-static/pom.xml $PROJECT_DIR/openssl-static/pom.xml
+COPY ./openssl-classes/pom.xml $PROJECT_DIR/openssl-classes/pom.xml
 COPY ./pom.xml $PROJECT_DIR/pom.xml
-
-# Download dependencies
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline checkstyle:check animal-sniffer:check surefire:test -ntp'
 
 # Pre-build boringssl
 RUN /bin/bash -c 'source $HOME/.bashrc && mvn -Plinux-aarch64 -pl boringssl-static scm:checkout@get-boringssl antrun:run@build-boringssl -DboringsslSourceDir=$WORKSPACE_DIR/boringssl-source -DboringsslHome=$WORKSPACE_DIR/boringssl -DlinkStatic=true'

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -85,7 +85,5 @@ COPY ./boringssl-static/pom.xml $PROJECT_DIR/boringssl-static/pom.xml
 COPY ./libressl-static/pom.xml $PROJECT_DIR/libressl-static/pom.xml
 COPY ./openssl-dynamic/pom.xml $PROJECT_DIR/openssl-dynamic/pom.xml
 COPY ./openssl-static/pom.xml $PROJECT_DIR/openssl-static/pom.xml
+COPY ./openssl-classes/pom.xml $PROJECT_DIR/openssl-classes/pom.xml
 COPY ./pom.xml $PROJECT_DIR/pom.xml
-
-# Download dependencies
-RUN /bin/bash -c 'source $HOME/.bashrc && mvn dependency:go-offline checkstyle:check animal-sniffer:check surefire:test -ntp'

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -79,11 +79,3 @@ ENV JAVA_HOME /jdk/
 RUN mkdir $WORKSPACE_DIR
 RUN mkdir $PROJECT_DIR
 WORKDIR $PROJECT_DIR
-
-# Copy all the pom.xml files so we can download dependencies etc.
-COPY ./boringssl-static/pom.xml $PROJECT_DIR/boringssl-static/pom.xml
-COPY ./libressl-static/pom.xml $PROJECT_DIR/libressl-static/pom.xml
-COPY ./openssl-dynamic/pom.xml $PROJECT_DIR/openssl-dynamic/pom.xml
-COPY ./openssl-static/pom.xml $PROJECT_DIR/openssl-static/pom.xml
-COPY ./openssl-classes/pom.xml $PROJECT_DIR/openssl-classes/pom.xml
-COPY ./pom.xml $PROJECT_DIR/pom.xml


### PR DESCRIPTION
Motivation:

We use the github cache to caching, there is no need to cache in the docker image as well

Modifications:

Remove caching in docker image

Result:

Cleanup