### PR TITLE
Fix segfault which was caused by not creating the ticket_keys_new atomic

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -335,6 +335,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     c->protocol = protocol;
     c->mode     = mode;
     c->ctx      = ctx;
+    c->ticket_keys_new = tcn_atomic_uint32_create();
     c->ticket_keys_resume = tcn_atomic_uint32_create();
     c->ticket_keys_renew = tcn_atomic_uint32_create();
     c->ticket_keys_fail = tcn_atomic_uint32_create();


### PR DESCRIPTION
Motivation:

We somehow missed to correctly create the ticket_keys_new atomic which then later on could cause a segfault when we tried to delete this

Modifications:

Correctly create the atomic

Result:

No more segfaults