### PR TITLE
Support RFC 8879 Certificate Compression for TLSv1.3 (#614)

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/CertificateCompressionAlgo.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/CertificateCompressionAlgo.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Provides compression/decompression implementations for TLS Certificate Compression
+ * (<a href="https://tools.ietf.org/html/rfc8879">RFC 8879</a>).
+ */
+public interface CertificateCompressionAlgo {
+    int TLS_EXT_CERT_COMPRESSION_ZLIB   = NativeStaticallyReferencedJniMethods.tlsExtCertCompressionZlib();
+    int TLS_EXT_CERT_COMPRESSION_BROTLI = NativeStaticallyReferencedJniMethods.tlsExtCertCompressionBrotli();
+    int TLS_EXT_CERT_COMPRESSION_ZSTD   = NativeStaticallyReferencedJniMethods.tlsExtCertCompressionZstd();
+
+    /**
+     * Compress the given input with the specified algorithm and return the compressed bytes.
+     *
+     * @param ssl           the SSL instance
+     * @param input         the uncompressed form of the certificate
+     * @return              the compressed form of the certificate
+     * @throws Exception    thrown if an error occurs while compressing
+     */
+    byte[] compress(long ssl, byte[] input) throws Exception;
+
+    /**
+     * Decompress the given input with the specified algorithm and return the decompressed bytes.
+     *
+     * <h3>Implementation
+     * <a href="https://tools.ietf.org/html/rfc8879#section-5">Security Considerations</a></h3>
+     * <p>Implementations SHOULD bound the memory usage when decompressing the CompressedCertificate message.</p>
+     * <p>
+     * Implementations MUST limit the size of the resulting decompressed chain to the specified {@code uncompressedLen},
+     * and they MUST abort the connection (throw an exception) if the size of the output of the decompression
+     * function exceeds that limit.
+     * </p>
+     *
+     * @param ssl               the SSL instance
+     * @param uncompressedLen   the expected length of the uncompressed certificate
+     * @param input             the compressed form of the certificate
+     * @return                  the decompressed form of the certificate
+     * @throws Exception        thrown if an error occurs while decompressing or output
+     * size exceeds {@code uncompressedLen}
+     */
+    byte[] decompress(long ssl, int uncompressedLen, byte[] input) throws Exception;
+
+    /**
+     * Return the ID for the compression algorithm provided for by a given implementation.
+     *
+     * @return compression algorithm ID as specified by RFC8879
+     * <PRE>
+     * {@link CertificateCompressionAlgo#TLS_EXT_CERT_COMPRESSION_ZLIB}
+     * {@link CertificateCompressionAlgo#TLS_EXT_CERT_COMPRESSION_BROTLI}
+     * {@link CertificateCompressionAlgo#TLS_EXT_CERT_COMPRESSION_ZSTD}
+     * </PRE>
+     */
+    int algorithmId();
+
+}

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -172,4 +172,10 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslRenegotiateFreely();
     static native int sslRenegotiateIgnore();
     static native int sslRenegotiateExplicit();
+    static native int sslCertCompressionDirectionCompress();
+    static native int sslCertCompressionDirectionDecompress();
+    static native int sslCertCompressionDirectionBoth();
+    static native int tlsExtCertCompressionZlib();
+    static native int tlsExtCertCompressionBrotli();
+    static native int tlsExtCertCompressionZstd();
 }

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -116,6 +116,10 @@ public final class SSL {
     public static final int SSL_RENEGOTIATE_IGNORE = sslRenegotiateIgnore();
     public static final int SSL_RENEGOTIATE_EXPLICIT = sslRenegotiateExplicit();
 
+    public static final int SSL_CERT_COMPRESSION_DIRECTION_COMPRESS = sslCertCompressionDirectionCompress();
+    public static final int SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS = sslCertCompressionDirectionDecompress();
+    public static final int SSL_CERT_COMPRESSION_DIRECTION_BOTH = sslCertCompressionDirectionBoth();
+
     /* Return OpenSSL version number */
     public static native int version();
 

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -649,6 +649,35 @@ public final class SSLContext {
     public static native void setUseTasks(long ctx, boolean useTasks);
 
     /**
+     * Adds a certificate compression algorithm to the given {@link SSLContext} or throws an
+     * exception if certificate compression is not supported or the algorithm not recognized.
+     * For servers, algorithm preference order is dictated by the order of algorithm registration.
+     * Most preferred algorithm should be registered first.
+     *
+     * This method is currently only supported when {@code BoringSSL} is used.
+     *
+     * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Certificate-compression">
+     *     SSL_CTX_add_cert_compression_alg</a>
+     * <a href="https://www.ietf.org/rfc/rfc8879.txt">rfc8879</a>
+     *
+     * @param ctx       context, to which, the algorithm should be added.
+     * @param direction indicates whether decompression support should be advertized, compression should be applied for
+     *                  peers which support it, or both. This allows the caller to support one way compression only.
+     * <PRE>
+     * {@link SSL#SSL_CERT_COMPRESSION_DIRECTION_COMPRESS}
+     * {@link SSL#SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS}
+     * {@link SSL#SSL_CERT_COMPRESSION_DIRECTION_BOTH}
+     * </PRE>
+     * @param algorithm implementation of the compression and or decompression algorithm as a {@link CertificateCompressionAlgo}
+     * @return one on success or zero on error
+     */
+    public static int addCertificateCompressionAlgorithm(long ctx, int direction, final CertificateCompressionAlgo algorithm) {
+        return addCertificateCompressionAlgorithm0(ctx, direction, algorithm.algorithmId(), algorithm);
+    }
+
+    private static native int addCertificateCompressionAlgorithm0(long ctx, int direction, int algorithmId, final CertificateCompressionAlgo algorithm);
+
+    /**
      * Set the {@link SSLPrivateKeyMethod} to use for the given {@link SSLContext}.
      * This allows to offload private key operations
      * if needed.

--- a/openssl-dynamic/src/main/c/cert_compress.c
+++ b/openssl-dynamic/src/main/c/cert_compress.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "tcn.h"
+#include "ssl_private.h"
+#ifdef OPENSSL_IS_BORINGSSL
+#include "cert_compress.h"
+
+static int compress(jobject compression_algorithm, jmethodID compress_method, SSL* ssl, CBB* out,
+    const uint8_t* in, size_t in_len) {
+
+    int ret = 0;
+    JNIEnv *e = NULL;
+    jbyteArray inputArray = NULL;
+
+    if (compression_algorithm == NULL || compress_method == NULL) {
+        goto complete;
+    }
+    if (tcn_get_java_env(&e) != JNI_OK) {
+        goto complete;
+    }
+    if ((inputArray = (*e)->NewByteArray(e, in_len)) == NULL) {
+        goto complete;
+    }
+
+    (*e)->SetByteArrayRegion(e, inputArray, 0, in_len, (jbyte*) in);
+
+    jbyteArray resultArray = (*e)->CallObjectMethod(e, compression_algorithm, compress_method,
+                    P2J(ssl), inputArray);
+
+    if ((*e)->ExceptionCheck(e) != JNI_FALSE) {
+        (*e)->ExceptionClear(e);
+        goto complete; // Exception while calling into Java
+    }
+    if (resultArray == NULL) {
+        goto complete; // Received NULL array from call to Java
+    }
+
+    int resultLen = (*e)->GetArrayLength(e, resultArray);
+    uint8_t* outData = NULL;
+    if (!CBB_reserve(out, &outData, resultLen)) {
+        goto complete; // Unable to reserve space for compressed data
+    }
+    jbyte* resultData = (*e)->GetByteArrayElements(e, resultArray, NULL);
+    memcpy(outData, resultData, resultLen);
+    if (!CBB_did_write(out, resultLen)) {
+        goto complete; // Unable to advance bytes written to CBB
+    }
+    (*e)->ReleaseByteArrayElements(e, resultArray, resultData, JNI_ABORT);
+    ret = 1; // Success
+    goto complete;
+
+complete:
+    // Free up any allocated memory and return.
+    if (inputArray != NULL) {
+        (*e)->DeleteLocalRef(e, inputArray);
+    }
+    return ret;
+}
+
+static int decompress(jobject compression_algorithm, jmethodID decompress_method, SSL* ssl, CRYPTO_BUFFER** out,
+    size_t uncompressed_len, const uint8_t* in, size_t in_len) {
+
+    int ret = 0;
+    JNIEnv* e = NULL;
+    jbyteArray inputArray = NULL;
+
+    if (compression_algorithm == NULL || decompress_method == NULL) {
+        goto complete;
+    }
+    if (tcn_get_java_env(&e) != JNI_OK) {
+        goto complete;
+    }
+    if ((inputArray = (*e)->NewByteArray(e, in_len)) == NULL) {
+        goto complete;
+    }
+
+    (*e)->SetByteArrayRegion(e, inputArray, 0, in_len, (jbyte*) in);
+
+    // BoringSSL checks that `uncompressed_len <= ssl->max_cert_list` before calling `ssl_cert_decompression_func_t`
+    // `max_cert_list` contains the max cert size, avoiding excessive allocations.
+    jbyteArray resultArray = (*e)->CallObjectMethod(e, compression_algorithm, decompress_method,
+                    P2J(ssl), uncompressed_len, inputArray);
+
+    if ((*e)->ExceptionCheck(e) != JNI_FALSE) {
+        (*e)->ExceptionClear(e);
+        goto complete; // Exception while calling into Java
+    }
+    if (resultArray == NULL) {
+        goto complete; // Received NULL array from call to Java
+    }
+
+    int resultLen = (*e)->GetArrayLength(e, resultArray);
+    if (uncompressed_len != resultLen) {
+        goto complete; // Unexpected uncompressed length
+    }
+    uint8_t* outData;
+    if (!((*out) = CRYPTO_BUFFER_alloc(&outData, uncompressed_len))) {
+        goto complete; // Unable to allocate certificate decompression buffer
+    }
+    jbyte* resultData = (*e)->GetByteArrayElements(e, resultArray, NULL);
+    memcpy(outData, resultData, uncompressed_len);
+    (*e)->ReleaseByteArrayElements(e, resultArray, resultData, JNI_ABORT);
+    ret = 1; // Success
+
+complete:
+    // Free up any allocated memory and return.
+    if (inputArray != NULL) {
+        (*e)->DeleteLocalRef(e, inputArray);
+    }
+    return ret;
+
+}
+
+int zlib_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len)
+{
+    tcn_ssl_ctxt_t* c = NULL;
+    TCN_GET_SSL_CTX(ssl, c);
+    TCN_ASSERT(c != NULL);
+    return compress(c->ssl_cert_compression_zlib_algorithm, c->ssl_cert_compression_zlib_compress_method,
+        ssl, out, in, in_len);
+}
+
+int zlib_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len)
+{
+    tcn_ssl_ctxt_t* c = NULL;
+    TCN_GET_SSL_CTX(ssl, c);
+    TCN_ASSERT(c != NULL);
+    return decompress(c->ssl_cert_compression_zlib_algorithm, c->ssl_cert_compression_zlib_decompress_method,
+        ssl, out, uncompressed_len, in, in_len);
+}
+
+int brotli_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len)
+{
+    tcn_ssl_ctxt_t* c = NULL;
+    TCN_GET_SSL_CTX(ssl, c);
+    TCN_ASSERT(c != NULL);
+    return compress(c->ssl_cert_compression_brotli_algorithm, c->ssl_cert_compression_brotli_compress_method,
+        ssl, out, in, in_len);
+}
+
+int brotli_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len)
+{
+    tcn_ssl_ctxt_t* c = NULL;
+    TCN_GET_SSL_CTX(ssl, c);
+    TCN_ASSERT(c != NULL);
+    return decompress(c->ssl_cert_compression_brotli_algorithm, c->ssl_cert_compression_brotli_decompress_method,
+        ssl, out, uncompressed_len, in, in_len);
+}
+
+int zstd_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len)
+{
+    tcn_ssl_ctxt_t* c = NULL;
+    TCN_GET_SSL_CTX(ssl, c);
+    TCN_ASSERT(c != NULL);
+    return compress(c->ssl_cert_compression_zstd_algorithm, c->ssl_cert_compression_zstd_compress_method,
+        ssl, out, in, in_len);
+}
+
+int zstd_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len)
+{
+    tcn_ssl_ctxt_t* c = NULL;
+    TCN_GET_SSL_CTX(ssl, c);
+    TCN_ASSERT(c != NULL);
+    return decompress(c->ssl_cert_compression_zstd_algorithm, c->ssl_cert_compression_zstd_decompress_method,
+        ssl, out, uncompressed_len, in, in_len);
+}
+
+#endif // OPENSSL_IS_BORINGSSL

--- a/openssl-dynamic/src/main/c/cert_compress.h
+++ b/openssl-dynamic/src/main/c/cert_compress.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NETTY_TCNATIVE_CERT_COMPRESS_H_
+#define NETTY_TCNATIVE_CERT_COMPRESS_H_
+
+#ifdef OPENSSL_IS_BORINGSSL
+
+int zlib_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len);
+int zlib_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len);
+
+int brotli_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len);
+int brotli_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len);
+
+int zstd_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len);
+int zstd_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len);
+
+#endif // OPENSSL_IS_BORINGSSL
+
+#endif /* NETTY_TCNATIVE_CERT_COMPRESS_H_ */

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -600,6 +600,30 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateExp
 #endif
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslCertCompressionDirectionCompress)(TCN_STDARGS) {
+    return SSL_CERT_COMPRESSION_DIRECTION_COMPRESS;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslCertCompressionDirectionDecompress)(TCN_STDARGS) {
+    return SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslCertCompressionDirectionBoth)(TCN_STDARGS) {
+    return SSL_CERT_COMPRESSION_DIRECTION_BOTH;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, tlsExtCertCompressionZlib)(TCN_STDARGS) {
+    return TLSEXT_cert_compression_zlib;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, tlsExtCertCompressionBrotli)(TCN_STDARGS) {
+    return TLSEXT_cert_compression_brotli;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, tlsExtCertCompressionZstd)(TCN_STDARGS) {
+    return TLSEXT_cert_compression_zstd;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpCipherServerPreference, ()I, NativeStaticallyReferencedJniMethods) },
@@ -725,8 +749,13 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslRenegotiateOnce, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslRenegotiateFreely, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslRenegotiateIgnore, ()I, NativeStaticallyReferencedJniMethods) },
-  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateExplicit, ()I, NativeStaticallyReferencedJniMethods) }
-
+  { TCN_METHOD_TABLE_ENTRY(sslRenegotiateExplicit, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslCertCompressionDirectionCompress, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslCertCompressionDirectionDecompress, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslCertCompressionDirectionBoth, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionZlib, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionBrotli, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionZstd, ()I, NativeStaticallyReferencedJniMethods) }
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -170,6 +170,10 @@ extern const char* TCN_UNKNOWN_AUTH_METHOD;
 #define SSL_SESSION_TICKET_HMAC_KEY_LEN 16
 #define SSL_SESSION_TICKET_KEY_SIZE     48
 
+#define SSL_CERT_COMPRESSION_DIRECTION_COMPRESS     0x01
+#define SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS   0x02
+#define SSL_CERT_COMPRESSION_DIRECTION_BOTH         0x03
+
 extern void *SSL_temp_keys[SSL_TMP_KEY_MAX];
 
 // HACK!
@@ -267,6 +271,21 @@ extern void *SSL_temp_keys[SSL_TMP_KEY_MAX];
 #define SSL_ERROR_WANT_CERTIFICATE_VERIFY       -1
 #endif
 
+#ifndef TLSEXT_cert_compression_zlib
+// See https://datatracker.ietf.org/doc/html/rfc8879#section-3
+#define TLSEXT_cert_compression_zlib            1
+#endif
+
+#ifndef TLSEXT_cert_compression_brotli
+// See https://datatracker.ietf.org/doc/html/rfc8879#section-3
+#define TLSEXT_cert_compression_brotli          2
+#endif
+
+#ifndef TLSEXT_cert_compression_zstd
+// See https://datatracker.ietf.org/doc/html/rfc8879#section-3
+#define TLSEXT_cert_compression_zstd            3
+#endif
+
 typedef struct tcn_ssl_ctxt_t tcn_ssl_ctxt_t;
 
 typedef struct {
@@ -319,6 +338,18 @@ struct tcn_ssl_ctxt_t {
     jobject                  ssl_private_key_method;
     jmethodID                ssl_private_key_sign_method;
     jmethodID                ssl_private_key_decrypt_method;
+
+    jobject                  ssl_cert_compression_zlib_algorithm;
+    jmethodID                ssl_cert_compression_zlib_compress_method;
+    jmethodID                ssl_cert_compression_zlib_decompress_method;
+
+    jobject                  ssl_cert_compression_brotli_algorithm;
+    jmethodID                ssl_cert_compression_brotli_compress_method;
+    jmethodID                ssl_cert_compression_brotli_decompress_method;
+
+    jobject                  ssl_cert_compression_zstd_algorithm;
+    jmethodID                ssl_cert_compression_zstd_compress_method;
+    jmethodID                ssl_cert_compression_zstd_decompress_method;
 #endif // OPENSSL_IS_BORINGSSL
 
     tcn_ssl_verify_config_t  verify_config;


### PR DESCRIPTION
Motivation:

Certificates in TLSv1.3 can be compressed but Netty does not yet support this. BoringSSL does support it and this change will use that support to provide an API which Netty can use to support certificate compression.

Modifications:

- `CertificateCompressionAlgo.java` class to allow compression implementations to be built in Java.
- Native `addCertificateCompressionAlgorithm0` which allows registration of compression algorithms with BoringSSL.
- JNI work to maintain Java compression algorithm callbacks and call them when BoringSSL needs a certificate compressed or decompressed.

Result:

New API, which Netty can use to provide support for certificate compression.