### PR TITLE
Try stabilising build with CERN CentOS mirror

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -7,7 +7,7 @@ ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 
 # Update as we need to use the vault now.
-RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/vault.centos.org\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo
 
 # install dependencies
 RUN yum install -y \


### PR DESCRIPTION
Motivation:
Recently, our builds have been failing a lot with `PYCURL ERROR 7`, where the repository metadata fails to download.
It seems like the vault.centos.org server(s) are sometimes having trouble keeping up with their load.
In my local testing, the mirror site hosted by CERN seemed much more responsive.

Modification:
Switch to the CERN mirror of vault.centos.org.

Result:
Hopefully we now have fewer builds fail because `yum` can't download repository metadata or download packages.