### PR TITLE
Declarative JPMS descriptors

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -63,7 +63,7 @@
     <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>${javaModuleNameNative}</javaModuleName>
+    <javaModuleName>${javaDefaultModuleName}</javaModuleName>
   </properties>
 
   <dependencies>
@@ -277,7 +277,7 @@
                     </if>
 
                     <copy todir="${nativeJarWorkdir}">
-                      <zipfileset src="${defaultJarFile}" />
+                      <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
                     <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
@@ -555,7 +555,7 @@
                     </if>
 
                     <copy todir="${nativeJarWorkdir}">
-                      <zipfileset src="${defaultJarFile}" />
+                      <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
                     <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
@@ -890,7 +890,7 @@
                     </if>
 
                     <copy todir="${nativeJarWorkdir}">
-                      <zipfileset src="${defaultJarFile}" />
+                      <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
                     <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
@@ -1309,7 +1309,7 @@
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
                     <copy todir="${nativeJarWorkdir}">
-                      <zipfileset src="${defaultJarFile}" />
+                      <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
                     <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />
@@ -1556,7 +1556,7 @@
                     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
                     <copy todir="${nativeJarWorkdir}">
-                      <zipfileset src="${defaultJarFile}" />
+                      <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
                     <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                       <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />

--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -40,7 +40,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>${javaModuleNameNative}</javaModuleName>
+    <javaModuleName>${javaDefaultModuleName}</javaModuleName>
   </properties>
 
   <build>
@@ -112,7 +112,7 @@
             <configuration>
               <target>
                 <copy todir="${nativeJarWorkdir}">
-                  <zipfileset src="${defaultJarFile}" />
+                  <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                 </copy>
                 <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />

--- a/openssl-classes/src/main/java/module-info.yml
+++ b/openssl-classes/src/main/java/module-info.yml
@@ -1,0 +1,2 @@
+exports:
+  - package: io.netty.internal.tcnative

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -36,7 +36,7 @@
     <nativeSourceDirectory />
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>${javaModuleNameNative}</javaModuleName>
+    <javaModuleName>${javaDefaultModuleName}</javaModuleName>
   </properties>
 
   <build>
@@ -77,7 +77,7 @@
             <configuration>
               <target>
                 <copy todir="${nativeJarWorkdir}">
-                  <zipfileset src="${defaultJarFile}" />
+                  <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                 </copy>
                 <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />

--- a/openssl-static/pom.xml
+++ b/openssl-static/pom.xml
@@ -39,7 +39,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
-    <javaModuleName>${javaModuleNameNative}</javaModuleName>
+    <javaModuleName>${javaDefaultModuleName}</javaModuleName>
   </properties>
 
   <build>
@@ -109,7 +109,7 @@
             <configuration>
               <target>
                 <copy todir="${nativeJarWorkdir}">
-                  <zipfileset src="${defaultJarFile}" />
+                  <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                 </copy>
                 <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
                   <zipfileset dir="${nativeLibOnlyDir}/META-INF/native" />

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,36 @@
       </plugin>
 
       <plugin>
+        <groupId>io.github.dmlloyd.module-info</groupId>
+        <artifactId>module-info</artifactId>
+        <version>2.1</version>
+        <executions>
+          <execution>
+            <id>default-jar-module-info</id>
+            <phase>process-classes</phase>
+            <configuration>
+              <moduleName>${javaModuleName}</moduleName>
+              <outputDirectory>${project.build.outputDirectory}/META-INF/versions/11/</outputDirectory>
+            </configuration>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>native-jar-module-info</id>
+            <phase>process-classes</phase>
+            <configuration>
+              <moduleName>${javaModuleNameNative}</moduleName>
+              <outputDirectory>${nativeJarWorkdir}//META-INF/versions/11/</outputDirectory>
+            </configuration>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration combine.self="override">
@@ -439,7 +469,7 @@
                   <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
-                  <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                  <Multi-Release>true</Multi-Release>
                 </manifestEntries>
                 <index>true</index>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
tcnative should provide declarative modules for the set of its artifacts.
    
This is a preliminary contribution that will enable the support of declarative JPMS descriptors for Netty 4.2 branch.

Generated artifacts are multi release jar to remain compatible with Java 8.

This has been tested with `netty-tcnative-openssl-static` on my arm64 mac with a jlink generated image.
