### PR TITLE
Patch APR to remove crypt dependency

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
     #    uses a compiled language
 
     - name: Install tools / libraries 
-      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar libapr1-dev libssl-dev cmake perl ninja-build
+      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool libtool-bin make tar libapr1-dev libssl-dev cmake perl ninja-build
 
     - name: Build project
       run: ./mvnw clean package -DskipTests=true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,7 +67,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool libtool-bin make tar libapr1-dev libssl-dev cmake perl ninja-build
 
     - name: Build project
-      run: ./mvnw clean package -DskipTests=true
+      run: ./mvnw clean package -pl openssl-dynamic -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -23,6 +23,7 @@ RUN yum install -y \
  lsb-core \
  make \
  openssl-devel \
+ patch \
  perl \
  tar \
  unzip \

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -14,7 +14,7 @@ RUN yum install -y http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-g
 # Install requirements
 RUN  set -x && \
   yum -y install epel-release && \
-  yum -y install wget tar git make autoconf automake libtool openssl-devel ninja-build gcc-c++
+  yum -y install wget tar git make autoconf automake libtool openssl-devel ninja-build gcc-c++ patch
 
 # Install Java
 RUN yum install -y java-1.8.0-openjdk-devel golang

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -31,6 +31,7 @@ RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > 
  libc-bin=2.13-38+deb7u10 \
  libc6=2.13-38+deb7u10 libc6-dev \
  make \
+ patch \
  perl-base=5.14.2-21+deb7u3 \
  tar \
  unzip \

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -27,6 +27,7 @@ RUN zypper install --force-resolution --no-recommends --no-confirm \
  lsb-release \
  make \
  ninja \
+ patch \
  perl \
  tar \
  unzip \

--- a/patches/apr_crypt.patch
+++ b/patches/apr_crypt.patch
@@ -1,0 +1,10 @@
+--- configure.in.old	2023-01-09 14:22:19
++++ configure.in	2023-01-09 14:22:43
+@@ -729,7 +729,6 @@
+       AC_SEARCH_LIBS(gethostbyname, nsl)
+       AC_SEARCH_LIBS(gethostname, nsl)
+       AC_SEARCH_LIBS(socket, socket)
+-      AC_SEARCH_LIBS(crypt, crypt ufc)
+       AC_CHECK_LIB(truerand, main)
+       AC_SEARCH_LIBS(modf, m)
+        ;;

--- a/pom.xml
+++ b/pom.xml
@@ -679,6 +679,10 @@
                           </then>
                         </if>
 
+                        <echo message="Patching APR to not link against libcrypt" />
+                        <patch patchfile="${project.basedir}/../patches/apr_crypt.patch" strip="0" dir="${aprSourceDir}" />
+                        <exec executable="buildconf" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
+
                         <if>
                           <equals arg1="${osxCrossCompile}" arg2="true" />
                           <then>

--- a/pom.xml
+++ b/pom.xml
@@ -681,6 +681,7 @@
 
                         <echo message="Patching APR to not link against libcrypt" />
                         <patch patchfile="../patches/apr_crypt.patch" strip="0" dir="${aprSourceDir}" />
+                        <exec executable="buildconf" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
 
                         <if>
                           <equals arg1="${osxCrossCompile}" arg2="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,6 @@
 
                         <echo message="Patching APR to not link against libcrypt" />
                         <patch patchfile="../patches/apr_crypt.patch" strip="0" dir="${aprSourceDir}" />
-                        <exec executable="buildconf" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
 
                         <if>
                           <equals arg1="${osxCrossCompile}" arg2="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,7 @@
                         </if>
 
                         <echo message="Patching APR to not link against libcrypt" />
-                        <patch patchfile="${project.basedir}/../patches/apr_crypt.patch" strip="0" dir="${aprSourceDir}" />
+                        <patch patchfile="../patches/apr_crypt.patch" strip="0" dir="${aprSourceDir}" />
                         <exec executable="buildconf" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
 
                         <if>


### PR DESCRIPTION
Motivation:

We dont use any APR features that uses libcrypt so we can safely not link against it. This resolves various issues as some distributions otherwise need the extra installation of libxcrypt-compat etc.

Modifications:

- Add patchfile for APR configure.in to remove linking against libcrypt
- Patch APR during build

Result:

Fixes https://github.com/netty/netty-tcnative/issues/703