### PR TITLE
Also add Specification-* entries to MANIFEST.MF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
               <archive>
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
                   <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>


### PR DESCRIPTION
Motivation:

Some tools depend on the Specification-* entries in the MANIFEST.MF. Unfortunaly
 we don't add these at the moment

Modifications:

Configure plugin to also add the Specification-* entries

Result:

MANIFEST.MF contains Specification-* entries