### PR TITLE
Cleanup build for boringssl

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -524,7 +524,7 @@
                         <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_ASM_FLAGS_RELEASE=${cmakeAsmFlags}" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
                           <arg value="${cmakeOsxDeploymentTarget}" />
@@ -546,9 +546,8 @@
                           <equals arg1="${os.detected.name}" arg2="linux" />
                           <then>
                             <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
-                              <arg value="crypto/libcrypto.a" />
-                              <arg value="crypto/fipsmodule/fipsmodule" />
-                              <arg value="ssl/libssl.a" />
+                              <arg value="crypto" />
+                              <arg value="ssl" />
                             </exec>
                           </then>
                           <else>
@@ -869,7 +868,7 @@
                         <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_ASM_FLAGS_RELEASE=${cmakeAsmFlags}" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
                           <arg value="-DCMAKE_SYSTEM_NAME=Linux" />
@@ -1302,7 +1301,7 @@
                         <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_ASM_FLAGS_RELEASE=${cmakeAsmFlags}" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
                           <arg value="-DCMAKE_SYSTEM_PROCESSOR=arm64" />
@@ -1549,7 +1548,7 @@
                         <exec executable="cmake" failonerror="true" dir="${boringsslHome}" resolveexecutable="true">
                           <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
-                          <arg value="-DCMAKE_ASM_FLAGS=${cmakeAsmFlags}" />
+                          <arg value="-DCMAKE_ASM_FLAGS_RELEASE=${cmakeAsmFlags}" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=${cmakeCFlags}" />
                           <arg value="-DCMAKE_CXX_FLAGS_RELEASE=${cmakeCxxFlags}" />
                           <arg value="-DCMAKE_SYSTEM_PROCESSOR=x86_64" />

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -45,8 +45,8 @@ RUN yum install -y centos-release-scl
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^# baseurl=http:\/\/mirror.centos.org\/centos\/6\//baseurl=https:\/\/vault.centos.org\/centos\/6\//g' /etc/yum.repos.d/CentOS-SCLo-scl.repo
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/6\//baseurl=https:\/\/vault.centos.org\/centos\/6\//g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
-RUN yum -y install devtoolset-7-gcc devtoolset-7-gcc-c++
-RUN echo 'source /opt/rh/devtoolset-7/enable' >> ~/.bashrc
+RUN yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++
+RUN echo 'source /opt/rh/devtoolset-9/enable' >> ~/.bashrc
 
 RUN rm -rf $SOURCE_DIR
 


### PR DESCRIPTION
Motivation:

We did not correctly specify the ASM flags to apply

Modifications:

- Use correct CMAKE flag for ASM
- Update to devtools-9
- Correctly specify boringssl targets to compile

Result:

Cleanup