### PR TITLE
Fix linux build for openssl-static

### DIFF
--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -387,7 +387,7 @@
                         <echo message="Building OpenSSL" />
                         <mkdir dir="${opensslHome}" />
                         <exec executable="config" failonerror="true" dir="${opensslSourceDir}" resolveexecutable="true">
-                          <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${opensslHome} --openssldir=${opensslHome}" />
+                          <arg line="-O3 -fno-omit-frame-pointer -fPIC no-ssl2 no-ssl3 no-shared no-comp -DOPENSSL_NO_HEARTBEATS --prefix=${opensslHome} --openssldir=${opensslHome} --libdir=lib" />
                         </exec>
                         <exec executable="make" failonerror="true" dir="${opensslSourceDir}" resolveexecutable="true">
                           <arg value="depend" />


### PR DESCRIPTION
It looks like https://github.com/netty/netty-tcnative/commit/0828ffc73499269bbc6ffd8bf5ad3c98b0a67b9d broke the build on linux (my apologies!).

The openssl build now puts the libraries into `/lib64` instead of `/lib` so the following steps wouldn't include the native code in the jar. This change asks the build to put it into the old location (similar to the Mac build, which is what I tested in the last PR).

I tested this on a linux machine and verified that the build is now ~similarly sized to before the previous commit (and that it works)