### PR TITLE
Prevent classloader leak via JNI

### DIFF
--- a/openssl-dynamic/src/main/c/jnilib.c
+++ b/openssl-dynamic/src/main/c/jnilib.c
@@ -70,7 +70,7 @@ jstring tcn_new_stringn(JNIEnv *env, const char *str, size_t l)
     if (bytes != NULL) {
         (*env)->SetByteArrayRegion(env, bytes, 0, l, (jbyte *)str);
         result = (*env)->NewObject(env, jString_class, jString_init, bytes);
-        (*env)->DeleteLocalRef(env, bytes);
+        NETTY_JNI_UTIL_DELETE_LOCAL(env, bytes);
         return result;
     } /* else fall through */
     return NULL;

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1297,7 +1297,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
 
         // Delete the local reference as we not know how long the chain is and local references are otherwise
         // only freed once jni method returns.
-        (*e)->DeleteLocalRef(e, bArray);
+        NETTY_JNI_UTIL_DELETE_LOCAL(e, bArray);
     }
     return array;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.7.Final</jniUtilVersion>
+    <jniUtilVersion>0.0.9.Final</jniUtilVersion>
     <javaDefaultModuleName>io.netty.internal.tcnative</javaDefaultModuleName>
     <javaModuleName>${javaDefaultModuleName}</javaModuleName>
     <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>


### PR DESCRIPTION
Motivation:

We should use weak references to hold global references to our own classes as otherwise it will be not possible to unload the classloader.

Modifications:

Use weak references for the classes in JNI.

Result:

No more classloader leaks. Related to https://github.com/netty/netty/issues/13480