### PR TITLE
Fix Automatic-Module-Name for jars that contain native libs

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -63,7 +63,7 @@
     <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
+    <javaModuleName>${javaModuleNameNative}</javaModuleName>
   </properties>
 
   <dependencies>
@@ -374,6 +374,7 @@
         <nativeLibOsParts>${os.detected.name}_aarch_64</nativeLibOsParts>
         <jniClassifier>${os.detected.name}-aarch_64</jniClassifier>
         <jniArch>aarch_64</jniArch>
+        <javaModuleNameClassifier>${os.detected.name}.aarch_64</javaModuleNameClassifier>
       </properties>
 
       <build>
@@ -888,6 +889,7 @@
         <nativeLibOsParts>${os.detected.name}_aarch_64</nativeLibOsParts>
         <jniClassifier>${os.detected.name}-aarch_64</jniClassifier>
         <jniArch>aarch_64</jniArch>
+        <javaModuleNameClassifier>${os.detected.name}.aarch_64</javaModuleNameClassifier>
       </properties>
       <build>
         <plugins>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -40,7 +40,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
+    <javaModuleName>${javaModuleNameNative}</javaModuleName>
   </properties>
 
   <build>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -259,6 +259,7 @@
         <jniClassifier>${os.detected.name}-aarch_64</jniClassifier>
         <nativeLibOsParts>${os.detected.name}_aarch_64</nativeLibOsParts>
         <jniArch>aarch_64</jniArch>
+        <javaModuleNameClassifier>${os.detected.name}.aarch_64</javaModuleNameClassifier>
       </properties>
 
       <build>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -39,7 +39,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
+    <javaModuleName>${javaModuleNameNative}</javaModuleName>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,10 @@
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
     <jniUtilVersion>0.0.5.Final</jniUtilVersion>
-    <javaModuleName>io.netty.internal.tcnative</javaModuleName>
+    <javaDefaultModuleName>io.netty.internal.tcnative</javaDefaultModuleName>
+    <javaModuleName>${javaDefaultModuleName}</javaModuleName>
+    <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>
+    <javaModuleNameNative>${javaDefaultModuleName}.openssl.${javaModuleNameClassifier}</javaModuleNameNative>
   </properties>
 
   <build>


### PR DESCRIPTION
Motivation:

The '-' is not allowed in module names and so the used module names are invalid.
See https://sormuras.github.io/blog/2018-11-16-invalid-automatic-module-names.html.

Modifications:

Adjust module names to not use invalid chars

Result:

Fixes https://github.com/netty/netty-tcnative/issues/724