### PR TITLE
Remove compile scope junit dependencies from openssl-dynamic submodule

### DIFF
--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -161,16 +161,6 @@
       <artifactId>netty-tcnative-classes</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
Motivation:

So junit dependencies are not transitively included when users depend on netty-tcnative in compile scope.

Modification:

Removed the junit dependencies from the openssl-dynamic submodule, so that they are inherited from netty-tcnative-parent with the proper test scope.

netty-tcnative-parent declares the junit dependencies as test scope in its dependencies.  But the openssl-dynamic submodule was overriding the scope to be the default (compile) scope.

Result:

Junit dependencies are not transitively included when users depend on netty-tcnative in compile scope.

Fixes #761