### PR TITLE
Use main branch for BoringSSL

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -85,7 +85,6 @@
     <boringsslHome>${boringsslSourceDir}/build</boringsslHome>
     <boringsslSourceDir>${project.build.directory}/boringssl-${boringsslBranch}</boringsslSourceDir>
     <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
-    <boringsslBranch>master</boringsslBranch>
     <linkStatic>true</linkStatic>
     <compileLibrary>true</compileLibrary>
     <msvcSslIncludeDirs>${boringsslSourceDir}/include</msvcSslIncludeDirs>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <nativeLibOsParts>${os.detected.name}_${os.detected.arch}</nativeLibOsParts>
     <aprVersion>1.7.5</aprVersion>
     <aprSha256>3375fa365d67bcf945e52b52cba07abea57ef530f40b281ffbe977a9251361db</aprSha256>
-    <boringsslBranch>master</boringsslBranch>
+    <boringsslBranch>main</boringsslBranch>
     <!--
       See https://boringssl.googlesource.com/boringssl/+/refs/heads/master for the latest commit
     -->


### PR DESCRIPTION
Motivation:

BoringSSL does not have a master branch anymore, switch to main

Modifications:

Switch to main branch

Result:

Project builds again