### PR TITLE
Fix BoringSSL osx cross-compilation incorrect binary output

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -1131,7 +1131,7 @@
         <cmakeCxxFlags>-O3 -fno-omit-frame-pointer -target ${target} -Wno-error=range-loop-analysis</cmakeCxxFlags>
         <cflags>-target ${target} -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3</cflags>
         <cppflags>-target ${target} -DHAVE_OPENSSL -I${boringsslSourceDir}/include</cppflags>
-        <ldflags>-arch arm64 -L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
+        <ldflags>-arch x86_64 -L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
         <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-osx_x86_64.jar</nativeJarFile>
         <nativeLibOsParts>${os.detected.name}_osx_x86_64</nativeLibOsParts>
@@ -1248,8 +1248,8 @@
                           <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
-                          <arg value="-DCMAKE_SYSTEM_PROCESSOR=arm64" />
-                          <arg value="-DCMAKE_OSX_ARCHITECTURES=arm64" />
+                          <arg value="-DCMAKE_SYSTEM_PROCESSOR=x86_64" />
+                          <arg value="-DCMAKE_OSX_ARCHITECTURES=x86_64" />
                           <arg value="${cmakeOsxDeploymentTarget}" />
                           <arg value="-GNinja" />
                           <arg value="${boringsslSourceDir}" />


### PR DESCRIPTION
With the current maven configuration, when compiling from apple-silicon to intel produces arch64 binaries instead of x86_64 (via profile `mac-intel-cross-compile`)

```
❯ file libnetty_tcnative.jnilib
libnetty_tcnative.jnilib: Mach-O 64-bit dynamically linked shared library arm64
```

This PR replaces the wrong parameters in the compilation which now produces the correct target binaries
```
❯ file libnetty_tcnative.jnilib
libnetty_tcnative.jnilib: Mach-O 64-bit dynamically linked shared library x86_64
```