### PR TITLE
Set read-only permissions on GitHub workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -5,12 +5,17 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,6 +63,8 @@ jobs:
   stage-release-linux:
     runs-on: ubuntu-latest
     needs: prepare-release
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -159,6 +166,8 @@ jobs:
     runs-on: windows-2019
     name: stage-release-windows-x86_64
     needs: prepare-release
+    permissions:
+      contents: write
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v3
@@ -241,6 +250,8 @@ jobs:
     runs-on: ubuntu-latest
     # Wait until we have staged everything
     needs: [stage-release-linux, stage-release-windows-x86_64]
+    permissions:
+      contents: write
     steps:
       - name: Download release-workspace
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Fixes #778

As per the linked issue, this workflow sets read-only top-level permissions on all workflows.

It is my understanding that the jobs in `release.yml` all require write permissions (they all set `git config`, so I assume commits will be written and pushed), so those have been given at the job level. This ensures that if a new job is added in the future that doesn't require write permissions, it'll only have read access.

If I misunderstood something and other workflows require additional permissions or some jobs in `release.yml` don't require write access, let me know and I'll fix the PR.