### PR TITLE
Explicit specify the platform for Docker files

### DIFF
--- a/docker/Dockerfile.arch
+++ b/docker/Dockerfile.arch
@@ -1,4 +1,4 @@
-FROM archlinux/base
+FROM --platform=linux/amd64 archlinux/base
 
 ARG java_version=8
 ENV JAVA_VERSION $java_version

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -1,4 +1,4 @@
-FROM centos:6.10
+FROM --platform=linux/amd64 centos:6.10
 
 ENV SOURCE_DIR /root/source
 ENV CMAKE_VERSION_BASE 3.26

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,4 +1,4 @@
-FROM centos:7.6.1810
+FROM --platform=linux/amd64 centos:7.6.1810
 
 ARG gcc_version=10.2-2020.11
 ARG openssl_version=1_1_1d

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,5 +1,5 @@
 ARG debian_version=7
-FROM debian:$debian_version
+FROM --platform=linux/amd64 debian:$debian_version
 # needed to do again after FROM due to docker limitation
 ARG debian_version
 

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -1,5 +1,5 @@
 ARG opensuse_version=15.1
-FROM opensuse/leap:$opensuse_version
+FROM --platform=linux/amd64 opensuse/leap:$opensuse_version
 # needed to do again after FROM due to docker limitation
 ARG opensuse_version
 


### PR DESCRIPTION
Motivation:

We should explicit specify the platform we use for docker to ensure our build produce the correct artifacts

Modifications:

Add --platform=linux/amd64 to docker files

Result:

Ensure build produces correct artifacts