### PR TITLE
Skip japicmp check for non released modules

### DIFF
--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -38,6 +38,7 @@
     <compileLibrary>true</compileLibrary>
     <!-- Don't deploy this artifact to Maven Central -->
     <maven.deploy.skip>true</maven.deploy.skip>
+    <skipJapicmp>true</skipJapicmp>
   </properties>
 
   <build>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -37,6 +37,7 @@
     <compileLibrary>true</compileLibrary>
     <!-- Don't deploy this artifact to Maven Central -->
     <maven.deploy.skip>true</maven.deploy.skip>
+    <skipJapicmp>true</skipJapicmp>
   </properties>
 
   <build>


### PR DESCRIPTION
Motivation:

We need to skip the javacmp check for modules that are not released.

Modifications:

Define the property to true

Result:

No more build failures. See https://github.com/netty/netty-tcnative/issues/686