### PR TITLE
Upload hidden files for staging

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -61,7 +61,7 @@ jobs:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
           if-no-files-found: error
-
+          include-hidden-files: true
 
   stage-snapshot-windows:
     runs-on: windows-2019
@@ -109,6 +109,7 @@ jobs:
           name: windows-x86_64-local-staging
           path: boringssl-static/local-staging
           if-no-files-found: error
+          include-hidden-files: true
 
   deploy-staged-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           name: prepare-release-workspace
           path: ${{ github.workspace }}/**
+          include-hidden-files: true
 
   stage-release-linux:
     runs-on: ubuntu-latest
@@ -147,6 +148,7 @@ jobs:
           name: ${{ matrix.setup }}-local-staging
           path: ~/local-staging
           if-no-files-found: error
+          include-hidden-files: true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/
@@ -232,6 +234,7 @@ jobs:
           name: windows-x86_64-local-staging
           path: prepare-release-workspace/boringssl-static/local-staging
           if-no-files-found: error
+          include-hidden-files: true
 
       - name: Rollback release on failure
         working-directory: prepare-release-workspace


### PR DESCRIPTION
Motivation:

Due a change in the upload action of github we now need to explicit enable the uplaod of hidden files (dot-files). Not doing this breaks our staging workflow which depends on some of these files.

See https://github.com/actions/upload-artifact/issues/602

Modifications:

Explicit set include-hidden-files: true

Result:

Staging works again