### PR TITLE
Update to openssl 1.1.1q

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,9 @@
     -->
     <libresslSha256>ff88bffe354818b3ccf545e3cafe454c5031c7a77217074f533271d63c37f08d</libresslSha256>
     <opensslMinorVersion>1.1.1</opensslMinorVersion>
-    <opensslPatchVersion>n</opensslPatchVersion>
+    <opensslPatchVersion>q</opensslPatchVersion>
     <opensslVersion>${opensslMinorVersion}${opensslPatchVersion}</opensslVersion>
-    <opensslSha256>40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a</opensslSha256>
+    <opensslSha256>d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca</opensslSha256>
     <aprHome>${project.build.directory}/apr</aprHome>
     <aprSourceDir>${project.build.directory}/apr-source</aprSourceDir>
     <aprPatchFile>r1871981-macos11.patch</aprPatchFile>


### PR DESCRIPTION
Motivation:

A new openssl release was announced, lets use it

Modifications:

Update to 1.1.1q

Result:

Use latest release during build