### PR TITLE
Use Junit5

### DIFF
--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -161,6 +161,16 @@
       <artifactId>netty-tcnative-classes</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
+++ b/openssl-dynamic/src/test/java/io/netty/internal/tcnative/AbstractNativeTest.java
@@ -15,7 +15,8 @@
  */
 package io.netty.internal.tcnative;
 
-import org.junit.BeforeClass;
+
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.File;
 
@@ -25,7 +26,7 @@ import java.io.File;
  */
 public abstract class AbstractNativeTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void loadNativeLib() throws Exception {
         String testClassesRoot =  AbstractNativeTest.class.getProtectionDomain().getCodeSource().getLocation().getFile();
         File[] directories = new File(testClassesRoot + File.separator + "META-INF" + File.separator + "native")

--- a/openssl-dynamic/src/test/java/io/netty/internal/tcnative/CertificateVerifierTest.java
+++ b/openssl-dynamic/src/test/java/io/netty/internal/tcnative/CertificateVerifierTest.java
@@ -15,10 +15,13 @@
  */
 package io.netty.internal.tcnative;
 
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CertificateVerifierTest extends AbstractNativeTest {
 
@@ -28,14 +31,13 @@ public class CertificateVerifierTest extends AbstractNativeTest {
         for (Field field : fields) {
             if (field.isAccessible()) {
                 int errorCode = field.getInt(null);
-                Assert.assertTrue(
-                        "errorCode '" + errorCode + "' must be valid", CertificateVerifier.isValid(errorCode));
+                assertTrue(CertificateVerifier.isValid(errorCode), "errorCode '" + errorCode + "' must be valid");
             }
         }
     }
 
     @Test
     public void testNonValidErrorCode() {
-        Assert.assertFalse(CertificateVerifier.isValid(Integer.MIN_VALUE));
+        assertFalse(CertificateVerifier.isValid(Integer.MIN_VALUE));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <netty.build.version>30</netty.build.version>
+    <netty.build.version>31</netty.build.version>
+    <junit.version>5.9.0</junit.version>
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <forceAutogen>false</forceAutogen>
     <forceConfigure>false</forceConfigure>
@@ -245,12 +246,6 @@
             <exclude>**/*TestUtil*</exclude>
           </excludes>
           <runOrder>random</runOrder>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>io.netty.build.junit.TimedOutTestsListener</value>
-            </property>
-          </properties>
           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
         </configuration>
@@ -475,6 +470,18 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-build-common</artifactId>
       <version>${netty.build.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Motivation:

We should use Junit5 these days

Modifications:

- Adjust dependencies
- Adjust code to use junit5

Result:

Not depend on junit 4 anymore