### PR TITLE
Fix usage of ghaction-import-gpg

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -196,7 +196,7 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Install tools


### PR DESCRIPTION
Motivation:

The name of the config param changed when we updated the version

Modifications:

Use correct name

Result:

Release works again on windows