### PR TITLE
Ensure we link against openssl 1.1 on macOS

### DIFF
--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -235,6 +235,7 @@
                   <configureArgs>
                     <configureArg>${macOsxDeploymentTarget}</configureArg>
                     <configureArg>--with-apr=/usr/local/opt/apr/libexec/</configureArg>
+                    <configureArg>--with-ssl=/usr/local/opt/openssl@1.1/</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>


### PR DESCRIPTION
Motivation:

We should ensure we link against openssl 1.1 on macOS even if openssl 3.x is installed as well.

Modifications:

Add configure argument

Result:

Fixes https://github.com/netty/netty-tcnative/issues/719