### PR TITLE
Fix Automatic-Module-Name for dynamic linked tcnative

### DIFF
--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -36,7 +36,7 @@
     <nativeSourceDirectory />
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>io.netty.tcnative.openssl.${jniClassifier}</javaModuleName>
+    <javaModuleName>${javaModuleNameNative}</javaModuleName>
   </properties>
 
   <build>


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty-tcnative/pull/725 fixed the Automatic-Module-Name for the static linked tcnative artifacts but missed to do the same for the dynamic linked one.

Modifications:

Define correct property

Result:

Be able to use dynamic linked tcnative with modules