### PR TITLE
Add missing NULL checks

### DIFF
--- a/openssl-dynamic/src/main/c/cert_compress.c
+++ b/openssl-dynamic/src/main/c/cert_compress.c
@@ -54,6 +54,9 @@ static int compress(jobject compression_algorithm, jmethodID compress_method, SS
         return 0; // Unable to reserve space for compressed data
     }
     jbyte* resultData = (*e)->GetByteArrayElements(e, resultArray, NULL);
+    if (resultData == NULL) {
+        return 0;
+    }
     memcpy(outData, resultData, resultLen);
     (*e)->ReleaseByteArrayElements(e, resultArray, resultData, JNI_ABORT);
     if (!CBB_did_write(out, resultLen)) {
@@ -102,6 +105,9 @@ static int decompress(jobject compression_algorithm, jmethodID decompress_method
         return 0; // Unable to allocate certificate decompression buffer
     }
     jbyte* resultData = (*e)->GetByteArrayElements(e, resultArray, NULL);
+    if (resultData == NULL) {
+        return 0;
+    }
     memcpy(outData, resultData, uncompressed_len);
     (*e)->ReleaseByteArrayElements(e, resultArray, resultData, JNI_ABORT);
     return 1; // Success

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1849,7 +1849,6 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getSessionId)(TCN_STDARGS, jlong ssl)
         return NULL;
     }
 
-
     if ((bArray = (*e)->NewByteArray(e, len)) == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Motivation:

We didn't have all the necessary NULL checks in place which could cause a segfault when an operation failed in native code due an OOME (for example).

Modifications:

Add missing NULL checks

Result:

Correctly handle error scenarios