### PR TITLE
Replace usage of mirrorlist with baseurl

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -8,6 +8,8 @@ ENV GCC_VERSION $gcc_version
 ENV OPENSSL_VERSION $openssl_version
 ENV MAVEN_VERSION 3.9.1
 ENV APR_VERSION $apr_version
+ENV CMAKE_VERSION_BASE 3.26
+ENV CMAKE_VERSION $CMAKE_VERSION_BASE.4
 
 RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
@@ -33,9 +35,6 @@ RUN set -x && \
   tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
   mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /
 ENV PATH="/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
-
-# Install CMake
-RUN yum install -y cmake3 && ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 # Cross compile Apache Apr for aarch64 - static
 RUN set -x && \
@@ -71,6 +70,9 @@ RUN set -x && \
   ./Configure linux-aarch64 --cross-compile-prefix=aarch64-none-linux-gnu- --prefix=/opt/openssl-$OPENSSL_VERSION-share shared && \
   make && make install && \
   popd
+
+# Install cmake
+RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zvxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Downloading and installing SDKMAN!
 RUN curl -s "https://get.sdkman.io" | bash


### PR DESCRIPTION
Motivation:

We can't use the default mirrorlist anymore as it will fail and so fail the docker build

Modifications:

Use baseurl with the correct vault

Result:

Docker image can be build again