### PR TITLE
Update multiple actions to v3

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,10 +31,10 @@ jobs:
 
     name: ${{ matrix.setup }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: build-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -58,7 +58,7 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-${{ matrix.setup }}-target
@@ -71,7 +71,7 @@ jobs:
     runs-on: windows-2019
     name: windows-x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -92,7 +92,7 @@ jobs:
           args: install ninja nasm
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: build-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -102,7 +102,7 @@ jobs:
       - name: Build netty-tcnative-boringssl-static
         run: ./mvnw.cmd --file pom.xml -am -pl boringssl-static clean package
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-windows-target

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -32,10 +32,10 @@ jobs:
 
     name: stage-snapshot-${{ matrix.setup }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: stage-snapshot-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -62,7 +62,7 @@ jobs:
         run: docker-compose ${{ matrix.docker-compose-run }}
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
@@ -73,7 +73,7 @@ jobs:
     runs-on: windows-2019
     name: stage-snapshot-windows-x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Create local staging directory
         run: mkdir local-staging
@@ -97,7 +97,7 @@ jobs:
           args: install ninja nasm
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: stage-snapshot-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -108,7 +108,7 @@ jobs:
         run: ./mvnw.cmd --file pom.xml -am -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: boringssl-static/local-staging
@@ -119,7 +119,7 @@ jobs:
     # Wait until we have staged everything
     needs: [stage-snapshot, stage-snapshot-windows]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -134,25 +134,25 @@ jobs:
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups and windows build. There is currently no way to pull this out of the config.
       - name: Download windows_x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: ~/windows-x86_64-local-staging
 
       - name: Download centos7-aarch64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: centos7-aarch64-local-staging
           path: ~/centos7-aarch64-local-staging
 
       - name: Download debian7-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: debian7-x86_64-local-staging
           path: ~/debian7-x86_64-local-staging
 
       - name: Download centos6-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: centos6-x86_64-local-staging
           path: ~/centos6-x86_64-local-staging
@@ -170,7 +170,7 @@ jobs:
           cp -r ~/centos6-x86_64-local-staging/deferred/* ~/local-staging/deferred/
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: deploy-staged-snapshot-m2-repository-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -28,7 +28,7 @@ jobs:
 
     name: ${{ matrix.setup }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -39,7 +39,7 @@ jobs:
             pr-${{ matrix.setup }}-docker-cache-
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: build-pr-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -55,7 +55,7 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-pr-${{ matrix.setup }}-target
@@ -67,7 +67,7 @@ jobs:
     runs-on: windows-2019
     name: windows-x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
@@ -88,7 +88,7 @@ jobs:
           args: install ninja nasm
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: build-pr-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -98,7 +98,7 @@ jobs:
       - name: Build netty-tcnative-boringssl-static
         run: ./mvnw.cmd --file pom.xml -am -pl boringssl-static clean package
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: build-pr-windows-target

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -12,7 +12,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
 
@@ -33,7 +33,7 @@ jobs:
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: prepare-release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -49,7 +49,7 @@ jobs:
         run: ./.github/scripts/release_checkout_tag.sh release.properties
 
       - name: Upload workspace
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: prepare-release-workspace
           path: ${{ github.workspace }}/**
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Download release-workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
@@ -83,7 +83,7 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
 
@@ -99,7 +99,7 @@ jobs:
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: stage-release-linux-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -141,7 +141,7 @@ jobs:
         run: docker-compose ${{ matrix.docker-compose-run }}
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
@@ -159,7 +159,7 @@ jobs:
     needs: prepare-release
     steps:
       - name: Download release-workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: prepare-release-workspace
           path: prepare-release-workspace
@@ -201,7 +201,7 @@ jobs:
           args: install ninja nasm
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: staging-release-cache-windows-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -222,7 +222,7 @@ jobs:
         run: ./mvnw --file pom.xml -Pstage -am -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
 
       - name: Upload local staging directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: prepare-release-workspace/boringssl-static/local-staging
@@ -240,7 +240,7 @@ jobs:
     needs: [stage-release-linux, stage-release-windows-x86_64]
     steps:
       - name: Download release-workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
@@ -267,25 +267,25 @@ jobs:
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups. There is currently no way to pull this out of the config.
       - name: Download windows-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-x86_64-local-staging
           path: ~/windows-x86_64-local-staging
 
       - name: Download centos7-aarch64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: centos7-aarch64-local-staging
           path: ~/centos7-aarch64-local-staging
 
       - name: Download debian7-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: debian7-x86_64-local-staging
           path: ~/debian7-x86_64-local-staging
 
       - name: Download centos6-x86_64 staging directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: centos6-x86_64-local-staging
           path: ~/centos6-x86_64-local-staging
@@ -297,7 +297,7 @@ jobs:
         run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/centos7-aarch64-local-staging/staging ~/debian7-x86_64-local-staging/staging ~/centos6-x86_64-local-staging/staging
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: deploy-staged-release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Cache .m2/repository
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: analyze-${{ matrix.language }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Motivation:
Actions such as `checkout`, `cache`, `download-artifact`, and `upload-artifact` have a major upgrade available which is v3. We should consider upgrading to them for extended functionalities and support.

Modification:
Upgraded all of those above-mentioned actions to v3.

Result:
Latest actions version