### PR TITLE
Specify -Wno-deprecated-declarations when compiling

### DIFF
--- a/openssl-dynamic/src/main/native-package/configure.ac
+++ b/openssl-dynamic/src/main/native-package/configure.ac
@@ -28,7 +28,7 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CANONICAL_HOST
 AC_CANONICAL_SYSTEM
 
-${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value"}
+${CFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -Wno-deprecated-declarations"}
 ${CXXFLAGS="-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value"}
 
 ## -----------------------------------------------


### PR DESCRIPTION
Motivation:

We need to use -Wno-deprecated-declarations on newer macOS versions as otherwise the build will fail

Modifications:

Add  -Wno-deprecated-declarations

Result:

Be able to build on latest macOs