### PR TITLE
Upgrade to latest sha in chromium-stable branch

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,8 +1,8 @@
 FROM centos:6.10
 
 ENV SOURCE_DIR /root/source
-ENV CMAKE_VERSION_BASE 3.8
-ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
+ENV CMAKE_VERSION_BASE 3.26
+ENV CMAKE_VERSION $CMAKE_VERSION_BASE.4
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 ENV MAVEN_VERSION 3.9.1
@@ -24,6 +24,7 @@ RUN yum install -y \
  openssl-devel \
  patch \
  perl \
+ perl-parent \
  tar \
  unzip \
  wget \
@@ -34,7 +35,7 @@ WORKDIR $SOURCE_DIR
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
 RUN wget -q https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
-RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && tar zvxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-Linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH' >> ~/.bashrc
+RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zvxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 RUN yum install -y centos-release-scl
 # Update repository urls as we need to use the vault now.
@@ -45,6 +46,14 @@ RUN yum -y install devtoolset-7-gcc devtoolset-7-gcc-c++
 RUN echo 'source /opt/rh/devtoolset-7/enable' >> ~/.bashrc
 
 RUN rm -rf $SOURCE_DIR
+
+# Downloading and installing perlbrew as we need a more up to date perl version for boringssl
+# Use the same version as centos7 does.
+RUN curl -L https://install.perlbrew.pl | bash
+RUN echo 'source ~/perl5/perlbrew/etc/bashrc' >> ~/.bashrc
+
+RUN /root/perl5/perlbrew/bin/perlbrew install --thread --switch perl-5.16.3
+RUN ln -sf /root/perl5/perlbrew/perls/perl-5.16.3/bin/perl /usr/bin/perl
 
 # Downloading and installing SDKMAN!
 RUN curl -s "https://get.sdkman.io" | bash

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <!--
       See https://boringssl.googlesource.com/boringssl/+/refs/heads/chromium-stable for the latest commit
     -->
-    <boringsslCommitSha>1ccef4908ce04adc6d246262846f3cd8a111fa44</boringsslCommitSha>
+    <boringsslCommitSha>ca1690e221677cea3fb946f324eb89d846ec53f2</boringsslCommitSha>
     <libresslVersion>3.4.3</libresslVersion>
     <!--
       See https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/SHA256 for the SHA256 signature


### PR DESCRIPTION
Motivation:

We are using up-to-date sha.

Modifications:

Use sha ca1690e221677cea3fb946f324eb89d846ec53f2

Result:

Use latest commit of chromium-stable branch