### PR TITLE
Include license distribution in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,14 @@
     <tag>HEAD</tag>
   </scm>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <properties>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <checkstyle.skip>true</checkstyle.skip>


### PR DESCRIPTION
The library missing license information in maven central triggers failures for those running `maven-license-plugin` to verify licenses.