### PR TITLE
Fix possible corruption / segfault when using atomics

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -662,7 +662,7 @@ static void ssl_dyn_lock_function(int mode, struct CRYPTO_dynlock_value *l,
 static void ssl_dyn_destroy_function(struct CRYPTO_dynlock_value *l,
                           const char *file, int line)
 {
-    tcn_lock_destroy(&l->mutex);
+    tcn_lock_destroy(l->mutex);
     free(l->file);
     free(l);
 }

--- a/openssl-dynamic/src/main/c/tcn_atomic.cpp
+++ b/openssl-dynamic/src/main/c/tcn_atomic.cpp
@@ -20,9 +20,8 @@ tcn_atomic_uint32_t tcn_atomic_uint32_create() {
     return (tcn_atomic_uint32_t) new std::atomic<uint32_t>(0);
 }
 
-void tcn_atomic_uint32_destroy(tcn_atomic_uint32_t* atomic) {
-    delete (std::atomic<uint32_t> *) *atomic;
-    *atomic = nullptr;
+void tcn_atomic_uint32_destroy(tcn_atomic_uint32_t atomic) {
+    delete (std::atomic<uint32_t> *) atomic;
 }
 
 uint32_t tcn_atomic_uint32_get(tcn_atomic_uint32_t atomic) {

--- a/openssl-dynamic/src/main/c/tcn_atomic.h
+++ b/openssl-dynamic/src/main/c/tcn_atomic.h
@@ -27,7 +27,7 @@ typedef void* tcn_atomic_uint32_t;
 
 tcn_atomic_uint32_t tcn_atomic_uint32_create();
 
-void tcn_atomic_uint32_destroy(tcn_atomic_uint32_t* atomic);
+void tcn_atomic_uint32_destroy(tcn_atomic_uint32_t atomic);
 
 uint32_t tcn_atomic_uint32_get(tcn_atomic_uint32_t atomic);
 

--- a/openssl-dynamic/src/main/c/tcn_lock.cpp
+++ b/openssl-dynamic/src/main/c/tcn_lock.cpp
@@ -20,9 +20,8 @@ tcn_lock_t tcn_lock_create() {
     return (tcn_lock_t) new std::mutex;
 }
 
-void tcn_lock_destroy(tcn_lock_t* lock) {
-    delete (std::mutex *) *lock;
-    *lock = nullptr;
+void tcn_lock_destroy(tcn_lock_t lock) {
+    delete (std::mutex *) lock;
 }
 
 void tcn_lock_acquire(tcn_lock_t lock) {

--- a/openssl-dynamic/src/main/c/tcn_lock.h
+++ b/openssl-dynamic/src/main/c/tcn_lock.h
@@ -24,7 +24,7 @@ typedef void* tcn_lock_t;
 
 tcn_lock_t tcn_lock_create();
 
-void tcn_lock_destroy(tcn_lock_t* lock);
+void tcn_lock_destroy(tcn_lock_t lock);
 
 void tcn_lock_acquire(tcn_lock_t lock);
 

--- a/openssl-dynamic/src/main/c/tcn_lock_rw.cpp
+++ b/openssl-dynamic/src/main/c/tcn_lock_rw.cpp
@@ -22,9 +22,8 @@ tcn_lock_rw_t tcn_lock_rw_create() {
     return (tcn_lock_rw_t) new std::shared_timed_mutex;
 }
 
-void tcn_lock_rw_destroy(tcn_lock_rw_t* lock) {
-    delete (std::shared_timed_mutex *) *lock;
-    *lock = nullptr;
+void tcn_lock_rw_destroy(tcn_lock_rw_t lock) {
+    delete (std::shared_timed_mutex *) lock;
 }
 
 tcn_lock_w_t tcn_lock_w_acquire(tcn_lock_rw_t lock) {

--- a/openssl-dynamic/src/main/c/tcn_lock_rw.h
+++ b/openssl-dynamic/src/main/c/tcn_lock_rw.h
@@ -26,7 +26,7 @@ typedef void* tcn_lock_r_t;
 
 tcn_lock_rw_t tcn_lock_rw_create();
 
-void tcn_lock_rw_destroy(tcn_lock_rw_t* lock);
+void tcn_lock_rw_destroy(tcn_lock_rw_t lock);
 
 tcn_lock_w_t tcn_lock_w_acquire(tcn_lock_rw_t lock);
 


### PR DESCRIPTION
Motivation:

8740651154d184c1dc90b9345e765edb42121119 did introduce a change to not use APR at all. This change did introduce a bug that could cause memory corruption / segfaults by passing a pointer to a pointer while just a pointer was expected.

Modifications:

- Correctly pass pointer
- Adjust c function to be more consistent and so always expect only a pointer
- Add extra NULL checks for safety reasons

Result:

No more segfaults