### PR TITLE
Remove weak symbol when building with BoringSSL

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1255,7 +1255,7 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
                                                          jlong ssl /* SSL * */) {
     // Use weak linking with GCC as this will alow us to run the same packaged version with multiple
     // version of openssl.
-    #if defined(__GNUC__) || defined(__GNUG__)
+    #if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
         if (!SSL_get0_alpn_selected) {
             return NULL;
         }

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -469,6 +469,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 
 #if defined(__GNUC__) || defined(__GNUG__)
     // only supported with GCC, this will be used to support different openssl versions at the same time.
+#ifndef OPENSSL_IS_BORINGSSL
     extern int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
            unsigned protos_len) __attribute__((weak));
     extern void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx, int (*cb) (SSL *ssl, const unsigned char **out,
@@ -476,8 +477,8 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
            void *arg), void *arg) __attribute__((weak));
     extern void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
            unsigned *len) __attribute__((weak));
+    extern void SSL_CTX_set_cert_cb(SSL_CTX *c, int (*cert_cb)(SSL *ssl, void *arg), void *arg) __attribute__((weak));
 
-#ifndef OPENSSL_IS_BORINGSSL
     extern X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl) __attribute__((weak));
     extern void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *param, unsigned int flags) __attribute__((weak));
     extern int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *param, const char *name, size_t namelen) __attribute__((weak));
@@ -486,7 +487,6 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 #endif // OPENSSL_IS_BORINGSSL
 
     extern int SSL_get_sigalgs(SSL *s, int idx, int *psign, int *phash, int *psignhash, unsigned char *rsig, unsigned char *rhash) __attribute__((weak));
-    extern void SSL_CTX_set_cert_cb(SSL_CTX *c, int (*cert_cb)(SSL *ssl, void *arg), void *arg) __attribute__((weak));
 #endif
 
 #ifdef OPENSSL_IS_BORINGSSL

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -967,7 +967,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos0)(TCN_STDARGS, jlong ctx, jby
         jint selectorFailureBehavior)
 {
     // Only supported with GCC
-    #if defined(__GNUC__) || defined(__GNUG__)
+    #if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
         if (!SSL_CTX_set_alpn_protos || !SSL_CTX_set_alpn_select_cb) {
             return;
         }
@@ -2024,12 +2024,12 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertificateCallback)(TCN_STDARGS, jlong 
 
 // Use weak linking with GCC as this will alow us to run the same packaged version with multiple
 // version of openssl.
-#if defined(__GNUC__) || defined(__GNUG__)
+#if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
     if (!SSL_CTX_set_cert_cb) {
         tcn_ThrowException(e, "Requires OpenSSL 1.0.2+");
         return;
     }
-#endif // defined(__GNUC__) || defined(__GNUG__)
+#endif
 
 // We can only support it when either use openssl version >= 1.0.2 or GCC as this way we can use weak linking
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(__GNUC__) || defined(__GNUG__)


### PR DESCRIPTION
(I wasn't able to figure out the build, but I'm hoping CI will catch if I messed anything up.)

Motivation:

Current revisions of BoringSSL have upgraded the `unsigned` parameter to a `size_t` one. (Folks requested that we start to work through -Wshorten-64-to-32 warnings.) This is broadly API-compatible but breaks netty-tcnative's weak symbol machinery because it copies the functionp prototype.

Modification:

Move the remaining functions BoringSSL always has into the OPENSSL_IS_BORINGSSL block and disable the weak symbol checks.

Result:

netty-tcnative builds with BoringSSL.

Further work can probably be done here to clean this up, depending on what the project wants. First of all, it's 2022 and you can probably just stop supporting OpenSSL 1.0.1. Then much of this goes away anyway.

Beyond that, BoringSSL usually does feature detection with either OPENSSL_VERSION_NUMBER (we define a roughly analogous OpenSSL version) or our BORINGSSL_API_VERSION symbol. If you went with a strategy like that, it'd be a bit easier for us, though I don't know if it'd be a headache for other cases. Or perhaps we can come up with a suitable abstraction here.