### PR TITLE
Expose SSL3_RT_MAX_ENCRYPTED_LENGTH via constant

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -77,6 +77,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sslErrorWantAccept();
 
     static native int sslMaxPlaintextLength();
+    static native int sslMaxEncryptedLength();
     static native int sslMaxRecordLength();
 
     static native int x509CheckFlagAlwaysCheckSubject();

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -98,6 +98,8 @@ public final class SSL {
     public static final int SSL_MODE_RELEASE_BUFFERS                = sslModeReleaseBuffers();
     public static final int SSL_MODE_ENABLE_FALSE_START             = sslModeEnableFalseStart();
     public static final int SSL_MAX_PLAINTEXT_LENGTH = sslMaxPlaintextLength();
+    public static final int SSL_MAX_ENCRYPTED_LENGTH = sslMaxEncryptedLength();
+
     /**
      * The <a href="https://tools.ietf.org/html/rfc5246#section-6.2.1">TLS 1.2 RFC</a> defines the maximum length to be
      * {@link #SSL_MAX_PLAINTEXT_LENGTH}, but there are some implementations such as

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -156,6 +156,10 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslMaxPlaintextLe
     return SSL3_RT_MAX_PLAIN_LENGTH;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslMaxEncryptedLength)(TCN_STDARGS) {
+    return SSL3_RT_MAX_ENCRYPTED_LENGTH;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslMaxRecordLength)(TCN_STDARGS) {
     // SSL3_RT_MAX_ENCRYPTED_OVERHEAD = Padding + Message Digest Hash
     // IV + Padding + Message Digest + Length allowed by RFC + Extra data amount
@@ -668,6 +672,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslErrorWantConnect, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslErrorWantAccept, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslMaxPlaintextLength, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslMaxEncryptedLength, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslMaxRecordLength, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509CheckFlagAlwaysCheckSubject, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509CheckFlagDisableWildCards, ()I, NativeStaticallyReferencedJniMethods) },


### PR DESCRIPTION
Motivation:

We need to expose SSL3_RT_MAX_ENCRYPTED_LENGTH so we can use it to detemine the capacity of src ByteBuffer for unwrap operations.

Modifications:

Add method and constant that exposed SSL3_RT_MAX_ENCRYPTED_LENGTH

Result:

Be able to correctly size the capacity of the ByteBuffer