### PR TITLE
Upgrade setup-java action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,9 +74,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -79,9 +79,10 @@ jobs:
         run: mkdir local-staging
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -122,9 +123,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       # Setup some env to re-use later.
       - name: Prepare enviroment variables

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -70,9 +70,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -17,9 +17,10 @@ jobs:
           ref: main
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Setup git configuration
         run: |
@@ -86,6 +87,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Setup git configuration
         run: |
@@ -176,9 +178,10 @@ jobs:
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -249,9 +252,10 @@ jobs:
         run: chmod 755 ./prepare-release-workspace/mvnw
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
+          distribution: zulu
 
       - name: Setup git configuration
         run: |


### PR DESCRIPTION
Motivation:

We should use the latest setup-java action

Modifications:

- Upgrade to v3
- Add distribution setting

Result:

Use latest action version