### PR TITLE
Added Fragment-Host declaration to bundles shipping native libs

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -39,6 +39,7 @@
             <archive>
               <manifestEntries>
                 <Automatic-Module-Name>io.netty.tcnative.boringssl</Automatic-Module-Name>
+                <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>
           </configuration>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -51,6 +51,7 @@
             <archive>
               <manifestEntries>
                 <Automatic-Module-Name>io.netty.tcnative.libressl</Automatic-Module-Name>
+                <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>
           </configuration>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -47,6 +47,7 @@
             <archive>
               <manifestEntries>
                 <Automatic-Module-Name>io.netty.tcnative.openssl.dynamic</Automatic-Module-Name>
+                <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>
           </configuration>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -50,6 +50,7 @@
             <archive>
               <manifestEntries>
                 <Automatic-Module-Name>io.netty.tcnative.openssl</Automatic-Module-Name>
+                <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>
           </configuration>


### PR DESCRIPTION
Motivation:

We need to add a Fragment-Host entry to the manifest for the jars that contain the native libs so its possible to use these in OSGI.

Modifications:

Add Fragment-Host entry to manifest.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/683