### PR TITLE
Add method to allow to set curves / groups per SSL instance

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -566,7 +566,7 @@ public final class SSL {
     /**
      * Sets the curves to use.
      *
-     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_set1_curves_list.html">SSL_set1_curves_list</a>.
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_set1_curves_list.html">SSL_set1_curves_list</a>.
      * @param ssl the SSL instance (SSL *)
      * @param curves the curves to use.
      * @return {@code true} if successful, {@code false} otherwise.
@@ -593,7 +593,7 @@ public final class SSL {
     /**
      * Sets the curves to use.
      *
-     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_set1_curves.html">SSL_set1_curves</a>.
+     * See <a href="https://www.openssl.org/docs/man1.1.1/man3/SSL_set1_curves.html">SSL_set1_curves</a>.
      * @param ssl the SSL instance (SSL *)
      * @param curves the curves to use.
      * @return {@code true} if successful, {@code false} otherwise.

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -562,6 +562,53 @@ public final class SSL {
      */
     public static native boolean setCipherSuites(long ssl, String ciphers, boolean tlsv13)
             throws Exception;
+
+    /**
+     * Sets the curves to use.
+     *
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_set1_curves_list.html">SSL_set1_curves_list</a>.
+     * @param ssl the SSL instance (SSL *)
+     * @param curves the curves to use.
+     * @return {@code true} if successful, {@code false} otherwise.
+     */
+    public static boolean setCurvesList(long ssl, String... curves) {
+        if (curves == null) {
+            throw new NullPointerException("curves");
+        }
+        if (curves.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String curve: curves) {
+            sb.append(curve);
+            // Curves are separated by : as explained in the manpage.
+            sb.append(':');
+        }
+        sb.setLength(sb.length() - 1);
+        return setCurvesList0(ssl, sb.toString());
+    }
+
+    private static native boolean setCurvesList0(long ctx, String curves);
+
+    /**
+     * Sets the curves to use.
+     *
+     * See <a href="https://www.openssl.org/docs/man1.1.0/man3/SSL_set1_curves.html">SSL_set1_curves</a>.
+     * @param ssl the SSL instance (SSL *)
+     * @param curves the curves to use.
+     * @return {@code true} if successful, {@code false} otherwise.
+     */
+    public static boolean setCurves(long ssl, int[] curves) {
+        if (curves == null) {
+            throw new NullPointerException("curves");
+        }
+        if (curves.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        return setCurves0(ssl, curves);
+    }
+    private static native boolean setCurves0(long ctx, int[] curves);
+
     /**
      * Returns the ID of the session as byte array representation.
      *

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1636,6 +1636,36 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
     return array;
 }
 
+TCN_IMPLEMENT_CALL(jboolean, SSL, setCurvesList0)(TCN_STDARGS, jlong ssl, jstring curves) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    TCN_CHECK_NULL(ssl_, ssl, JNI_FALSE);
+
+    if (curves == NULL) {
+        return JNI_FALSE;
+    }
+    const char *nativeString = (*e)->GetStringUTFChars(e, curves, 0);
+    int ret = tcn_SSL_set1_curves_list(ssl_, nativeString);
+    (*e)->ReleaseStringUTFChars(e, curves, nativeString);
+
+    return ret == 1 ? JNI_TRUE : JNI_FALSE;
+}
+
+TCN_IMPLEMENT_CALL(jboolean, SSL, setCurves0)(TCN_STDARGS, jlong ssl, jintArray curves) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    TCN_CHECK_NULL(ssl_, ssl, JNI_FALSE);
+
+    if (curves == NULL) {
+        return JNI_FALSE;
+    }
+    int len = (*e)->GetArrayLength(e, curves);
+    jint *nativeCurves = (*e)->GetIntArrayElements(e, curves, NULL);
+    int ret = tcn_SSL_set1_curves(ssl_, (int *) nativeCurves, len);
+    (*e)->ReleaseIntArrayElements(e, curves, nativeCurves, JNI_ABORT);
+    return ret == 1 ? JNI_TRUE : JNI_FALSE;
+}
+
 TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
                                                          jstring ciphers, jboolean tlsv13)
 {
@@ -2681,6 +2711,8 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(getMaxWrapOverhead, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getCiphers, (J)[Ljava/lang/String;, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setCipherSuites, (JLjava/lang/String;Z)Z, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setCurvesList0, (JLjava/lang/String;)Z, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(setCurves0, (J[I)Z, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getSessionId, (J)[B, SSL) },
   { TCN_METHOD_TABLE_ENTRY(getHandshakeCount, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(clearError, ()V, SSL) },

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -503,11 +503,18 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 
 #ifdef OPENSSL_IS_BORINGSSL
 #define tcn_SSL_CTX_set1_curves_list(ctx, s) SSL_CTX_set1_curves_list(ctx, s)
+#define tcn_SSL_set1_curves_list(ssl, s) SSL_set1_curves_list(ssl, s)
+#define tcn_SSL_set1_curves(ssl, clist, clistlen) SSL_set1_curves(ssl, clist, clistlen)
 #else
 #ifndef SSL_CTRL_SET_GROUPS_LIST
 #define SSL_CTRL_SET_GROUPS_LIST                92
 #endif // SSL_CTRL_SET_GROUPS_LIST
+#ifndef SSL_CTRL_SET_GROUPS
+#define SSL_CTRL_SET_GROUPS                     91
+#endif // SSL_CTRL_SET_GROUPS
 #define tcn_SSL_CTX_set1_curves_list(ctx, s) SSL_CTX_ctrl(ctx, SSL_CTRL_SET_GROUPS_LIST, 0, (char *)(s))
+#define tcn_SSL_set1_curves_list(s, str) SSL_ctrl(s, SSL_CTRL_SET_GROUPS_LIST, 0, (char *)(str))
+#define tcn_SSL_set1_curves(s, glist, glistlen) SSL_ctrl(s, SSL_CTRL_SET_GROUPS, glistlen,(char *)(glist))
 #endif // OPENSSL_IS_BORINGSSL
 
 #endif /* SSL_PRIVATE_H */


### PR DESCRIPTION
Motivation:

At the moment its only possible to set the curves / groups per SSL_CTX instance. Sometimes we need to pick them based on the SSL instance.

Modifications:

Add methods to allow setting curves / groups

Result:

Be able to specify curves / groups per SSL instance