### PR TITLE
Bump up os-maven-plugin to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

os-maven-plugin 1.6.2 does not recognize LoongArch information, os-maven-plugin supports LoongArch since 1.7.1

Modification:

Update pom.xml

Result:

LoongArch cpu information can be correctly identified