### PR TITLE
Use different module names for openssl-classes and the other jars

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -38,7 +38,6 @@
           <configuration>
             <archive>
               <manifestEntries>
-                <Automatic-Module-Name>io.netty.tcnative.boringssl</Automatic-Module-Name>
                 <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>
@@ -63,6 +62,8 @@
     <cppflags>-DHAVE_OPENSSL -I${boringsslSourceDir}/include</cppflags>
     <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
     <skipJapicmp>true</skipJapicmp>
+    <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
+    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
   </properties>
 
   <dependencies>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -39,6 +39,8 @@
     <!-- Don't deploy this artifact to Maven Central -->
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipJapicmp>true</skipJapicmp>
+    <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
+    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
   </properties>
 
   <build>
@@ -50,7 +52,6 @@
           <configuration>
             <archive>
               <manifestEntries>
-                <Automatic-Module-Name>io.netty.tcnative.libressl</Automatic-Module-Name>
                 <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>

--- a/openssl-classes/pom.xml
+++ b/openssl-classes/pom.xml
@@ -33,22 +33,6 @@
   <properties>
     <compileLibrary>true</compileLibrary>
     <linkStatic>false</linkStatic>
+    <javaModuleName>io.netty.tcnative.classes.openssl</javaModuleName>
   </properties>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <archive>
-              <manifestEntries>
-                <Automatic-Module-Name>io.netty.tcnative.openssl.classes</Automatic-Module-Name>
-              </manifestEntries>
-            </archive>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -35,6 +35,8 @@
     <linkStatic>false</linkStatic>
     <nativeSourceDirectory />
     <skipJapicmp>true</skipJapicmp>
+    <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
+    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
   </properties>
 
   <build>
@@ -46,7 +48,6 @@
           <configuration>
             <archive>
               <manifestEntries>
-                <Automatic-Module-Name>io.netty.tcnative.openssl.dynamic</Automatic-Module-Name>
                 <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -38,6 +38,8 @@
     <!-- Don't deploy this artifact to Maven Central -->
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipJapicmp>true</skipJapicmp>
+    <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
+    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
   </properties>
 
   <build>
@@ -49,7 +51,6 @@
           <configuration>
             <archive>
               <manifestEntries>
-                <Automatic-Module-Name>io.netty.tcnative.openssl</Automatic-Module-Name>
                 <Fragment-Host>io.netty.tcnative-classes</Fragment-Host>
               </manifestEntries>
             </archive>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
     <jniUtilVersion>0.0.3.Final</jniUtilVersion>
+    <javaModuleName>io.netty.internal.tcnative</javaModuleName>
   </properties>
 
   <build>
@@ -433,7 +434,7 @@
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                 </manifest>
                 <manifestEntries>
-                  <Automatic-Module-Name>io.netty.internal.tcnative</Automatic-Module-Name>
+                  <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
                 </manifestEntries>
                 <index>true</index>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Motivation:

We need to ensure we use different module names for openssl-classes and the other jars that contains the native code. Otherwise it is impossible to load these.

Modifications:

- Use different module name for openssl-classes
- Use the same module name for all the jars that contains native bits.

Result:

Fixes https://github.com/netty/netty-tcnative/issues/708