### PR TITLE
Update workflows to make things more robust when it comes to caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,6 +38,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -45,7 +46,7 @@ jobs:
             build-${{ matrix.setup }}-m2-repository-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: build-${{ matrix.setup }}-docker-cache-{hash}
@@ -97,6 +98,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -39,6 +39,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-snapshot-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -46,7 +47,7 @@ jobs:
             stage-snapshot-${{ matrix.setup }}-m2-repository-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
@@ -102,6 +103,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-snapshot-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -176,6 +178,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: deploy-staged-snapshot-m2-repository-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: pr-${{ matrix.setup }}-docker-cache-{hash}
@@ -43,6 +43,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-pr-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -93,6 +94,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: build-pr-windows-m2-repository-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -40,6 +40,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: prepare-release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -109,6 +110,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: stage-release-linux-${{ matrix.setup }}-m2-repository-cache-${{ hashFiles('**/pom.xml') }}
@@ -116,7 +118,7 @@ jobs:
             stage-release-linux-${{ matrix.setup }}-m2-repository-cache-
 
       # Enable caching of Docker layers
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         env:
           docker-cache-name: staging-${{ matrix.setup }}-cache-docker
         continue-on-error: true
@@ -214,6 +216,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: staging-release-cache-windows-m2-repository-${{ hashFiles('**/pom.xml') }}
@@ -313,6 +316,7 @@ jobs:
 
       # Cache .m2/repository
       - uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: ~/.m2/repository
           key: deploy-staged-release-cache-m2-repository-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,7 @@ jobs:
 
     # Cache .m2/repository
     - uses: actions/cache@v3
+      continue-on-error: true
       with:
         path: ~/.m2/repository
         key: analyze-${{ matrix.language }}-cache-m2-repository-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Motivation:

When caching fails during workflow execution we should still continue the build as its just an optimization. Also we should use the new fork for docker layer caching

Modifications:

- Update action that does the docker layer caching to the new fork
- Ignore errors during caching

Result:

More stable builds