### PR TITLE
Expose SSL_CTX_set_max_cert_list

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -750,4 +750,14 @@ public final class SSLContext {
     }
 
     private static native boolean setCurvesList0(long ctx, String curves);
+
+    /**
+     * Set the maximum number of bytes for the certificate chain during handshake.
+     * See
+     * <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_max_cert_list.html">SSL_CTX_set_max_cert_list</a>
+     * for more details.
+     * @param ctx context to use
+     * @param size the maximum number of bbytes
+     */
+    public static native void setMaxCertList(long ctx, long size);
 }

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2697,6 +2697,14 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCurvesList0)(TCN_STDARGS, jlong ctx,
     return ret == 1 ? JNI_TRUE : JNI_FALSE;
 }
 
+TCN_IMPLEMENT_CALL(void, SSLContext, setMaxCertList)(TCN_STDARGS, jlong ctx, jlong size) {
+    tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
+
+    TCN_CHECK_NULL(c, ctx, /* void */);
+
+    SSL_CTX_set_max_cert_list(c->ctx, size);
+}
+
 TCN_IMPLEMENT_CALL(jint, SSLContext, addCertificateCompressionAlgorithm0)(TCN_STDARGS, jlong ctx, jint direction, jint algorithmId, jobject algorithm) {
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
     TCN_CHECK_NULL(c, ctx, 0);
@@ -2849,8 +2857,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getSslCtx, (J)J, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(setUseTasks, (JZ)V, SSLContext) },
   { TCN_METHOD_TABLE_ENTRY(setNumTickets, (JI)Z, SSLContext) },
-  { TCN_METHOD_TABLE_ENTRY(setCurvesList0, (JLjava/lang/String;)Z, SSLContext) }
-
+  { TCN_METHOD_TABLE_ENTRY(setCurvesList0, (JLjava/lang/String;)Z, SSLContext) },
+  { TCN_METHOD_TABLE_ENTRY(setMaxCertList, (JJ)V, SSLContext) }
   // addCertificateCompressionAlgorithm0 --> needs dynamic method table
 };
 


### PR DESCRIPTION
Motivation:

Sometimes its necessary to increase the maximum number of bytes a certificate chain can be

Modifications:

Expose SSL_CTX_set_max_cert_list

Result:

Be able to increase the limit