### PR TITLE
FIPS: Add pom profile to build fips compliant boringSSL netty-tcnative

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -88,7 +88,6 @@
         <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
         <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
         <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
-        <enableUnitTest>${run_fips_tests}</enableUnitTest>
         <jniArch>${os.detected.arch}</jniArch>
       </properties>
 
@@ -224,15 +223,6 @@
                             <!-- This is needed to generate bssl execute file to verify isfips property-->
                             <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
                             </exec>
-                            <!-- Test to verify is BoooringSSL build is FIPS complaint-->
-                            <if>
-                              <equals arg1="${enableUnitTest}" arg2="1"/>
-                              <then>
-                                <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
-                                  <arg value="run_fips_tests" />
-                                </exec>
-                              </then>
-                            </if>
                             <exec executable="./tool/bssl" failonerror="false" dir="${boringsslBuildDir}" outputproperty="boringssl.isfips.result">
                               <arg value="isfips" />
                             </exec>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -109,7 +109,7 @@
               </execution>
             </executions>
             <configuration>
-              <url>https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-853ca1ea1168dff08011e5d42d94609cc0ca2e27.tar.xz</url>
+              <url>https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-${boringsslBranch}.tar.xz</url>
               <unpack>true</unpack>
               <outputDirectory>${project.build.directory}/boringssl-${boringsslBranch}</outputDirectory>
             </configuration>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -75,6 +75,292 @@
   </dependencies>
 
   <profiles>
+
+    <!-- The profile that builds a fips-boringssl-static jar -->
+    <profile>
+      <id>fips-boringssl-static</id>
+      <properties>
+        <boringsslCheckoutDir>${project.build.directory}/boringssl-${boringsslBranch}/boringssl</boringsslCheckoutDir>
+        <boringsslBuildDir>${boringsslCheckoutDir}/build</boringsslBuildDir>
+        <!--   Latest FIPS compliant boringSSL commit   -->
+        <boringsslBranch>${env.BORINGSSL_COMMIT}</boringsslBranch>
+        <linkStatic>true</linkStatic>
+        <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
+        <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
+        <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
+        <enableUnitTest>${run_fips_tests}</enableUnitTest>
+        <jniArch>${os.detected.arch}</jniArch>
+      </properties>
+
+      <build>
+        <plugins>
+
+          <!-- Download the BoringSSL source -->
+          <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <executions>
+              <execution>
+                <id>install-fips-boringssl</id>
+                <phase>process-sources</phase>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <url>https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-853ca1ea1168dff08011e5d42d94609cc0ca2e27.tar.xz</url>
+              <unpack>true</unpack>
+              <outputDirectory>${project.build.directory}/boringssl-${boringsslBranch}</outputDirectory>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${generatedSourcesDir}/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Add the commit ID and branch to the manifest. -->
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+              <instructions>
+                <Apr-Version>${aprVersion}</Apr-Version>
+                <BoringSSL-Revision>${boringsslBuildNumber}</BoringSSL-Revision>
+                <BoringSSL-Branch>${boringsslBranch}</BoringSSL-Branch>
+              </instructions>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <!-- Build the BoringSSL static libs -->
+              <execution>
+                <id>build-boringssl</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                    <property environment="env" />
+                    <if>
+                      <available file="${boringsslBuildDir}" />
+                      <then>
+                        <echo message="BoringSSL was already build, skipping the build step." />
+                      </then>
+                      <else>
+                        <echo message="Building BoringSSL" />
+
+                        <mkdir dir="${boringsslBuildDir}" />
+
+                        <if>
+                          <equals arg1="${os.detected.name}" arg2="windows" />
+                          <then>
+                            <!-- On Windows, build with /MT for static linking -->
+                            <property name="cmakeAsmFlags" value="" />
+                            <property name="cmakeCFlags" value="/MT" />
+                            <!-- Disable one warning to be able to build on windows -->
+                            <property name="cmakeCxxFlags" value="/MT /wd4091" />
+                          </then>
+                          <elseif>
+                            <equals arg1="${os.detected.name}" arg2="linux" />
+                            <then>
+                              <!-- On *nix, add ASM flags to disable executable stack -->
+                              <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                              <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                              <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
+                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                            </then>
+                          </elseif>
+                          <else>
+                            <!-- On *nix, add ASM flags to disable executable stack -->
+                            <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
+                            <property name="cmakeCFlags" value="-std=c99 -O3 -fno-omit-frame-pointer" />
+                            <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
+                          </else>
+                        </if>
+                        <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_BUILD_TYPE=Release" />
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
+                          <arg value="-DCMAKE_C_COMPILER=clang" />
+                          <arg value="-DCMAKE_CXX_COMPILER=clang++" />
+                          <arg value="-DFIPS=1" />
+                          <arg value="-GNinja" />
+                          <arg value="${boringsslCheckoutDir}" />
+                        </exec>
+                        <if>
+                          <!-- may be called ninja-build or ninja -->
+                          <!-- See https://github.com/netty/netty-tcnative/issues/475 -->
+                          <available file="ninja-build" filepath="${env.PATH}" />
+                          <then>
+                            <property name="ninjaExecutable" value="ninja-build" />
+                          </then>
+                          <else>
+                            <property name="ninjaExecutable" value="ninja" />
+                          </else>
+                        </if>
+                        <if>
+                          <equals arg1="${os.detected.name}" arg2="linux" />
+                          <then>
+                            <!-- This is needed to generate bssl execute file to verify isfips property-->
+                            <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                            </exec>
+                            <!-- Test to verify is BoooringSSL build is FIPS complaint-->
+                            <if>
+                              <equals arg1="${enableUnitTest}" arg2="1"/>
+                              <then>
+                                <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                                  <arg value="run_fips_tests" />
+                                </exec>
+                              </then>
+                            </if>
+                            <exec executable="./tool/bssl" failonerror="false" dir="${boringsslBuildDir}" outputproperty="boringssl.isfips.result">
+                              <arg value="isfips" />
+                            </exec>
+                            <if>
+                              <equals arg1="${boringssl.isfips.result}" arg2="1"/>
+                              <then>
+                                <echo message="Boringssl is fips compliant" />
+                              </then>
+                            </if>
+                            <fail message="The boringssl is not fips">
+                              <condition>
+                                <not>
+                                  <equals arg1="${boringssl.isfips.result}" arg2="1"/>
+                                </not>
+                              </condition>
+                            </fail>
+                          </then>
+                          <else>
+                            <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true" />
+                          </else>
+                        </if>
+                      </else>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Add the ant tasks from ant-contrib -->
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                    <!-- Strip on linux. See https://github.com/netty/netty-tcnative/issues/129 -->
+                    <if>
+                      <and>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <equals arg1="${strip.skip}" arg2="false" />
+                      </and>
+                      <then>
+                        <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
+                          <arg value="--strip-debug" />
+                          <arg value="libnetty_tcnative.so" />
+                        </exec>
+                      </then>
+                    </if>
+
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
+                    </copy>
+
+                    <!-- linux / osx -->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="libnetty_tcnative.*" to="libnetty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+                    <!-- windows-->
+                    <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
+                      <fileset dir="${nativeJarWorkdir}/META-INF/native/" />
+                      <globmapper from="netty_tcnative.*" to="netty_tcnative_${os.detected.name}_${jniArch}.*" />
+                    </move>
+                    <!-- Copy license material for attribution-->
+                    <copy file="../NOTICE.txt" todir="${nativeJarWorkdir}/META-INF/" />
+                    <copy file="../LICENSE.txt" todir="${nativeJarWorkdir}/META-INF/" />
+                    <copy todir="${nativeJarWorkdir}/META-INF/license">
+                      <fileset dir="../license" />
+                    </copy>
+                    <!-- Append the Bundle-NativeCode section -->
+                    <manifest file="${nativeJarWorkdir}/META-INF/MANIFEST.MF" mode="update">
+                      <attribute name="Bundle-NativeCode" value="${tcnativeManifest}" />
+                    </manifest>
+
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <attachartifact file="${nativeJarFile}" classifier="${os.detected.classifier}" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Configure the distribution statically linked against OpenSSL and APR -->
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <name>netty_tcnative</name>
+                  <nativeSourceDirectory>${generatedSourcesDir}/c</nativeSourceDirectory>
+                  <customPackageDirectory>${generatedSourcesDir}/native-package</customPackageDirectory>
+                  <libDirectory>${nativeLibOnlyDir}</libDirectory>
+                  <forceAutogen>${forceAutogen}</forceAutogen>
+                  <forceConfigure>${forceConfigure}</forceConfigure>
+                  <windowsBuildTool>msbuild</windowsBuildTool>
+                  <!-- <verbose>true</verbose> -->
+                  <configureArgs>
+                    <configureArg>--with-ssl=no</configureArg>
+                    <configureArg>--with-apr=${aprHome}</configureArg>
+                    <configureArg>--with-static-libs</configureArg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
+                    <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
+                    <configureArg>LDFLAGS=-L${boringsslBuildDir}/ssl -L${boringsslBuildDir}/crypto -L${boringsslBuildDir}/decrepit -ldecrepit -lssl -lcrypto</configureArg>
+                  </configureArgs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- Default profile that builds a platform-specific jar -->
     <profile>
       <id>boringssl-static-default</id>
@@ -284,7 +570,7 @@
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
                       <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/\1" />
                     </copy>
-                    
+
                     <!-- linux / osx -->
                     <move todir="${nativeJarWorkdir}/META-INF/native/" flatten="true">
                       <fileset dir="${nativeJarWorkdir}/META-INF/native/" />

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -83,7 +83,7 @@
         <boringsslCheckoutDir>${project.build.directory}/boringssl-${boringsslBranch}/boringssl</boringsslCheckoutDir>
         <boringsslBuildDir>${boringsslCheckoutDir}/build</boringsslBuildDir>
         <!--   Latest FIPS compliant boringSSL commit   -->
-        <boringsslBranch>${env.BORINGSSL_COMMIT}</boringsslBranch>
+        <boringsslBranch>853ca1ea1168dff08011e5d42d94609cc0ca2e27</boringsslBranch>
         <linkStatic>true</linkStatic>
         <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
         <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>


### PR DESCRIPTION
### Motivation:
As discussed in [issue](https://github.com/netty/netty-tcnative/issues/799), considering the growing demand for FIPS compliance in security-sensitive environments, an official netty-tcnative release supporting FIPS validation would greatly benefit the open-source community. This would simplify integration and provide a reliable, community-supported solution.

### Setup Configurations:
Tools: cmake 3.20, ninja build 1.10.0, clang-12, golang, java 11, maven 3.6.3, libapr1, automake, autoconf, libtool, libunwind-dev, pkg-config

Fips validated BoringSSL commit used is 853ca1ea1168dff08011e5d42d94609cc0ca2e27

### Build Steps: 

- Run Maven 
```
 mvn clean install -f boringssl-static/pom.xml -Pfips-boringssl-static
```

- While build is running you should see in logs:
```
...
Boringssl is fips compliant
...
```
- After build steps are completed you should see Jars eg.
```
.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.61.Final/netty-tcnative-boringssl-static-2.0.61.Final.jar
.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.61.Final/netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
```

### Modifications:
- Added pom profile `fips-boringssl-static` for fips compliant


### Tested on: 
Tested on linux AMD and ARM machine, which are supported as per FIPS security document attached in reference.
Output: https://drive.google.com/file/d/1eAFUIrHLbB7xiTpxHPs__N3Ha_Ltli76/view?usp=sharing

### Reference: 
Guidance on how to build FIPS validated modules: https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf
