### PR TITLE
Deprecate bioSetFd and make it a no op

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -222,12 +222,15 @@ public final class SSL {
     public static native long bioNewByteBuffer(long ssl, int nonApplicationBufferSize);
 
     /**
-     * Sets the socket file descriptor of the rbio field inside the SSL struct (ssl->rbio->num)
+     * Sets the socket file descriptor
      *
      * @param ssl the SSL instance (SSL *)
      * @param fd the file descriptor of the socket used for the given SSL connection
+     *
+     * @deprecated This is not supported official by OpenSSL or BoringSSL so its just a no op.
      */
-     public static native void bioSetFd(long ssl, int fd);
+    @Deprecated
+    public static native void bioSetFd(long ssl, int fd);
 
     /**
      * Set the memory location which that OpenSSL's internal BIO will use to write encrypted data to, or read encrypted

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -345,9 +345,7 @@ static long bio_java_bytebuffer_ctrl(BIO* bio, int cmd, long num, void* ptr) {
         case BIO_CTRL_FLUSH:
             return 1;
         case BIO_C_SET_FD:
-#if defined(OPENSSL_IS_BORINGSSL) || defined(LIBRESSL_VERSION_NUMBER)
-            bio->num = *((int *)ptr);
-#endif
+            // Make this a no op.
             return 1;
         default:
             return 0;
@@ -400,14 +398,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
 TCN_IMPLEMENT_CALL(void, SSL, bioSetFd)(TCN_STDARGS, jlong ssl, jint fd) {
     SSL *ssl_ = J2P(ssl, SSL *);
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
-
-    BIO* bio = SSL_get_rbio(ssl_);
-
-    // We do not want the fd to be closed
-    int rc = BIO_set_fd(bio, fd, 0);
-    if (rc != 1) {
-        tcn_ThrowException(e, "Failed to set BIO fd");
-    }
+    // no op.
 }
 
 TCN_IMPLEMENT_CALL(jint, SSL, bioLengthByteBuffer)(TCN_STDARGS, jlong bioAddress) {


### PR DESCRIPTION
Motivation:

As explained by @davidben this is not something that should be supported and it might break any time.

Modifications:

Make the method a no op and deprecate it

Result:

Fixes https://github.com/netty/netty-tcnative/issues/864