### PR TITLE
Upgrade hawtjni plugin to latest version

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -323,7 +323,7 @@
           <!-- Configure the distribution statically linked against OpenSSL and APR -->
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>
@@ -658,7 +658,7 @@
           <!-- Configure the distribution statically linked against OpenSSL and APR -->
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>
@@ -1078,7 +1078,7 @@
           <!-- Configure the distribution statically linked against OpenSSL and APR -->
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>
@@ -1326,7 +1326,7 @@
           <!-- Configure the distribution statically linked against OpenSSL and APR -->
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -164,7 +164,7 @@
       <!-- Configure the distribution statically linked against OpenSSL and APR -->
       <plugin>
         <groupId>org.fusesource.hawtjni</groupId>
-        <artifactId>maven-hawtjni-plugin</artifactId>
+        <artifactId>hawtjni-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>build-native-lib</id>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -129,7 +129,7 @@
       <!-- Generate the .so/.dynlib/.dll as part of the build. -->
       <plugin>
         <groupId>org.fusesource.hawtjni</groupId>
-        <artifactId>maven-hawtjni-plugin</artifactId>
+        <artifactId>hawtjni-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>build-native-lib</id>
@@ -233,7 +233,7 @@
         <plugins>
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>
@@ -272,7 +272,7 @@
         <plugins>
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>
@@ -384,7 +384,7 @@
           <!-- Generate the .so/.dynlib/.dll as part of the build. -->
           <plugin>
             <groupId>org.fusesource.hawtjni</groupId>
-            <artifactId>maven-hawtjni-plugin</artifactId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-native-lib</id>

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -161,7 +161,7 @@
       <!-- Configure the distribution statically linked against OpenSSL and APR -->
       <plugin>
         <groupId>org.fusesource.hawtjni</groupId>
-        <artifactId>maven-hawtjni-plugin</artifactId>
+        <artifactId>hawtjni-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>build-native-lib</id>

--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,8 @@
         </plugin>
         <plugin>
           <groupId>org.fusesource.hawtjni</groupId>
-          <artifactId>maven-hawtjni-plugin</artifactId>
-          <version>1.11</version>
+          <artifactId>hawtjni-maven-plugin</artifactId>
+          <version>1.18</version>
         </plugin>
         <plugin>
           <artifactId>maven-scm-plugin</artifactId>


### PR DESCRIPTION
Motivation:

The version of hawtjni that we are using is very old. Let's upgrade

Modifications:

Upgrade to 1.18

Result:

Use latest version of the plugin