### PR TITLE
Don't repackage jar for uber profile

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -709,9 +709,7 @@
       <id>uber-staging</id>
 
       <properties>
-        <unpackDir>${project.build.directory}/unpack</unpackDir>
-        <libDir>${project.build.directory}/lib</libDir>
-        <nativeDir>${project.build.outputDirectory}/META-INF/native</nativeDir>
+        <maven.main.skip>true</maven.main.skip>
         <skipTests>true</skipTests>
         <!--
           As we just re-package we don't want to do any extra steps that are needed for static compilation or
@@ -719,7 +717,6 @@
         -->
         <linkStatic>false</linkStatic>
         <compileLibrary>false</compileLibrary>
-        <uberArch>${os.detected.arch}</uberArch>
       </properties>
 
       <repositories>
@@ -730,155 +727,44 @@
         </repository>
       </repositories>
 
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <configuration combine.self="override">
-                  <artifactItems>
-                    <!-- Unpack just the native libraries -->
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>osx-${uberArch}</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/osx-${uberArch}</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>osx-aarch_64</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/osx-aarch_64</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>linux-${uberArch}</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/linux-${uberArch}</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>linux-aarch_64</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/linux-aarch_64</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>windows-${uberArch}</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/windows-${uberArch}</outputDirectory>
-                    </artifactItem>
-
-                    <!-- Now unpack all of the Java classes and the original MANIFEST.MF -->
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <type>jar</type>
-                      <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                      <includes>**/*.class,**/MANIFEST.MF</includes>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-jni-libs</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target name="copy-jni-libs">
-                    <mkdir dir="${nativeDir}" />
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                    </copy>
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/osx-aarch_64/META-INF/native" />
-                    </copy>
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                    </copy>
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/linux-aarch_64/META-INF/native" />
-                    </copy>
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/windows-${uberArch}/META-INF/native" />
-                    </copy>
-
-                     <!-- Copy license material for attribution-->
-                    <copy file="../NOTICE.txt" todir="${project.build.outputDirectory}/META-INF/" />
-                    <copy file="../LICENSE.txt" todir="${project.build.outputDirectory}/META-INF/" />
-                    <copy todir="${project.build.outputDirectory}/META-INF/license">
-                      <fileset dir="../license" />
-                    </copy>
-
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>maven-bundle-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate-manifest</id>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>manifest</goal>
-                </goals>
-                <configuration>
-                  <supportedProjectTypes>
-                    <supportedProjectType>jar</supportedProjectType>
-                  </supportedProjectTypes>
-                  <instructions>
-                    <Export-Package>io.netty.internal.tcnative.*</Export-Package>
-                    <Bundle-NativeCode>
-                      META-INF/native/libnetty_tcnative_osx_${uberArch}.jnilib;osname=macos;osname=macosx;processor=${uberArch},
-                      META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib;osname=macos;osname=macosx;processor=aarch_64,
-                      META-INF/native/libnetty_tcnative_linux_${uberArch}.so;osname=linux;processor=${uberArch},
-                      META-INF/native/libnetty_tcnative_linux_aarch_64.so;osname=linux;processor=aarch_64,
-                      META-INF/native/netty_tcnative_windows_${uberArch}.dll;osname=win32;processor=${uberArch}
-                    </Bundle-NativeCode>
-                  </instructions>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-x86_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-aarch_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>windows-x86_64</classifier>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>uber-snapshot</id>
 
       <properties>
-        <unpackDir>${project.build.directory}/unpack</unpackDir>
-        <libDir>${project.build.directory}/lib</libDir>
-        <nativeDir>${project.build.outputDirectory}/META-INF/native</nativeDir>
+        <maven.main.skip>true</maven.main.skip>
         <skipTests>true</skipTests>
         <!--
           As we just re-package we don't want to do any extra steps that are needed for static compilation or
@@ -886,117 +772,36 @@
         -->
         <linkStatic>false</linkStatic>
         <compileLibrary>false</compileLibrary>
-        <uberArch>${os.detected.arch}</uberArch>
       </properties>
 
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <configuration combine.self="override">
-                  <artifactItems>
-                    <!-- Unpack just the native libraries (windows excluded as we not publish snapshots for it yet) -->
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>osx-${uberArch}</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/osx-${uberArch}</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>linux-${uberArch}</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${unpackDir}/linux-${uberArch}</outputDirectory>
-                    </artifactItem>
-
-                    <!-- Now unpack all of the Java classes and the original MANIFEST.MF -->
-                    <artifactItem>
-                      <groupId>io.netty</groupId>
-                      <artifactId>netty-tcnative-boringssl-static</artifactId>
-                      <version>${project.version}</version>
-                      <type>jar</type>
-                      <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                      <includes>**/*.class,**/MANIFEST.MF</includes>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-jni-libs</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <!-- Windows excluded as we not publish snapshots for it yet -->
-                  <target name="copy-jni-libs">
-                    <mkdir dir="${nativeDir}" />
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/osx-${uberArch}/META-INF/native" />
-                    </copy>
-                    <copy todir="${nativeDir}" flatten="true">
-                      <fileset dir="${unpackDir}/linux-${uberArch}/META-INF/native" />
-                    </copy>
-
-                     <!-- Copy license material for attribution-->
-                    <copy file="../NOTICE.txt" todir="${project.build.outputDirectory}/META-INF/" />
-                    <copy file="../LICENSE.txt" todir="${project.build.outputDirectory}/META-INF/" />
-                    <copy todir="${project.build.outputDirectory}/META-INF/license">
-                      <fileset dir="../license" />
-                    </copy>
-
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>maven-bundle-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate-manifest</id>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>manifest</goal>
-                </goals>
-                <configuration>
-                  <supportedProjectTypes>
-                    <supportedProjectType>jar</supportedProjectType>
-                  </supportedProjectTypes>
-                  <instructions>
-                    <Export-Package>io.netty.internal.tcnative.*</Export-Package>
-                    <Bundle-NativeCode>
-                      META-INF/native/libnetty_tcnative_osx_${uberArch}.jnilib;osname=macos;osname=macosx;processor=${uberArch},
-                      META-INF/native/libnetty_tcnative_linux_${uberArch}.so;osname=linux;processor=${uberArch},
-                      META-INF/native/netty_tcnative_windows_${uberArch}.dll;osname=win32;processor=${uberArch}
-                    </Bundle-NativeCode>
-                  </instructions>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-x86_64</classifier>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <version>${project.version}</version>
+          <classifier>windows-x86_64</classifier>
+        </dependency>
+      </dependencies>
     </profile>
+
     <!-- Profile to cross-compile for mac m1 -->
     <profile>
       <id>osx-m1-cross-compile</id>


### PR DESCRIPTION
Motivation:

We shouldn't repackage the native libs for the uber profile but better depend on the artifacts and so let the build tool handle this.

Modifications:

Change uber and uber-snapshot profile to not repackage

Result:

Less likely to see conflicts due multiple versions of tcnative on the classpath