### PR TITLE
Upgrade maven-settings-action to latest version

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -176,7 +176,7 @@ jobs:
             deploy-stage-snapshot-m2-repository-cache-
 
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -117,7 +117,7 @@ jobs:
           restore-keys: |
             stage-release-linux-${{ matrix.setup }}-m2-repository-cache-
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{
@@ -213,7 +213,7 @@ jobs:
           restore-keys: |
             staging-release-cache-windows-m2-repository-
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{
@@ -314,7 +314,7 @@ jobs:
             deploy-staged-release-cache-m2-repository-
 
 
-      - uses: s4u/maven-settings-action@v2.2.0
+      - uses: s4u/maven-settings-action@v2.8.0
         with:
           servers: |
             [{


### PR DESCRIPTION
Motivation:

We should use the latest maven-settings-action to fix warnings

Modifications:

Update maven-settings-action to 2.8.0

Result:

No more warnings