### PR TITLE
Add SSL.bioSetFd method to JNI code to support Pixie integration

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -218,6 +218,13 @@ public final class SSL {
     public static native long bioNewByteBuffer(long ssl, int nonApplicationBufferSize);
 
     /**
+     * TBD
+     * @param ssl
+     * @param fd
+     */
+     public static native void bioSetFd(long ssl, int fd);
+
+    /**
      * Set the memory location which that OpenSSL's internal BIO will use to write encrypted data to, or read encrypted
      * data from.
      * <p>

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -218,9 +218,11 @@ public final class SSL {
     public static native long bioNewByteBuffer(long ssl, int nonApplicationBufferSize);
 
     /**
-     * TBD
-     * @param ssl
-     * @param fd
+     * Set the socket file descriptor of the rbio field inside the SSL struct (ssl->rbio->num). This is
+     * allows
+     *
+     * @param ssl the SSL instance (SSL *)
+     * @param fd the file descriptor of the socket used for the given SSL connection
      */
      public static native void bioSetFd(long ssl, int fd);
 

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -218,8 +218,7 @@ public final class SSL {
     public static native long bioNewByteBuffer(long ssl, int nonApplicationBufferSize);
 
     /**
-     * Set the socket file descriptor of the rbio field inside the SSL struct (ssl->rbio->num). This is
-     * allows
+     * Sets the socket file descriptor of the rbio field inside the SSL struct (ssl->rbio->num)
      *
      * @param ssl the SSL instance (SSL *)
      * @param fd the file descriptor of the socket used for the given SSL connection

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -344,6 +344,11 @@ static long bio_java_bytebuffer_ctrl(BIO* bio, int cmd, long num, void* ptr) {
             return 1;
         case BIO_CTRL_FLUSH:
             return 1;
+#ifdef OPENSSL_IS_BORINGSSL
+        case BIO_C_SET_FD:
+            bio->num = *((int *)ptr);
+            return 1;
+#endif
         default:
             return 0;
     }
@@ -391,6 +396,23 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
   }
 }
 #endif // OPENSSL_NO_ENGINE
+
+TCN_IMPLEMENT_CALL(void, SSL, bioSetFd)(TCN_STDARGS, jlong ssl, jint fd) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    if (ssl_ == NULL) {
+      tcn_ThrowException(e, "ssl pointer is null!");
+    }
+    BIO* bio = SSL_get_rbio(ssl_);
+
+    // We do not want to fd to be closed
+    int rc = BIO_set_fd(bio, fd, 0);
+    if (rc != 1) {
+      // Need to handle error
+      tcn_ThrowException(e, "Failed to set BIO fd");
+    }
+    return;
+}
 
 TCN_IMPLEMENT_CALL(jint, SSL, bioLengthByteBuffer)(TCN_STDARGS, jlong bioAddress) {
     BIO* bio = J2P(bioAddress, BIO*);
@@ -2657,7 +2679,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getShutdown, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setShutdown, (JI)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(freeSSL, (J)V, SSL) },
-  { TCN_METHOD_TABLE_ENTRY(bioNewByteBuffer, (JI)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(bioSetFd, (JI)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(bioNewByteBuffer, (JI)J, SSL) },
   { TCN_METHOD_TABLE_ENTRY(freeBIO, (J)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(shutdownSSL, (J)I, SSL) },

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -399,19 +399,15 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
 
 TCN_IMPLEMENT_CALL(void, SSL, bioSetFd)(TCN_STDARGS, jlong ssl, jint fd) {
     SSL *ssl_ = J2P(ssl, SSL *);
+    TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-    if (ssl_ == NULL) {
-      tcn_ThrowException(e, "ssl pointer is null!");
-    }
     BIO* bio = SSL_get_rbio(ssl_);
 
-    // We do not want to fd to be closed
+    // We do not want the fd to be closed
     int rc = BIO_set_fd(bio, fd, 0);
     if (rc != 1) {
-      // Need to handle error
-      tcn_ThrowException(e, "Failed to set BIO fd");
+        tcn_ThrowException(e, "Failed to set BIO fd");
     }
-    return;
 }
 
 TCN_IMPLEMENT_CALL(jint, SSL, bioLengthByteBuffer)(TCN_STDARGS, jlong bioAddress) {

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -344,11 +344,11 @@ static long bio_java_bytebuffer_ctrl(BIO* bio, int cmd, long num, void* ptr) {
             return 1;
         case BIO_CTRL_FLUSH:
             return 1;
-#ifdef OPENSSL_IS_BORINGSSL
         case BIO_C_SET_FD:
+#if defined(OPENSSL_IS_BORINGSSL) || defined(LIBRESSL_VERSION_NUMBER)
             bio->num = *((int *)ptr);
-            return 1;
 #endif
+            return 1;
         default:
             return 0;
     }


### PR DESCRIPTION
I've been working on extending the pixie platform to support out of the box instrumentation for [twitter/finagle](https://github.com/twitter/finagle) and eventually the netty project (https://github.com/pixie-io/pixie/issues/407).

For those that aren't familiar, [Pixie](https://github.com/pixie-io/pixie) is an open source, Kubernetes Observability tool that provides auto instrumentation by leveraging eBPF. It has support for tracing network traffic for a variety of protocols (http/2, kafka, mysql, mux, etc) even if encrypted with openssl. Its openssl tracing support works by instrumenting the `SSL_read` and `SSL_write` functions through a uprobe. This uprobe captures the data just before encryption or just after decryption, in addition to navigating [openssl's rbio struct](https://github.com/pixie-io/pixie/blob/294d3f36214dece583dd499ebd578cecb7cc7425/src/stirling/source_connectors/socket_tracer/bcc_bpf/openssl_trace.c#L59-L78) to access the socket file descriptor (necessary for associating network traffic with a particular container).

Due to how netty uses openssl today, the openssl SSL struct passed to `SSL_read` and `SSL_write` does not have the socket fd set. This is because netty's Java code handles the network transport and leverages openssl only for encryption and decryption. The functionality added in this PR will allow netty to populate the SSL struct's rbio field with the socket file descriptor when a channel becomes active (first created).

My understanding is that each netty channel will be given its own ssl engine (where I've updated in https://github.com/netty/netty/pull/12438), so setting this socket file descriptor on a per connection basis shouldn't be a problem. It's also worth mentioning that getting this to work with Pixie requires setting `-Dio.netty.native.deleteLibAfterLoading=false`. So while the goal is to instrument netty TLS connections with minimal configuration, that option would be necessary.

As mentioned below, I've verified this works with a few requests and responses in pixie's test suite. I wanted to open up this PR to facilitate discussion on how to accomplish this integration between pixie and netty and look forward to your feedback :)

## Testing
- [x] Verified that pixie's netty TLS tracing works for a twitter/finagle service on https://github.com/pixie-io/pixie/pull/446

## Todo
- [ ] Deploy a Twitter production service with this change to stress test there aren't any regressions
- [x] Other items from code review