### PR TITLE
Expose OpenSSL security level methods

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -725,6 +725,26 @@ public final class SSLContext {
     public static native boolean setNumTickets(long ctx, int tickets);
 
     /**
+     * Set the security level.<br>
+     * This method is currently only supported with OpenSSL version 1.1.0 and newer.<br>
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html">man SSL_CTX_set_security_level</a>
+     *
+     * @param ctx Server or Client context to use.
+     * @param level the security level
+     */
+    public static native void setSecurityLevel(long ctx, int level);
+
+    /**
+     * Get the current security level.<br>
+     * This method is currently only supported with OpenSSL version 1.1.0 and newer.<br>
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_security_level.html">man SSL_CTX_get_security_level</a>
+     *
+     * @param ctx Server or Client context to use.
+     * @return the current security level
+     */
+    public static native int getSecurityLevel(long ctx);
+
+    /**
      * Sets the curves to use.
      *
      * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set1_curves_list.html">SSL_CTX_set1_curves_list</a>.

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -626,6 +626,56 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setNumTickets)(TCN_STDARGS, jlong ctx, 
 #endif
 }
 
+TCN_IMPLEMENT_CALL(void, SSLContext, setSecurityLevel)(TCN_STDARGS, jlong ctx, jint level)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    TCN_CHECK_NULL(c, ctx, /* void */);
+
+#if defined(OPENSSL_IS_BORINGSSL) || defined(LIBRESSL_VERSION_NUMBER)
+    // Not supported by BoringSSL and LibreSSL
+    tcn_Throw(e, "Not supported using BoringSSL/LibreSSL");
+    return;
+#else
+    // Only supported with GCC
+    #if defined(__GNUC__) || defined(__GNUG__)
+        if (!SSL_CTX_set_security_level) {
+            return;
+        }
+    #endif
+
+    // We can only support it when either use openssl version >= 1.1.0 or GCC as this way we can use weak linking
+    #if OPENSSL_VERSION_NUMBER >= 0x10100000L  || defined(__GNUC__) || defined(__GNUG__)
+        SSL_CTX_set_security_level(c->ctx, level);
+    #endif
+#endif
+}
+
+TCN_IMPLEMENT_CALL(jint, SSLContext, getSecurityLevel)(TCN_STDARGS, jlong ctx)
+{
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    TCN_CHECK_NULL(c, ctx, 0);
+
+#if defined(OPENSSL_IS_BORINGSSL) || defined(LIBRESSL_VERSION_NUMBER)
+    // Not supported by BoringSSL and LibreSSL
+    tcn_Throw(e, "Not supported using BoringSSL/LibreSSL");
+    return -1;
+#else
+    // Only supported with GCC
+    #if defined(__GNUC__) || defined(__GNUG__)
+        if (!SSL_CTX_get_security_level) {
+            return -1;
+        }
+    #endif
+
+    // We can only support it when either use openssl version >= 1.1.0 or GCC as this way we can use weak linking
+    #if OPENSSL_VERSION_NUMBER >= 0x10100000L  || defined(__GNUC__) || defined(__GNUG__)
+        return SSL_CTX_get_security_level(c->ctx);
+    #endif
+#endif
+}
+
 TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDHLength)(TCN_STDARGS, jlong ctx, jint length)
 {
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
@@ -2818,6 +2868,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getSslCtx, (J)J, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(setUseTasks, (JZ)V, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(setNumTickets, (JI)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setSecurityLevel, (JI)V, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(getSecurityLevel, (J)I, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(setCurvesList0, (JLjava/lang/String;)Z, SSLContext) }
 
   // addCertificateCompressionAlgorithm0 --> needs dynamic method table


### PR DESCRIPTION
Motivation:

From version 1.1.0, OpenSSL provides a "security level" configuration which specifies which minimum security parameters are allowed for connexions (SSL version, ciphers, signature algorithms, and so on).
Setting a value less secure than the platform's default one can be useful, for instance when wanting to connect to legacy servers.
`netty-handler` will have to be modified to expose this feature to the user.

Modifications:

Add the `setSecurityLevel` and `getSecurityLevel` methods to the `SSLContext`.
 
Result:

The security level configuration is available for usage in netty-handler.
