### PR TITLE
Migrate using maven central

### DIFF
--- a/.github/scripts/bundle_create.sh
+++ b/.github/scripts/bundle_create.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2025 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Expected bundle name and directory"
+    exit 1
+fi
+
+# Create a bundle zip that contains all jars.
+# See https://central.sonatype.org/publish/publish-portal-upload/
+pushd $2
+zip -r $1 * -x maven-metadata-central-staging.xml
+popd

--- a/.github/scripts/bundle_upload.sh
+++ b/.github/scripts/bundle_upload.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2025 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Expected bundle-name, username, password"
+    exit 1
+fi
+
+# Generate the correct Bearer.
+# See https://central.sonatype.org/publish/publish-portal-api/
+BEARER=`printf "$2:$3" | base64`
+
+# Upload a previous build bundle.
+# See https://central.sonatype.org/publish/publish-portal-api/
+curl --request POST \
+  --header "Authorization: Bearer $BEARER" \
+  --form bundle=@$1 \
+  https://central.sonatype.com/api/v1/publisher/upload

--- a/.github/scripts/local_staging_merge_release.sh
+++ b/.github/scripts/local_staging_merge_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ----------------------------------------------------------------------------
-# Copyright 2021 The Netty Project
+# Copyright 2025 The Netty Project
 #
 # The Netty Project licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 # ----------------------------------------------------------------------------
+
 set -e
 if [ "$#" -lt 2 ]; then
     echo "Expected target directory and at least one local staging directory"
@@ -24,12 +25,10 @@ TARGET=$1
 for ((i=2; i<=$#; i++))
 do
   DIR="${!i}"
-  SUB_DIR=$(ls -d "${DIR}"/* | awk -F / '{print $NF}')
 
-  if [ ! -d "${TARGET}/${SUB_DIR}" ]
+  if [ ! -d "${TARGET}" ]
   then
-      mkdir -p "${TARGET}/${SUB_DIR}"
+      mkdir -p "${TARGET}"
   fi
-  cat "${DIR}"/"${SUB_DIR}"/.index >> "${TARGET}/${SUB_DIR}"/.index
   cp -r "${DIR}"/"${SUB_DIR}"/* "${TARGET}/${SUB_DIR}"/
 done

--- a/.github/scripts/local_staging_merge_snapshot.sh
+++ b/.github/scripts/local_staging_merge_snapshot.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2021 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+set -e
+if [ "$#" -lt 2 ]; then
+    echo "Expected target directory and at least one local staging directory"
+    exit 1
+fi
+TARGET=$1
+
+for ((i=2; i<=$#; i++))
+do
+  DIR="${!i}"
+  SUB_DIR=$(ls -d "${DIR}"/* | awk -F / '{print $NF}')
+
+  if [ ! -d "${TARGET}/${SUB_DIR}" ]
+  then
+      mkdir -p "${TARGET}/${SUB_DIR}"
+  fi
+  cat "${DIR}"/"${SUB_DIR}"/.index >> "${TARGET}/${SUB_DIR}"/.index
+  cp -r "${DIR}"/"${SUB_DIR}"/* "${TARGET}/${SUB_DIR}"/
+done

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -102,7 +102,7 @@ jobs:
         run: mkdir -p ~/local-staging
 
       - name: Stage snapshots to local staging directory
-        run: ./mvnw -B -ntp -am -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true
+        run: ./mvnw -B -ntp -am -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/local-staging -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v4
@@ -186,15 +186,10 @@ jobs:
         with:
           servers: |
             [{
-              "id": "sonatype-nexus-snapshots",
-              "username": "${{ secrets.SONATYPE_USERNAME }}",
-              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+              "id": "central-portal-snapshots",
+              "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+              "password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
             }]
-
-      # Setup some env to re-use later.
-      - name: Prepare enviroment variables
-        run: |
-          echo "LOCAL_STAGING_DIR=$HOME/local-staging" >> $GITHUB_ENV
 
       # Hardcode the staging artifacts that need to be downloaded.
       # These must match the matrix setups and windows build. There is currently no way to pull this out of the config.
@@ -240,10 +235,10 @@ jobs:
       - name: Generate uber jar and deploy to local staging.
         run: |
           mkdir -p ~/uber-local-staging
-          ./mvnw -B --file pom.xml -Puber-snapshot -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/uber-local-staging -DskipRemoteStaging=true -DskipTests=true
+          ./mvnw -B --file pom.xml -Puber-snapshot -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=$HOME/uber-local-staging -DskipTests=true
 
       - name: Merge staging repositories
-        run: bash ./.github/scripts/merge_local_staging.sh ~/local-staging ~/windows-x86_64-local-staging ~/macos-aarch64-local-staging ~/macos-x86_64-local-staging ~/centos7-aarch64-local-staging ~/debian7-x86_64-local-staging ~/centos6-x86_64-local-staging ~/uber-local-staging
+        run: bash ./.github/scripts/local_staging_merge_snapshot.sh ~/local-staging ~/windows-x86_64-local-staging ~/macos-aarch64-local-staging ~/macos-x86_64-local-staging ~/centos7-aarch64-local-staging ~/debian7-x86_64-local-staging ~/centos6-x86_64-local-staging ~/uber-local-staging
 
       - name: Deploy local staged artifacts
-        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$HOME/local-staging

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.setup }}-local-staging
-          path: ~/local-staging
+          path: ./prepare-release-workspace/target/central-staging
           if-no-files-found: error
           include-hidden-files: true
 
@@ -228,13 +228,13 @@ jobs:
 
       - name: Stage release to local staging directory
         working-directory: prepare-release-workspace
-        run: ./mvnw --file pom.xml -Pstage -am -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=local-staging -DskipRemoteStaging=true -DskipTests=true -D'checkstyle.skip=true'
+        run: ./mvnw --file pom.xml -Pstage -am -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -D'checkstyle.skip=true'
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64-local-staging
-          path: prepare-release-workspace/boringssl-static/local-staging
+          path: ./prepare-release-workspace/target/central-staging
           if-no-files-found: error
           include-hidden-files: true
 
@@ -322,13 +322,13 @@ jobs:
 
       - name: Stage snapshots to local staging directory
         working-directory: ./prepare-release-workspace/
-        run: ./mvnw -B -ntp -am -pl openssl-dynamic,boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Dgpg.keyname=${{ secrets.GPG_KEYNAME }}
+        run: ./mvnw -B -ntp -am -pl openssl-dynamic,boringssl-static clean javadoc:jar package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true
 
       - name: Upload local staging directory
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.setup }}-local-staging
-          path: ~/local-staging
+          path: ./prepare-release-workspace/target/central-staging
           if-no-files-found: error
           include-hidden-files: true
 
@@ -436,24 +436,27 @@ jobs:
 
       - name: Copy previous build artifacts to local maven repository
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/install_local_staging.sh ~/.m2/repository ~/windows-x86_64-local-staging/staging ~/macos-aarch64-local-staging/staging ~/macos-x86_64-local-staging/staging ~/centos7-aarch64-local-staging/staging ~/debian7-x86_64-local-staging/staging ~/centos6-x86_64-local-staging/staging
+        run: bash ./.github/scripts/install_local_staging.sh ~/.m2/repository ~/windows-x86_64-local-staging ~/macos-aarch64-local-staging ~/macos-x86_64-local-staging ~/centos7-aarch64-local-staging ~/debian7-x86_64-local-staging ~/centos6-x86_64-local-staging
 
       - name: Generate uber jar and deploy to local staging.
         working-directory: ./prepare-release-workspace/
         run: |
           mkdir -p ~/uber-local-staging
-          ./mvnw -B --file pom.xml -Puber-snapshot -pl boringssl-static clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/uber-local-staging -DskipRemoteStaging=true -DskipTests=true
+          ./mvnw -B --file pom.xml -Puber-staging -pl boringssl-static clean package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true
 
       # This step takes care of merging all the previous staged repositories in a way that will allow us to deploy
       # all together with one maven command.
       - name: Merge staging repositories
         working-directory: ./prepare-release-workspace/
-        run: bash ./.github/scripts/merge_local_staging.sh /home/runner/local-staging/staging ~/windows-x86_64-local-staging/staging ~/macos-aarch64-local-staging/staging ~/macos-x86_64-local-staging/staging ~/centos7-aarch64-local-staging/staging ~/debian7-x86_64-local-staging/staging ~/centos6-x86_64-local-staging/staging ~/uber-local-staging/staging
+        run: bash ./.github/scripts/local_staging_merge_release.sh ~/local-staging ~/windows-x86_64-local-staging ~/macos-aarch64-local-staging ~/macos-x86_64-local-staging ~/centos7-aarch64-local-staging ~/debian7-x86_64-local-staging ~/centos6-x86_64-local-staging ~/uber-local-staging
 
-      - name: Deploy local staged artifacts
+      - name: Create bundle
         working-directory: ./prepare-release-workspace/
-        # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=$HOME/local-staging -DskipStagingRepositoryClose=true
+        run: bash ./.github/scripts/bundle_create.sh ~/central-bundle.zip ~/local-staging/
+
+      - name: Upload bundle to maven central
+        working-directory: ./prepare-release-workspace/
+        run: bash ./.github/scripts/bundle_upload.sh ~/central-bundle.zip ${{ secrets.MAVEN_CENTRAL_USERNAME }} ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -1051,14 +1051,6 @@
         <compileLibrary>false</compileLibrary>
       </properties>
 
-      <repositories>
-        <repository>
-          <id>staged-releases</id>
-          <name>Staged Releases</name>
-          <url>https://oss.sonatype.org/service/local/repositories/${stagingRepositoryId}/content/</url>
-        </repository>
-      </repositories>
-
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -39,7 +39,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true"
 
   stage-release:
     <<: *common

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -60,7 +60,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true && ./mvnw -Plinux-aarch64 -am -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true && ./mvnw -Plinux-aarch64 -am -pl boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
@@ -70,5 +70,5 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} && ./mvnw -Plinux-aarch64 -am -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -Plinux-aarch64 -am -pl openssl-dynamic -DaprArmHome=/opt/apr-$$APR_VERSION-share -DopensslArmHome=/opt/openssl-$$OPENSSL_VERSION-share clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} && ./mvnw -Plinux-aarch64 -am -pl boringssl-static clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -49,7 +49,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true"
 
   stage-release:
     <<: *common
@@ -63,7 +63,7 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pstage -am -pl openssl-dynamic clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pstage -am -pl openssl-dynamic clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   shell:
     <<: *common

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,14 @@
     </license>
   </licenses>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <properties>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <checkstyle.skip>true</checkstyle.skip>
@@ -487,6 +495,26 @@
           <arguments>-Prestricted-release,sonatype-oss-release -DmoduleSelector=none</arguments>
           <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
           <autoVersionSubmodules>true</autoVersionSubmodules>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <skipPublishing>true</skipPublishing>
+          <autoPublish>false</autoPublish>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.7.0</version>
+        <configuration>
+          <serverId>central-portal-snapshots</serverId>
+          <nexusUrl>https://central.sonatype.com/repository/maven-snapshots</nexusUrl>
+          <skipRemoteStaging>true</skipRemoteStaging>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Motivation:

OSSRH is deprecated and will be shut down soon. Let's switch to using maven central

Modifications:

- Replace old plugin with central-publishing-maven-plugin for release
- Adjust workflow to setup the right token / password
- Add scripts

Result:

Snapshot deployments and release works again