### PR TITLE
Use MACOSX_DEPLOYMENT_TARGET=10.13 when compiling BoringSSL

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -97,6 +97,9 @@
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
     <javaModuleName>${javaDefaultModuleName}</javaModuleName>
+    <!-- 10.13 is the minimum required by BoringSSL -->
+    <macOsxDeploymentTarget>MACOSX_DEPLOYMENT_TARGET=10.13</macOsxDeploymentTarget>
+    <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13</cmakeOsxDeploymentTarget>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Motivation:
We need to use MACOSX_DEPLOYMENT_TARGET=10.13 when compiling BoringSSL as its the minimum as of today

Modifications:

Set MACOSX_DEPLOYMENT_TARGET=10.13

Result:

Be able to build on macOS