### PR TITLE
Don't call strdup on packagePrefix.

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -57,7 +57,7 @@ static jclass    jString_class;
 static jmethodID jString_init;
 static jmethodID jString_getBytes;
 static jclass    byteArrayClass;
-static const char* staticPackagePrefix = NULL;
+static char* const staticPackagePrefix = NULL;
 
 jstring tcn_new_stringn(JNIEnv *env, const char *str, size_t l)
 {
@@ -150,7 +150,7 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
 //            Library to reflect that.
-static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, char const* packagePrefix) {
     int errorOnLoadCalled = 0;
     int bufferOnLoadCalled = 0;
     int jniMethodsOnLoadCalled = 0;

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -266,7 +266,7 @@ static void netty_internal_tcnative_Library_JNI_OnUnload(JNIEnv* env) {
     netty_internal_tcnative_SSL_JNI_OnUnLoad(env, staticPackagePrefix);
     netty_internal_tcnative_SSLContext_JNI_OnUnLoad(env, staticPackagePrefix);
     netty_internal_tcnative_SSLSession_JNI_OnUnLoad(env, staticPackagePrefix);
-    free(staticPackagePrefix);
+    free((void *) staticPackagePrefix);
     staticPackagePrefix = NULL;
 }
 

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -57,7 +57,7 @@ static jclass    jString_class;
 static jmethodID jString_init;
 static jmethodID jString_getBytes;
 static jclass    byteArrayClass;
-static char* staticPackagePrefix = NULL;
+static const char* staticPackagePrefix = NULL;
 
 jstring tcn_new_stringn(JNIEnv *env, const char *str, size_t l)
 {

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -57,7 +57,7 @@ static jclass    jString_class;
 static jmethodID jString_init;
 static jmethodID jString_getBytes;
 static jclass    byteArrayClass;
-static char* const staticPackagePrefix = NULL;
+static char const* staticPackagePrefix = NULL;
 
 jstring tcn_new_stringn(JNIEnv *env, const char *str, size_t l)
 {

--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -217,9 +217,7 @@ static jint netty_internal_tcnative_Library_JNI_OnLoad(JNIEnv* env, const char* 
                    "getBytes", "()[B", error);
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", error);
-    if (packagePrefix) {
-        staticPackagePrefix = strdup(packagePrefix);
-    }
+    staticPackagePrefix = packagePrefix;
     return NETTY_JNI_UTIL_JNI_VERSION;
 error:
     if (tcn_global_pool != NULL) {

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.3.Final</jniUtilVersion>
+    <jniUtilVersion>0.0.4.Final-SNAPSHOT</jniUtilVersion>
     <javaModuleName>io.netty.internal.tcnative</javaModuleName>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.4.Final-SNAPSHOT</jniUtilVersion>
+    <jniUtilVersion>0.0.4.Final</jniUtilVersion>
     <javaModuleName>io.netty.internal.tcnative</javaModuleName>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.4.Final</jniUtilVersion>
+    <jniUtilVersion>0.0.5.Final</jniUtilVersion>
     <javaModuleName>io.netty.internal.tcnative</javaModuleName>
   </properties>
 


### PR DESCRIPTION
Improves musl compatibility and slightly improves efficiency.

Requires https://github.com/netty/netty-jni-util/pull/8.