### PR TITLE
fix(boringssl): fix incorrect build profile for osx intel cross compile

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -1404,11 +1404,11 @@
         <cppflags>-target ${target} -DHAVE_OPENSSL -I${boringsslSourceDir}/include</cppflags>
         <ldflags>-arch x86_64 -L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
-        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-osx_x86_64.jar</nativeJarFile>
-        <nativeLibOsParts>${os.detected.name}_osx_x86_64</nativeLibOsParts>
-        <jniClassifier>${os.detected.name}-osx_x86_64</jniClassifier>
-        <jniArch>osx_64</jniArch>
-        <javaModuleNameClassifier>${os.detected.name}.osx_x86_64</javaModuleNameClassifier>
+        <nativeJarFile>${project.build.directory}/${project.build.finalName}-${os.detected.name}-x86_64.jar</nativeJarFile>
+        <nativeLibOsParts>${os.detected.name}_x86_64</nativeLibOsParts>
+        <jniClassifier>${os.detected.name}-x86_64</jniClassifier>
+        <jniArch>x86_64</jniArch>
+        <javaModuleNameClassifier>${os.detected.name}.x86_64</javaModuleNameClassifier>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Motivation:

boringssl-static profile `mac-intel-cross-compile` incorrectly sets arch resulting in `osx-osx-x86_64` build classifier.
It also wrongfully sets the native lib name to `libnetty_tcnative_osx_osx_64`, making `netty-handler` unable to find it

If the intention of this profile was to build cross platform (from linux to mac), then `os.detected.name` can be overridden to still produce the similar result.
```xml
<os.detected.name>osx</os.detected.name>
```

Modifications:
Adjust arch to `x86_64` in maven profile for boringssl static

Result:
`./mvn -Pmac-intel-cross-compile -am -pl boringssl-static clean package` builds correctly on an apple silicon system