### PR TITLE
Fix SSL.getSigAlgs() on BoringSSL for TLS 1.3

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2583,7 +2583,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getSigAlgs)(TCN_STDARGS, jlong ssl) {
     }
 
     for (i = 0; i < num_peer_sigalgs; i++) {
-        if ((alg = SSL_get_signature_algorithm_name(peer_sigalgs[i], SSL_version(ssl_) != TLS1_2_VERSION)) == NULL) {
+        if ((alg = SSL_get_signature_algorithm_name(peer_sigalgs[i], false)) == NULL) {
             // The signature algorithm is not known to BoringSSL, skip it.
             continue;
         }


### PR DESCRIPTION
Always pass `false` as the second parameter to
`SSL_get_signature_algorithm_name()`. This forces BoringSSL to omit the curve name and return algorithm names in the style expected by callers of `SSL.getSigAlgs()`. Previously this parameter was only false for TLS 1.2.

This change does *not* have associated tests because I was unable to find any.

This is to fix #923 