### PR TITLE
Expose SSL insecure legacy renegotiation consts

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -42,6 +42,8 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslOpNoTLSv12();
     static native int sslOpNoTLSv13();
     static native int sslOpNoTicket();
+    static native int sslOpAllowUnsafeLegacyRenegotiation();
+    static native int sslOpLegacyServerConnect();
 
     /**
      * Options not defined in the OpenSSL docs but may impact security.

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -74,6 +74,8 @@ public final class SSL {
     public static final int SSL_OP_NO_TICKET = sslOpNoTicket();
 
     public static final int SSL_OP_NO_COMPRESSION = sslOpNoCompression();
+    public static final int SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION = sslOpAllowUnsafeLegacyRenegotiation();
+    public static final int SSL_OP_LEGACY_SERVER_CONNECT = sslOpLegacyServerConnect();
 
     public static final int SSL_MODE_CLIENT         = 0;
     public static final int SSL_MODE_SERVER         = 1;

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -56,6 +56,14 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpNoCompressio
     return SSL_OP_NO_COMPRESSION;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpAllowUnsafeLegacyRenegotiation)(TCN_STDARGS) {
+    return SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpLegacyServerConnect)(TCN_STDARGS) {
+    return SSL_OP_LEGACY_SERVER_CONNECT;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSessCacheOff)(TCN_STDARGS) {
     return SSL_SESS_CACHE_OFF;
 }
@@ -635,6 +643,8 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv13, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTicket, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoCompression, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpAllowUnsafeLegacyRenegotiation, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslOpLegacyServerConnect, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheOff, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheServer, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheClient, ()I, NativeStaticallyReferencedJniMethods) },


### PR DESCRIPTION
Motivation:

Allow Netty users with OpenSsl to turn these flags back on, in order
to interoperate with legacy sites.

Modifications:

Expose new SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION and
SSL_OP_LEGACY_SERVER_CONNECT constants.

Result:

New constants, which Netty can use to provide legacy compatibility.

netty/netty#12230