### PR TITLE
Move logic for static cross-compile for linux-aarch64 to pom file.

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -837,38 +837,12 @@
 
                         <mkdir dir="${boringsslHome}" />
 
-                        <if>
-                          <equals arg1="${os.detected.name}" arg2="windows" />
-                          <then>
-                            <!-- On Windows, build with /MT for static linking -->
-                            <property name="cmakeAsmFlags" value="" />
-                            <property name="cmakeCFlags" value="/MT" />
-                            <!-- Disable one warning to be able to build on windows -->
-                            <property name="cmakeCxxFlags" value="/MT /wd4091" />
-                          </then>
-                          <elseif>
-                            <equals arg1="${os.detected.name}" arg2="linux" />
-                            <then>
-                              <!-- On *nix, add ASM flags to disable executable stack -->
-                              <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer" />
-                              <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
-                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
-                            </then>
-                          </elseif>
-                          <else>
-                            <!-- On *nix, add ASM flags to disable executable stack -->
-                            <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                            <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer" />
-                            <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
-                          </else>
-                        </if>
                         <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
-                          <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
-                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
+                          <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
+                          <arg value="-DCMAKE_C_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer" />
+                          <arg value="-DCMAKE_CXX_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
                           <arg value="-DCMAKE_SYSTEM_NAME=Linux" />
                           <arg value="-DCMAKE_SYSTEM_PROCESSOR=aarch64" />
                           <arg value="-DCMAKE_C_COMPILER=aarch64-none-linux-gnu-gcc" />

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -667,11 +667,12 @@
     </profile>
 
     <profile>
-      <id>linux-aarch64</id>
+      <id>linux-aarch64-cross-compile</id>
 
       <properties>
         <boringsslSourceDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslSourceDir>
         <boringsslHome>${boringsslSourceDir}/build</boringsslHome>
+        <crossCompile>linux</crossCompile>
         <linkStatic>true</linkStatic>
         <msvcSslIncludeDirs>${boringsslSourceDir}/include</msvcSslIncludeDirs>
         <msvcSslLibDirs>${boringsslHome}/ssl;${boringsslHome}/crypto</msvcSslLibDirs>
@@ -728,10 +729,6 @@
                       </files>
                       <content>release 7.6</content>
                     </requireFilesContent>
-                    <requireProperty>
-                      <property>aprArmHome</property>
-                      <message>The folder of APR for aarch64 must be specified by hand. Please try -DaprArmHome=</message>
-                    </requireProperty>
                   </rules>
                   <ignoreCache>true</ignoreCache>
                 </configuration>
@@ -984,7 +981,7 @@
                   <!-- <verbose>true</verbose> -->
                   <configureArgs>
                     <configureArg>--with-ssl=no</configureArg>
-                    <configureArg>--with-apr=${aprArmHome}</configureArg>
+                    <configureArg>--with-apr=${aprHome}</configureArg>
                     <configureArg>--with-static-libs</configureArg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
@@ -1178,7 +1175,7 @@
 
       <properties>
         <linkStatic>true</linkStatic>
-        <osxCrossCompile>true</osxCrossCompile>
+        <crossCompile>osx</crossCompile>
         <target>arm64-apple-macos11</target>
         <macOsxDeploymentTarget>OSX_DEPLOYMENT_TARGET=11.0</macOsxDeploymentTarget>
         <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0</cmakeOsxDeploymentTarget>
@@ -1425,7 +1422,7 @@
 
       <properties>
         <linkStatic>true</linkStatic>
-        <osxCrossCompile>true</osxCrossCompile>
+        <crossCompile>osx</crossCompile>
         <target>x86_64-apple-macos10.12</target>
         <macOsxDeploymentTarget>OSX_DEPLOYMENT_TARGET=10.12</macOsxDeploymentTarget>
         <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12</cmakeOsxDeploymentTarget>

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -40,7 +40,7 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw clean package -Plinux-aarch64 -am -pl openssl-dynamic  -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && ./mvnw clean package -Plinux-aarch64 -am -pl boringssl-static -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl -DskipTests"
+    command: /bin/bash -cl "./mvnw clean package -Plinux-aarch64-cross-compile -am -pl openssl-dynamic  -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && ./mvnw clean package -Plinux-aarch64-cross-compile -am -pl boringssl-static -DskipTests"
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
@@ -50,7 +50,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
-    command: /bin/bash -cl "./mvnw clean deploy -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && ./mvnw clean deploy -Plinux-aarch64 -am -pl boringssl-static -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl -DskipTests"
+    command: /bin/bash -cl "./mvnw clean deploy -Plinux-aarch64-cross-compile -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share -DskipTests && ./mvnw clean deploy -Plinux-aarch64-cross-compile -am -pl boringssl-static -DskipTests"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -60,7 +60,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true && ./mvnw -Plinux-aarch64 -am -pl boringssl-static -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64-cross-compile -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true && ./mvnw -Plinux-aarch64-cross-compile -am -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
@@ -70,5 +70,5 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} && ./mvnw -Plinux-aarch64 -am -pl boringssl-static -DaprArmHome=/opt/apr-$$APR_VERSION-static -DboringsslSourceDir=/root/workspace/boringssl-source -DboringsslHome=/root/workspace/boringssl clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -Plinux-aarch64-cross-compile -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} && ./mvnw -Plinux-aarch64-cross-compile -am -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -321,7 +321,7 @@
       </build>
     </profile>
     <profile>
-      <id>linux-aarch64</id>
+      <id>linux-aarch64-cross-compile</id>
 
       <properties>
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <aprSourceDir>${project.build.directory}/apr-source</aprSourceDir>
     <archBits>64</archBits>
     <linkStatic>false</linkStatic>
-    <osxCrossCompile>false</osxCrossCompile>
+    <crossCompile>false</crossCompile>
     <sslHome>${project.build.directory}/ssl</sslHome>
     <msvcSslIncludeDirs>${sslHome}/include</msvcSslIncludeDirs>
     <msvcSslLibDirs>${sslHome}/lib</msvcSslLibDirs>
@@ -699,7 +699,7 @@
                         <exec executable="buildconf" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
 
                         <if>
-                          <equals arg1="${osxCrossCompile}" arg2="true" />
+                          <equals arg1="${crossCompile}" arg2="osx" />
                           <then>
                             <!--
 +                             We need to set some extra variables as otherwise the configure of apr will fail when trying to cross-compile.
@@ -723,6 +723,32 @@
                               <arg line="install" />
                             </exec>
                           </then>
+                          <elseif>
+                            <equals arg1="${crossCompile}" arg2="linux" />
+                            <then>
+                              <!--
+  +                             We need to set some extra variables as otherwise the configure of apr will fail when trying to cross-compile.
+  +                             See https://stackoverflow.com/a/1605497/1074097
+  +                           -->
+                              <exec executable="configure" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                                <arg line="--disable-shared --prefix=${aprHome} CC=aarch64-none-linux-gnu-gcc CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' --host=aarch64-linux-gnu ac_cv_have_decl_sys_siglist=no ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8" />
+                              </exec>
+                              <!--
+                                Make will fail when it tries to use the gen_test_char program.
+                                We work around this by compile gen_test_char separate, execute and than rerun make.
+                                See https://stackoverflow.com/a/56262330/1074097
+                              -->
+                              <exec executable="make" failonerror="false" dir="${aprSourceDir}" resolveexecutable="true" />
+                              <exec executable="gcc" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                                <arg line="-Wall -O2 -DCROSS_COMPILE tools/gen_test_char.c -o tools/gen_test_char" />
+                              </exec>
+                              <exec executable="tools/gen_test_char" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" output="${aprSourceDir}/include/private/apr_escape_test_char.h" />
+                              <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
+                              <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
+                                <arg line="install" />
+                              </exec>
+                            </then>
+                          </elseif>
                           <else>
                             <exec executable="configure" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">
                               <!--


### PR DESCRIPTION
Motivation:

Let's try to keep logic together to make it easier to keep track of changes

Modifications:

Move logic for cross compile to pom file.

Result:

Easier to maintain