### PR TITLE
Fix BoringSSL artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,6 @@
 # Mac-specific directory that no other operating system needs.
 .DS_Store
 
-# Do not include stuff in the static modules as this is generated during the build
-*-static/src
-
 # exclude mainframer files
 mainframer
 .mainframer

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -93,7 +93,7 @@
     <msvcSslLibs>ssl.lib;crypto.lib</msvcSslLibs>
     <cflags>-Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3</cflags>
     <cppflags>-DHAVE_OPENSSL -I${boringsslSourceDir}/include</cppflags>
-    <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</ldflags>
+    <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto -static-libstdc++ -l:libstdc++.a</ldflags>
     <skipJapicmp>true</skipJapicmp>
     <!-- We need to use the same module name for all our "native" impls as only one should be loaded -->
     <javaModuleName>${javaDefaultModuleName}</javaModuleName>
@@ -991,7 +991,7 @@
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslSourceDir}/include</configureArg>
-                    <configureArg>LDFLAGS=-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto</configureArg>
+                    <configureArg>LDFLAGS=-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto -static-libstdc++ -l:libstdc++.a</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>
                     <configureArg>CC=aarch64-none-linux-gnu-gcc</configureArg>
                   </configureArgs>
@@ -1675,7 +1675,7 @@
         <!-- We do not use an -O flag to ensure we have all functions in the stack when a leak is reported later on -->
         <cflags>-Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -fsanitize=address</cflags>
         <cppflags>-DHAVE_OPENSSL -I${boringsslSourceDir}/include -fsanitize=address</cppflags>
-        <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto -fsanitize=address</ldflags>
+        <ldflags>-L${boringsslHome}/ssl -L${boringsslHome}/crypto -lssl -lcrypto -static-libstdc++ -l:libstdc++.a -fsanitize=address</ldflags>
       </properties>
     </profile>
   </profiles>

--- a/boringssl-static/src/test/java/io/netty/internal/tcnative/NativeTest.java
+++ b/boringssl-static/src/test/java/io/netty/internal/tcnative/NativeTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.internal.tcnative;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+public class NativeTest {
+
+    @Test
+    public void loadNativeLib() throws Exception {
+        String testClassesRoot =  NativeTest.class.getProtectionDomain().getCodeSource().getLocation().getFile();
+        File[] directories = new File(testClassesRoot + File.separator + "META-INF" + File.separator + "native")
+                .listFiles();
+        if (directories == null || directories.length != 1) {
+            throw new IllegalStateException("Could not find platform specific native directory");
+        }
+        String libName = System.mapLibraryName("netty_tcnative")
+                // Fix the filename (this is needed for macOS).
+                .replace(".dylib", ".jnilib");
+        String libPath = directories[0].getAbsoluteFile() + File.separator + libName;
+        System.load(libPath);
+    }
+}


### PR DESCRIPTION
Motivation:

We did end up with a BoringSSL artifact that could not load the native lib

Modifications:

-Add test that validates that the native lib can be loaded for BoringSSL

Result:

Correctly be able to use BoringSSL again