### PR TITLE
Add key log callback option to SSLContext

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/KeyLogCallback.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/KeyLogCallback.java
@@ -16,7 +16,7 @@
 package io.netty.internal.tcnative;
 
 /**
- * Callback hooked into <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/perl/c/include/openssl/ssl.h;l=912-923;drc=3618b14f3e00bf6053ec715ec04ef360d661b03a">SSL_CTX_set_keylog_callback</a>
+ * Callback hooked into <a href="https://github.com/google/boringssl/blob/master/include/openssl/ssl.h#L4379">SSL_CTX_set_keylog_callback</a>
  * This is intended for TLS debugging with tools like <a href="https://wiki.wireshark.org/TLS">Wireshark</a>.
  * For instance, a valid {@code SSLKEYLOGFILE} implementation could look like this:
  * <pre>{@code

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/KeyLogCallback.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/KeyLogCallback.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+/**
+ * Callback hooked into <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/perl/c/include/openssl/ssl.h;l=912-923;drc=3618b14f3e00bf6053ec715ec04ef360d661b03a">SSL_CTX_set_keylog_callback</a>
+ * This is intended for TLS debugging with tools like <a href="https://wiki.wireshark.org/TLS">Wireshark</a>.
+ * For instance, a valid {@code SSLKEYLOGFILE} implementation could look like this:
+ * <pre>{@code
+ *         final PrintStream out = new PrintStream("~/tls.sslkeylog_file");
+ *         SSLContext.setKeyLogCallback(ctxPtr, new KeyLogCallback() {
+ *             @Override
+ *             public void handle(long ssl, byte[] line) {
+ *                 out.println(new String(line));
+ *             }
+ *         });
+ * }</pre>
+ * <p>
+ * <strong>Warning:</strong> The log output will contain secret key material, and can be used to decrypt
+ * TLS sessions! The log output should be handled with the same care given to the private keys.
+ */
+public interface KeyLogCallback {
+    /**
+     * Called when a new key log line is emitted.
+     * <p>
+     * <strong>Warning:</strong> The log output will contain secret key material, and can be used to decrypt
+     * TLS sessions! The log output should be handled with the same care given to the private keys.
+     *
+     * @param ssl  the SSL instance
+     * @param line an array of the key types on client-mode or {@code null} on server-mode.
+     *
+     */
+    void handle(long ssl, byte[] line);
+}

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -534,6 +534,20 @@ public final class SSLContext {
      */
     public static native void setSniHostnameMatcher(long ctx, SniHostNameMatcher matcher);
 
+    /**
+     * Allow to hook {@link KeyLogCallback} into the debug infrastructor of the native TLS implementation.
+     * This will call {@code SSL_CTX_set_keylog_callback} and so replace the existing reference.
+     * This is intended for debugging use with tools like Wireshark.
+     * <p>
+     * <strong>Warning:</strong> The log output will contain secret key material, and can be used to decrypt
+     * TLS sessions! The log output should be handled with the same care given to the private keys.
+     * @param ctx Server or Client context to use.
+     * @param callback the callback to call when delivering debug output.
+     * @return {@code true} if the key-log callback was assigned,
+     * otherwise {@code false} if key-log callbacks are not supported.
+     */
+    public static native boolean setKeyLogCallback(long ctx, KeyLogCallback callback);
+
     private static byte[] protocolsToWireFormat(String[] protocols) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -350,6 +350,9 @@ struct tcn_ssl_ctxt_t {
     jobject                  ssl_cert_compression_zstd_algorithm;
     jmethodID                ssl_cert_compression_zstd_compress_method;
     jmethodID                ssl_cert_compression_zstd_decompress_method;
+
+    jobject                  keylog_callback;
+    jmethodID                keylog_callback_method;
 #endif // OPENSSL_IS_BORINGSSL
 
     tcn_ssl_verify_config_t  verify_config;

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2552,7 +2552,7 @@ static void keylog_cb(const SSL* ssl, const char *line) {
 
     JNIEnv *e = NULL;
     if (tcn_get_java_env(&e) != JNI_OK) {
-        // There's nothing we cna do with the JNIEnv*.
+        // There's nothing we can do with the JNIEnv*.
         return;
     }
 


### PR DESCRIPTION
Motivation:
Wireshark can decrypt TLS sessions during packet capture, if the session keys (etc.) are available from an SSL key log file. This log file format has become a de facto industry standard, and BoringSSL (and maybe the others too, didn't check) has a callback mechanism for delivering log lines in this format.

Modification:
Add `KeyLogCallback` interface and an `SSLContext.setKeyLogCallback` method, which integrators can easily implement the SSLKEYLOGFILE feature, or equivalent, on top of.

Result:
It is now possible to configure netty-tcnative in a way that TLS sessions can be decrypted at packet-capture time by Wireshark, making it easier to investigate and debug problems with TLS.