### PR TITLE
Use latest maven version

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip


### PR DESCRIPTION
Motivation:

A new maven release is out

Modifications:

Update to 3.8.6

Result:

Use latest maven version to build project