### PR TITLE
Return correct value from cert callback when no tasks are used

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2016,7 +2016,7 @@ static int certificate_cb(SSL* ssl, void* arg) {
         // Check if java threw an exception and if so signal back that we should not continue with the handshake.
         if ((*e)->ExceptionCheck(e) != JNI_TRUE) {
             // Everything good...
-            ret = -1;
+            ret = 1;
         }
     }
 


### PR DESCRIPTION
Motivation:

33b2338ce415be8d3d7cb0a9aab962d2456af3ee introduced a bug which lead to return the incorrect value when no tasks are used.

Modifications:

Correctly return 1 when succesful

Result:

Correctly signal back that the cert could be selected