### PR TITLE
Correctly flatten netty-tcnative-boringssl pom.xml

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -707,7 +707,6 @@
     -->
     <profile>
       <id>uber-staging</id>
-
       <properties>
         <maven.main.skip>true</maven.main.skip>
         <skipTests>true</skipTests>
@@ -759,6 +758,40 @@
           <classifier>windows-x86_64</classifier>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.2.2</version>
+            <configuration>
+              <!-- We need to also merge the dependencies defined by our profile. -->
+              <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
+              <!-- Ensure excludes are set correctly -->
+              <flattenDependencyMode>all</flattenDependencyMode>
+              <flattenMode>ossrh</flattenMode>
+            </configuration>
+            <executions>
+              <!-- enable flattening -->
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+              </execution>
+              <!-- ensure proper cleanup -->
+              <execution>
+                <id>flatten.clean</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>uber-snapshot</id>
@@ -787,12 +820,7 @@
           <version>${project.version}</version>
           <classifier>linux-aarch_64</classifier>
         </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-boringssl-static</artifactId>
-          <version>${project.version}</version>
-          <classifier>osx-x86_64</classifier>
-        </dependency>
+        <!-- Don't include osx as we dont deploy snapshots atm -->
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-tcnative-boringssl-static</artifactId>
@@ -800,6 +828,40 @@
           <classifier>windows-x86_64</classifier>
         </dependency>
       </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.2.2</version>
+            <configuration>
+              <!-- We need to also merge the dependencies defined by our profile. -->
+              <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
+              <!-- Ensure excludes are set correctly -->
+              <flattenDependencyMode>all</flattenDependencyMode>
+              <flattenMode>ossrh</flattenMode>
+            </configuration>
+            <executions>
+              <!-- enable flattening -->
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+              </execution>
+              <!-- ensure proper cleanup -->
+              <execution>
+                <id>flatten.clean</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <!-- Profile to cross-compile for mac m1 -->


### PR DESCRIPTION
Motivation:

6fb5b01208671c007ad7f752e51ccc8b25dfca2f introduced a change which changed how we package things. Unfortunally we missed to correctly flatten the pom.xml and so we not depend on the correct native libs.

Modifications:

- Add flatten plugin to the uber-* profiles

Result:

Depend on the correct native libs when uber profiles are used