### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting a security issue
+
+If you think the bug you found is likely to make Netty-based applications vulnerable to
+an attack, please do not use our public issue tracker but report it to
+[the dedicated private Google Group](https://groups.google.com/d/forum/netty-security)
+by sending an email to netty-security@googlegroups.com.
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As
+such, please give us 90 days to remediate the vulnerability before public disclosure.


### PR DESCRIPTION
Fixes #780.

As stated in the issue, this PR adds a security policy to the project. I based it on the [netty/netty policy](https://github.com/netty/netty/blob/main/SECURITY.md). The one change I made was adding a 90-day remediation timeline, which is pretty standard. However, I'm more than happy to make changes as requested. Let me know!