### PR TITLE
Fix aarch64 processor name for OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,9 +388,13 @@
                   <equals arg1="${os.detected.name}" arg2="osx" />
                 </condition>
 
-                <!-- In OSGi specification, the alias of x86_32 is x86 -->
-                <condition property="nativeCode.processor" value="x86" else="${os.detected.arch}">
+                <!-- In OSGi specification, the alias of x86_32 is x86... -->
+                <condition property="nativeCode.processor" value="x86">
                   <equals arg1="${os.detected.arch}" arg2="x86_32" />
+                </condition>
+                <!-- ... and aarch_64 is aarch64 -->
+                <condition property="nativeCode.processor" value="aarch64" else="${os.detected.arch}">
+                  <equals arg1="${os.detected.arch}" arg2="aarch_64" />
                 </condition>
 
                 <property name="tcnativeManifest" value="META-INF/native/${tcnative.snippet};processor=${nativeCode.processor}" />


### PR DESCRIPTION
Motivation:
OSGi does not recognize `aarch_64` (with the underscore) as a processor name.

Modification:
Add another rule to rewrite that processor name to not have the underscore for OSGi.

Result:
Our tcnative bundles should work again, on aarch_64 systems.

This is the tcnative equivalent of https://github.com/netty/netty/pull/12498