### PR TITLE
Upgrade to libressl 3.4.3

### DIFF
--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -109,7 +109,7 @@ const char* tcn_SSL_cipher_authentication_method(const SSL_CIPHER* cipher){
                 default:
                     return TCN_UNKNOWN_AUTH_METHOD;
             }
-#ifndef OPENSSL_NO_TLS1_3
+#if !defined(OPENSSL_NO_TLS1_3) && !defined(LIBRESSL_VERSION_NUMBER)
         case NID_kx_any:
             // Let us just pick one as we could use whatever we want.
             // See https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_get_kx_nid.html

--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,11 @@
       See https://boringssl.googlesource.com/boringssl/+/refs/heads/chromium-stable for the latest commit
     -->
     <boringsslCommitSha>3a667d10e94186fd503966f5638e134fe9fb4080</boringsslCommitSha>
-    <libresslVersion>3.3.5</libresslVersion>
+    <libresslVersion>3.4.3</libresslVersion>
     <!--
       See https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/SHA256 for the SHA256 signature
     -->
-    <libresslSha256>0a51393f0df1cf27e070054a2788a4d073339f363d79cd594076a1b4c48be9a5</libresslSha256>
+    <libresslSha256>ff88bffe354818b3ccf545e3cafe454c5031c7a77217074f533271d63c37f08d</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
     <opensslPatchVersion>m</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>


### PR DESCRIPTION
Motivation:

A new libressl release is out which fixes a security vuln.

Modifications:

Update to 3.4.3

Result:

Use non affected libressl version