### PR TITLE
Use boringssl master in boringssl-static subproject

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -85,7 +85,7 @@
     <boringsslHome>${boringsslSourceDir}/build</boringsslHome>
     <boringsslSourceDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslSourceDir>
     <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
-    <boringsslBranch>chromium-stable</boringsslBranch>
+    <boringsslBranch>master</boringsslBranch>
     <linkStatic>true</linkStatic>
     <compileLibrary>true</compileLibrary>
     <msvcSslIncludeDirs>${boringsslSourceDir}/include</msvcSslIncludeDirs>


### PR DESCRIPTION
Motivation:
This branch is already specified in the top-level project. However, when the stable branch is specified in the boringssl-static subproject, I get the stable branch when I build locally. Making the change in both places ensures there's no confusion in the build system.

Modification:
Change the `boringsslBranch` property to `master` in the boringssl-static subproject.

Result:
Local, CI, and all other builds always use the master-branch version of boringssl.