### PR TITLE
Update java versions to latest release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "8.0.402-zulu"
+        java_version : "8.0.412-zulu"
 
   build:
     image: netty-tcnative-centos:centos-6-1.8

--- a/docker/docker-compose.debian-7.18.yaml
+++ b/docker/docker-compose.debian-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         debian_version : "7"
-        java_version : "8.0.402-zulu"
+        java_version : "8.0.412-zulu"
 
   deploy-dynamic-only:
     image: netty-tcnative-debian:debian-7-1.8


### PR DESCRIPTION
Motivation:

The used java versions in our docker-compose file were outdated

Modifications:

Update all versions to latest release

Result:

Use latest versions on CI