### PR TITLE
Use --release 8 during compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,9 @@
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <checkstyle.skip>true</checkstyle.skip>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <netty.build.version>31</netty.build.version>
     <junit.version>5.9.0</junit.version>
     <animal.sniffer.skip>true</animal.sniffer.skip>
@@ -224,10 +225,11 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.13.0</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
+          <release>${maven.compiler.release}</release>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Motivation:

We should use --release 8 during compilation to ensure we always end up with the correct java version that is required.

Modifications:

- Upgrade compiler plugin so the release flag is only used when compiling with java9+
- Specify release flag
- Fix source and target version as we already use JDK8 classes in the code.

Result:

Always end up with the correct bytecode