### PR TITLE
Only build openssl-classes and boringssl-static on windows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -98,7 +98,7 @@ jobs:
             build-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
-        run: ./mvnw.cmd --file pom.xml -am -pl boringssl-static clean package
+        run: ./mvnw.cmd --file pom.xml clean package
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -101,7 +101,7 @@ jobs:
             stage-snapshot-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
-        run: ./mvnw.cmd --file pom.xml -am -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
+        run: ./mvnw.cmd --file pom.xml clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -94,7 +94,7 @@ jobs:
             build-pr-windows-m2-repository-cache-
 
       - name: Build netty-tcnative-boringssl-static
-        run: ./mvnw.cmd --file pom.xml -am -pl boringssl-static clean package
+        run: ./mvnw.cmd --file pom.xml clean package
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}

--- a/pom.xml
+++ b/pom.xml
@@ -788,6 +788,24 @@
       </modules>
     </profile>
 
+
+    <profile>
+      <id>windows-compile-static-only</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <moduleSelector>none</moduleSelector>
+      </properties>
+      <modules>
+        <!-- Ony Windows we only support boringssl-static -->
+        <module>openssl-classes</module>
+        <module>boringssl-static</module>
+      </modules>
+    </profile>
+
     <!--
       Profile for building all modules. This is enabled by default so if any profile is manually specified,
       this will be disabled automatically.

--- a/pom.xml
+++ b/pom.xml
@@ -449,8 +449,7 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
-          <!-- Specifying a profile here will disable the all profile, since it's activeByDefault -->
-          <arguments>-Prestricted-release,sonatype-oss-release -DmoduleSelector=none</arguments>
+          <arguments>-Prestricted-release,sonatype-oss-release</arguments>
           <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
@@ -796,9 +795,6 @@
           <family>windows</family>
         </os>
       </activation>
-      <properties>
-        <moduleSelector>none</moduleSelector>
-      </properties>
       <modules>
         <!-- Ony Windows we only support boringssl-static -->
         <module>openssl-classes</module>
@@ -806,16 +802,28 @@
       </modules>
     </profile>
 
-    <!--
-      Profile for building all modules. This is enabled by default so if any profile is manually specified,
-      this will be disabled automatically.
-    -->
     <profile>
-      <id>all</id>
+      <id>linux-compile-all</id>
       <activation>
-        <property>
-          <name>!moduleSelector</name>
-        </property>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <modules>
+        <module>openssl-classes</module>
+        <module>openssl-dynamic</module>
+        <module>openssl-static</module>
+        <module>boringssl-static</module>
+        <module>libressl-static</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>osx-compile-all</id>
+      <activation>
+        <os>
+          <family>osx</family>
+        </os>
       </activation>
       <modules>
         <module>openssl-classes</module>


### PR DESCRIPTION
Motivation:

When on windows we should only try to build openssl-classesand boringssl-static as nothing else is supported atm

Modifications:

- Add profile for windows which configure the correct modules to use
- Adjust workflow for windows to depend on the new profile

Result:

./mvn clean package works on windows out of the box