### PR TITLE
SSL_CVERIFY_REQUIRED to follow API docs

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -50,6 +50,10 @@ final class NativeStaticallyReferencedJniMethods {
      */
     static native int sslOpNoCompression();
 
+    static native int sslVerifyNone();
+    static native int sslVerifyPeer();
+    static native int sslVerifyIfNoPeerCert();
+
     static native int sslSessCacheOff();
     static native int sslSessCacheServer();
     static native int sslSessCacheClient();

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -60,9 +60,13 @@ public final class SSL {
      * Define the SSL verify levels
      */
     public static final int SSL_CVERIFY_IGNORED            = -1;
-    public static final int SSL_CVERIFY_NONE               = 0;
-    public static final int SSL_CVERIFY_OPTIONAL           = 1;
-    public static final int SSL_CVERIFY_REQUIRED           = 2;
+    public static final int SSL_CVERIFY_NONE               = sslVerifyNone();
+    public static final int SSL_CVERIFY_OPTIONAL           = sslVerifyPeer();
+    /**
+     * <a href="https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify.html">This flag must be used together with
+     * SSL_VERIFY_PEER.</a>
+     */
+    public static final int SSL_CVERIFY_REQUIRED           = sslVerifyPeer() | sslVerifyIfNoPeerCert();
 
     public static final int SSL_OP_CIPHER_SERVER_PREFERENCE = sslOpCipherServerPreference();
     public static final int SSL_OP_NO_SSLv2 = sslOpNoSSLv2();

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -56,6 +56,18 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpNoCompressio
     return SSL_OP_NO_COMPRESSION;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyNone)(TCN_STDARGS) {
+    return SSL_VERIFY_NONE;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyPeer)(TCN_STDARGS) {
+    return SSL_VERIFY_PEER;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslVerifyIfNoPeerCert)(TCN_STDARGS) {
+    return SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+}
+
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslOpAllowUnsafeLegacyRenegotiation)(TCN_STDARGS) {
     return SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
 }
@@ -647,6 +659,9 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTLSv13, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoTicket, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpNoCompression, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslVerifyNone, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslVerifyPeer, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslVerifyIfNoPeerCert, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpAllowUnsafeLegacyRenegotiation, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslOpLegacyServerConnect, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSessCacheOff, ()I, NativeStaticallyReferencedJniMethods) },


### PR DESCRIPTION
Motivation:
The OpenSSL docs specify that the `SSL_VERIFY_FAIL_IF_NO_PEER_CERT` flag must be masked with `SSL_VERIFY_PEER`. Currently netty hard codes a value of `2` for required which is just the value of `SSL_VERIFY_FAIL_IF_NO_PEER_CERT`.

[1] https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify.html
> Server mode: if the client did not return a certificate, the TLS/SSL
handshake is immediately terminated with a "handshake failure" alert. This flag must be used together with SSL_VERIFY_PEER.