### PR TITLE
Force installation of perlbrew

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -55,7 +55,7 @@ RUN rm -rf $SOURCE_DIR
 RUN curl -L https://install.perlbrew.pl | bash
 RUN echo 'source ~/perl5/perlbrew/etc/bashrc' >> ~/.bashrc
 
-RUN /root/perl5/perlbrew/bin/perlbrew install --notest  --thread --switch perl-5.16.3
+RUN /root/perl5/perlbrew/bin/perlbrew install --notest --force --thread --switch perl-5.16.3
 RUN ln -sf /root/perl5/perlbrew/perls/perl-5.16.3/bin/perl /usr/bin/perl
 
 # Downloading and installing SDKMAN!

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -27,6 +27,7 @@ RUN yum install -y \
  patch \
  perl \
  perl-parent \
+ perl-devel \
  tar \
  unzip \
  wget \

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -55,8 +55,8 @@ RUN rm -rf $SOURCE_DIR
 RUN curl -L https://install.perlbrew.pl | bash
 RUN echo 'source ~/perl5/perlbrew/etc/bashrc' >> ~/.bashrc
 
-RUN /root/perl5/perlbrew/bin/perlbrew install --notest --force --thread --switch perl-5.16.3
-RUN ln -sf /root/perl5/perlbrew/perls/perl-5.16.3/bin/perl /usr/bin/perl
+RUN /root/perl5/perlbrew/bin/perlbrew install --notest --force --thread --switch perl-5.40.1
+RUN ln -sf /root/perl5/perlbrew/perls/perl-5.40.1/bin/perl /usr/bin/perl
 
 # Downloading and installing SDKMAN!
 RUN curl -s "https://get.sdkman.io" | bash

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -55,6 +55,7 @@ RUN rm -rf $SOURCE_DIR
 RUN curl -L https://install.perlbrew.pl | bash
 RUN echo 'source ~/perl5/perlbrew/etc/bashrc' >> ~/.bashrc
 
+RUN /root/perl5/perlbrew/bin/perlbrew install-patchperl
 RUN /root/perl5/perlbrew/bin/perlbrew install --notest --force --thread --switch perl-5.40.1
 RUN ln -sf /root/perl5/perlbrew/perls/perl-5.40.1/bin/perl /usr/bin/perl
 


### PR DESCRIPTION
Motivation:

We need to force the installation of perlbrew otherwise the docker image generation might fail

Modifications:

Add --force

Result:

Docker image can be build again