### PR TITLE
Support for building with AWS Libcrypto (AWS-LC)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,6 +37,9 @@ jobs:
           - setup: centos7-aarch64
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build"
+          - setup: al2023-x86_64-aws_lc
+            docker-compose-build: "-f docker/docker-compose.al2023.yaml build"
+            docker-compose-run: "-f docker/docker-compose.al2023.yaml run build"
 
     name: ${{ matrix.setup }}
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -35,6 +35,9 @@ jobs:
           - setup: centos7-aarch64
             docker-compose-build: "-f docker/docker-compose.centos-7.yaml build"
             docker-compose-run: "-f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build"
+          - setup: al2023-x86_64-aws_lc
+            docker-compose-build: "-f docker/docker-compose.al2023.yaml build"
+            docker-compose-run: "-f docker/docker-compose.al2023.yaml run build"
 
     name: ${{ matrix.setup }}
     steps:

--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -1,0 +1,55 @@
+FROM --platform=linux/amd64 amazonlinux:2023
+
+ARG java_version=8.0.452-amzn
+ARG aws_lc_version=v1.52.0
+ENV JAVA_VERSION $java_version
+ENV AWS_LC_VERSION $aws_lc_version
+
+# install dependencies
+RUN dnf install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ bzip2 \
+ cmake \
+ git \
+ glibc-devel \
+ golang \
+ libtool \
+ make \
+ patch \
+ perl \
+ perl-parent \
+ perl-devel \
+ tar \
+ unzip \
+ wget \
+ which \
+ zip
+
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
+
+# Installing Java removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install java $JAVA_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
+RUN echo 'export PATH=$JAVA_HOME/bin:$PATH' >> ~/.bashrc
+
+ENV PATH /root/.sdkman/candidates/java/current/bin:$PATH
+
+RUN mkdir "$HOME/sources" && \
+    git clone https://github.com/aws/aws-lc.git "$HOME/sources/aws-lc" && \
+    cd "$HOME/sources/aws-lc" && \
+    git checkout $AWS_LC_VERSION && \
+    cmake -B build -S . -DCMAKE_INSTALL_PREFIX=/opt/aws-lc -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0 && \
+    cmake --build build -- -j && \
+    cmake --install build
+
+# Cleanup
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf && \
+    rm -rf "$HOME/sources"

--- a/docker/docker-compose.al2023.yaml
+++ b/docker/docker-compose.al2023.yaml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-al2023:x86_64
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.al2023
+
+  common: &common
+    image: netty-tcnative-al2023:x86_64
+    depends_on: [runtime-setup]
+    environment:
+      MAVEN_OPTS:
+      LD_LIBRARY_PATH: /opt/aws-lc/lib64
+      LDFLAGS: -L/opt/aws-lc/lib64 -lssl -lcrypto
+      CFLAGS: -I/opt/aws-lc/include  -DHAVE_OPENSSL -lssl -lcrypto
+      CXXFLAGS: -I/opt/aws-lc/include  -DHAVE_OPENSSL -lssl -lcrypto
+    volumes:
+      - ~/.m2/repository:/root/.m2/repository
+      - ..:/code
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -am -pl openssl-dynamic clean package"
+
+  shell:
+    <<: *common
+    volumes:
+      - ~/.m2:/root/.m2
+      - ~/.gitconfig:/root/.gitconfig
+      - ~/.gitignore:/root/.gitignore
+      - ..:/code
+    entrypoint: /bin/bash -l

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -153,7 +153,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int x509vErrIpAddressMismatch();
     static native int x509vErrDaneNoMatch();
 
-    // BoringSSL specific.
+    // BoringSSL and AWS-LC specific.
     static native int sslErrorWantCertificateVerify();
     static native int sslErrorWantPrivateKeyOperation();
     static native int sslSignRsaPkcsSha1();

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -176,7 +176,7 @@ public final class SSL {
     // https://boringssl.googlesource.com/boringssl/+/chromium-stable/include/openssl/ssl.h#519
     public static final int SSL_ERROR_WANT_PRIVATE_KEY_OPERATION = sslErrorWantPrivateKeyOperation();
 
-    // BoringSSL specific
+    // BoringSSL and AWS-LC specific
     public static final int SSL_ERROR_WANT_CERTIFICATE_VERIFY = sslErrorWantCertificateVerify();
 
     /**
@@ -961,7 +961,7 @@ public final class SSL {
     public static native long getSession(long ssl);
 
     /**
-     * Allow to set the renegotiation mode that is used. This is only support by {@code BoringSSL}.
+     * Allow to set the renegotiation mode that is used. This is only supported by {@code BoringSSL} and {@code AWS-LC}.
      *
      * See <a href="https://boringssl.googlesource.com/boringssl/+/refs/heads/master/include/openssl/ssl.h#4081">
      *     SSL_set_renegotiate_mode</a>..

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -668,7 +668,7 @@ public final class SSLContext {
      * For servers, algorithm preference order is dictated by the order of algorithm registration.
      * Most preferred algorithm should be registered first.
      *
-     * This method is currently only supported when {@code BoringSSL} is used.
+     * This method is currently only supported when {@code BoringSSL} or {@code AWS-LC} is used.
      *
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Certificate-compression">
      *     SSL_CTX_add_cert_compression_alg</a>
@@ -696,7 +696,7 @@ public final class SSLContext {
      * This allows to offload private key operations
      * if needed.
      *
-     * This method is currently only supported when {@code BoringSSL} is used.
+     * This method is currently only supported when {@code BoringSSL} and {@code AWS-LC} is used.
      *
      * @param ctx context to use
      * @param method method to use for the given context.
@@ -709,7 +709,7 @@ public final class SSLContext {
      * Sets the {@link AsyncSSLPrivateKeyMethod} to use for the given {@link SSLContext}.
      * This allows to offload private key operations if needed.
      *
-     * This method is currently only supported when {@code BoringSSL} is used.
+     * This method is currently only supported when {@code BoringSSL} and {@code AWS-LC} is used.
      *
      * @param ctx context to use
      * @param method method to use for the given context.

--- a/openssl-dynamic/src/main/c/cert_compress.c
+++ b/openssl-dynamic/src/main/c/cert_compress.c
@@ -16,7 +16,7 @@
 
 #include "tcn.h"
 #include "ssl_private.h"
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 #include "cert_compress.h"
 
 static int compress(jobject compression_algorithm, jmethodID compress_method, SSL* ssl, CBB* out,
@@ -168,4 +168,4 @@ int zstd_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len,
         ssl, out, uncompressed_len, in, in_len);
 }
 
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)

--- a/openssl-dynamic/src/main/c/cert_compress.h
+++ b/openssl-dynamic/src/main/c/cert_compress.h
@@ -17,7 +17,7 @@
 #ifndef NETTY_TCNATIVE_CERT_COMPRESS_H_
 #define NETTY_TCNATIVE_CERT_COMPRESS_H_
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 int zlib_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len);
 int zlib_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len);
@@ -28,6 +28,6 @@ int brotli_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len);
 int zstd_decompress_java(SSL* ssl, CRYPTO_BUFFER** out, size_t uncompressed_len, const uint8_t* in, size_t in_len);
 int zstd_compress_java(SSL* ssl, CBB* out, const uint8_t* in, size_t in_len);
 
-#endif // OPENSSL_IS_BORINGSSL
+#endif // OPENSSL_IS_AWSLC
 
 #endif /* NETTY_TCNATIVE_CERT_COMPRESS_H_ */

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -510,7 +510,7 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, x509vErrDaneNoMat
 #endif
 }
 
-// BoringSSL specific
+// BoringSSL and AWS-LC specific
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslErrorWantCertificateVerify)(TCN_STDARGS) {
     return SSL_ERROR_WANT_CERTIFICATE_VERIFY;
 }
@@ -572,7 +572,7 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslSignRsaPkcs1Md
 }
 
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateNever)(TCN_STDARGS) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return (jint) ssl_renegotiate_never;
 #else
     return 0;
@@ -580,7 +580,7 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateNev
 }
 
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateOnce)(TCN_STDARGS) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return (jint) ssl_renegotiate_once;
 #else
     return 0;
@@ -588,7 +588,7 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateOnc
 }
 
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateFreely)(TCN_STDARGS) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return (jint) ssl_renegotiate_freely;
 #else
     return 0;
@@ -597,7 +597,7 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateFre
 
 
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateIgnore)(TCN_STDARGS) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return (jint) ssl_renegotiate_ignore;
 #else
     return 0;
@@ -605,7 +605,7 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateIgn
 }
 
 TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslRenegotiateExplicit)(TCN_STDARGS) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return (jint) ssl_renegotiate_explicit;
 #else
     return 0;
@@ -744,7 +744,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(x509vErrEmailMismatch, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509vErrIpAddressMismatch, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(x509vErrDaneNoMatch, ()I, NativeStaticallyReferencedJniMethods) },
-  // BoringSSL specific
+  // BoringSSL and AWS-LC specific
   { TCN_METHOD_TABLE_ENTRY(sslErrorWantCertificateVerify, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslErrorWantPrivateKeyOperation, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(sslSignRsaPkcsSha1, ()I, NativeStaticallyReferencedJniMethods) },

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -114,7 +114,7 @@ struct TCN_bio_bytebuffer {
     R |= SSL_TMP_KEY_INIT_DH(2048);             \
     R |= SSL_TMP_KEY_INIT_DH(4096)
 
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 // This is the maximum overhead when encrypting plaintext as defined by
 // <a href="https://www.ietf.org/rfc/rfc5246.txt">rfc5264</a>,
 // <a href="https://www.ietf.org/rfc/rfc5289.txt">rfc5289</a> and openssl implementation itself.
@@ -133,7 +133,7 @@ struct TCN_bio_bytebuffer {
 // See SSL#getMaxWrapOverhead for the overhead based upon the SSL*
 // TODO(scott): this may be an over estimate because we don't account for short headers.
 #define TCN_MAX_SEAL_OVERHEAD_LENGTH (TCN_MAX_ENCRYPTED_PACKET_LENGTH + SSL3_RT_HEADER_LENGTH)
-#endif /*!defined(OPENSSL_IS_BORINGSSL)*/
+#endif /*!defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)*/
 
 static jint tcn_flush_sslbuffer_to_bytebuffer(struct TCN_bio_bytebuffer* bioUserData) {
     jint writeAmount = TCN_MIN(bioUserData->bufferLength, bioUserData->nonApplicationBufferLength) * sizeof(char);
@@ -499,7 +499,7 @@ static apr_status_t ssl_init_cleanup(void *data)
     /*
      * Try to kill the internals of the SSL library.
      */
-#if OPENSSL_VERSION_NUMBER >= 0x00907001 && !defined(OPENSSL_IS_BORINGSSL)
+#if OPENSSL_VERSION_NUMBER >= 0x00907001 && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     /* Corresponds to OPENSSL_load_builtin_modules():
      * XXX: borrowed from apps.h, but why not CONF_modules_free()
      * which also invokes CONF_modules_finish()?
@@ -537,10 +537,10 @@ static apr_status_t ssl_init_cleanup(void *data)
      }
 
 // In case we loaded any engine we should also call cleanup. This is especialy important in openssl < 1.1.
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     // This is deprecated since openssl 1.1 but does not exist at all in BoringSSL.
     ENGINE_cleanup();
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #endif // OPENSSL_NO_ENGINE
 
     /* Don't call ERR_free_strings here; ERR_load_*_strings only
@@ -1249,7 +1249,7 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
                                                          jlong ssl /* SSL * */) {
     // Use weak linking with GCC as this will alow us to run the same packaged version with multiple
     // version of openssl.
-    #if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
+    #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && (defined(__GNUC__) || defined(__GNUG__))
         if (!SSL_get0_alpn_selected) {
             return NULL;
         }
@@ -1273,7 +1273,7 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getAlpnSelected)(TCN_STDARGS,
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
                                                   jlong ssl /* SSL * */)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     const STACK_OF(CRYPTO_BUFFER) *chain = NULL;
     const CRYPTO_BUFFER * cert = NULL;
     const tcn_ssl_ctxt_t* c = NULL;
@@ -1281,7 +1281,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     STACK_OF(X509) *chain = NULL;
     X509 *cert = NULL;
     unsigned char *buf = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     int len;
     int i;
     int length;
@@ -1295,7 +1295,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
     // Get a stack of all certs in the chain.
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     TCN_GET_SSL_CTX(ssl_, c);
 
     TCN_ASSERT(c != NULL);
@@ -1313,7 +1313,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
     chain = SSL_get_peer_cert_chain(ssl_);
     len = sk_X509_num(chain);
     offset = 0;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     len -= offset;
     if (len <= 0) {
@@ -1329,7 +1329,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
 
     for(i = 0; i < len; i++) {
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         cert = sk_CRYPTO_BUFFER_value(chain, i + offset);
         length = CRYPTO_BUFFER_len(cert);
 #else
@@ -1341,11 +1341,11 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
             // In case of error just return an empty byte[][]
             return (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
         }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         bArray = (*e)->NewByteArray(e, length);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         if (bArray == NULL) {
             return NULL;
         }
@@ -1360,7 +1360,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
         OPENSSL_free(buf);
         buf = NULL;
 
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         (*e)->SetObjectArrayElement(e, array, i, bArray);
 
         // Delete the local reference as we not know how long the chain is and local references are otherwise
@@ -1373,13 +1373,13 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getPeerCertChain)(TCN_STDARGS,
 TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
                                                   jlong ssl /* SSL * */)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     const STACK_OF(CRYPTO_BUFFER) *certs = NULL;
     const CRYPTO_BUFFER *leafCert = NULL;
 #else
     X509 *cert = NULL;
     unsigned char *buf = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     jbyteArray bArray = NULL;
     int length;
@@ -1388,7 +1388,7 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     // Get a stack of all certs in the chain, the first is the leaf.
     certs = SSL_get0_peer_certificates(ssl_);
     if (certs == NULL || sk_CRYPTO_BUFFER_num(certs) <= 0) {
@@ -1403,10 +1403,10 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
     }
 
     length = i2d_X509(cert, &buf);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     if ((bArray = (*e)->NewByteArray(e, length)) != NULL) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) CRYPTO_BUFFER_data(leafCert));
     }
 #else
@@ -1419,7 +1419,7 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getPeerCertificate)(TCN_STDARGS,
     X509_free(cert);
 
     OPENSSL_free(buf);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return bArray;
 }
 
@@ -1522,13 +1522,13 @@ TCN_IMPLEMENT_CALL(void, SSL, setVerify)(TCN_STDARGS, jlong ssl, jint level, jin
     TCN_ASSERT(state != NULL);
     TCN_ASSERT(state->ctx != NULL);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_set_custom_verify(ssl_, tcn_set_verify_config(&state->verify_config, level, depth), tcn_SSL_cert_custom_verify);
 #else
     // No need to specify a callback for SSL_set_verify because we override the default certificate verification via SSL_CTX_set_cert_verify_callback.
     SSL_set_verify(ssl_, tcn_set_verify_config(&state->verify_config, level, depth), NULL);
     SSL_set_verify_depth(ssl_, state->verify_config.verify_depth);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, setOptions)(TCN_STDARGS, jlong ssl,
@@ -1585,7 +1585,7 @@ TCN_IMPLEMENT_CALL(jint, SSL, getMaxWrapOverhead)(TCN_STDARGS, jlong ssl)
     TCN_CHECK_NULL(ssl_, ssl, 0);
 
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     return (jint) SSL_max_seal_overhead(ssl_);
 #else
     // TODO(scott): When OpenSSL supports something like SSL_max_seal_overhead ... use it!
@@ -1694,12 +1694,12 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCipherSuites)(TCN_STDARGS, jlong ssl,
     rv = SSL_set_cipher_list(ssl_, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
 #else
     if (tlsv13 == JNI_TRUE) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
         // BoringSSL does not support setting TLSv1.3 cipher suites explicit for now.
         rv = JNI_TRUE;
 #else
         rv = SSL_set_ciphersuites(ssl_, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     } else {
         rv = SSL_set_cipher_list(ssl_, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
     }
@@ -1926,7 +1926,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if (flags != 0) {
         tcn_ThrowException(e, "flags must be 0");
     }
@@ -1966,7 +1966,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
     tcn_ThrowException(e, "hostname verification requires OpenSSL 1.0.2+");
 #endif // (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)) || LIBRESSL_VERSION_NUMBER >= 0x2060000fL || defined(__GNUC__) || defined(__GNUG__)
 
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong ssl) {
@@ -2000,8 +2000,10 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateBio)(TCN_STDARGS, jlong ssl,
                                                          jlong cert, jlong key,
                                                          jstring password)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) 
     tcn_Throw(e, "Not supported using BoringSSL");
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported using AWS-LC");
 #else
     SSL *ssl_ = J2P(ssl, SSL *);
 
@@ -2062,7 +2064,7 @@ cleanup:
     TCN_FREE_CSTRING(password);
     EVP_PKEY_free(pkey); // this function is safe to call with NULL
     X509_free(xcert); // this function is safe to call with NULL
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
@@ -2077,7 +2079,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
 
 // This call is only used to detect if we support KeyManager or not in netty. As we know that we support it in
 // BoringSSL we can just ignore this call. In the future we should remove the method all together.
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     char err[ERR_LEN];
 
     if (tcn_SSL_use_certificate_chain_bio(ssl_, b, skipfirst) < 0)  {
@@ -2085,7 +2087,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setCertificateChainBio)(TCN_STDARGS, jlong ssl,
         ERR_clear_error();
         tcn_Throw(e, "Error setting certificate chain (%s)", err);
     }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jlong, SSL, loadPrivateKeyFromEngine)(TCN_STDARGS, jstring keyId, jstring password)
@@ -2149,7 +2151,7 @@ TCN_IMPLEMENT_CALL(jlong, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
 {
     BIO *cert_bio = J2P(x509ChainBio, BIO *);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     STACK_OF(CRYPTO_BUFFER) *chain = sk_CRYPTO_BUFFER_new_null();
     CRYPTO_BUFFER *buffer = NULL;
     char *name = NULL;
@@ -2159,14 +2161,14 @@ TCN_IMPLEMENT_CALL(jlong, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
 #else
     X509* cert = NULL;
     STACK_OF(X509) *chain = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     char err[ERR_LEN];
     unsigned long error;
 
     TCN_CHECK_NULL(cert_bio, x509ChainBio, 0);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     while (PEM_read_bio(cert_bio, &name, &header, &data, &data_len)) {
 
         OPENSSL_free(name);
@@ -2184,15 +2186,15 @@ TCN_IMPLEMENT_CALL(jlong, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
     chain = sk_X509_new_null();
     while ((cert = PEM_read_bio_X509(cert_bio, NULL, NULL, NULL)) != NULL) {
         if (sk_X509_push(chain, cert) <= 0) {
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
             tcn_Throw(e, "No Certificate specified or invalid format");
             goto cleanup;
         }
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
         cert = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     }
 
     // ensure that if we have an error its just for EOL.
@@ -2212,25 +2214,25 @@ TCN_IMPLEMENT_CALL(jlong, SSL, parseX509Chain)(TCN_STDARGS, jlong x509ChainBio)
 cleanup:
     ERR_clear_error();
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     sk_CRYPTO_BUFFER_pop_free(chain, CRYPTO_BUFFER_free);
 #else
     sk_X509_pop_free(chain, X509_free);
     X509_free(cert);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     return 0;
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, freeX509Chain)(TCN_STDARGS, jlong x509Chain)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     STACK_OF(CRYPTO_BUFFER) *chain = J2P(x509Chain, STACK_OF(CRYPTO_BUFFER) *);
     sk_CRYPTO_BUFFER_pop_free(chain, CRYPTO_BUFFER_free);
 #else
     STACK_OF(X509) *chain = J2P(x509Chain, STACK_OF(X509) *);
     sk_X509_pop_free(chain, X509_free);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chain, jlong key)
@@ -2244,14 +2246,14 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
 
     EVP_PKEY* pkey = J2P(key, EVP_PKEY *);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     STACK_OF(CRYPTO_BUFFER) *cchain = J2P(chain, STACK_OF(CRYPTO_BUFFER) *);
     int numCerts = sk_CRYPTO_BUFFER_num(cchain);
     CRYPTO_BUFFER** certs = NULL;
 #else
     STACK_OF(X509) *cchain = J2P(chain, STACK_OF(X509) *);
     int numCerts = sk_X509_num(cchain);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     char err[ERR_LEN];
     int i;
@@ -2260,7 +2262,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
 
     TCN_CHECK_NULL(cchain, chain, /* void */);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if ((certs = OPENSSL_malloc(sizeof(CRYPTO_BUFFER*) * numCerts)) == NULL) {
         tcn_Throw(e, "OPENSSL_malloc returned NULL");
         return;
@@ -2269,19 +2271,21 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
     for (i = 0; i < numCerts; i++) {
         certs[i] = sk_CRYPTO_BUFFER_value(cchain, i);
     }
+#endif
 
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if (numCerts <= 0 || SSL_set_chain_and_key(ssl_, certs, numCerts, pkey, pkey == NULL ? &private_key_method : NULL) <= 0) {
 #else
     // SSL_use_certificate will increment the reference count of the cert.
     if (numCerts <= 0 || SSL_use_certificate(ssl_, sk_X509_value(cchain, 0)) <= 0) {
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         ERR_error_string_n(ERR_get_error(), err, ERR_LEN);
         ERR_clear_error();
         tcn_Throw(e, "Error setting certificate (%s)", err);
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     OPENSSL_free(certs);
 #else
     if (pkey != NULL) {
@@ -2313,7 +2317,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
             return;
         }
     }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 #endif
 }
@@ -2324,6 +2328,8 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterialClientSide)(TCN_STDARGS, jlong ssl, 
     tcn_Throw(e, "Not supported with LibreSSL");
 #elif defined(OPENSSL_IS_BORINGSSL)
     tcn_Throw(e, "Not supported with BoringSSL");
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported with AWS-LC");
 #else
     SSL *ssl_ = J2P(ssl, SSL *);
 
@@ -2398,13 +2404,13 @@ TCN_IMPLEMENT_CALL(void, SSL, enableOcsp)(TCN_STDARGS, jlong ssl) {
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     tcn_ThrowException(e, "netty-tcnative was built without OCSP support");
 
 #elif defined(TCN_OCSP_NOT_SUPPORTED)
     tcn_ThrowException(e, "OCSP stapling is not supported");
 
-#elif defined(OPENSSL_IS_BORINGSSL)
+#elif defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_enable_ocsp_stapling(ssl_);
 
 #else
@@ -2428,13 +2434,13 @@ TCN_IMPLEMENT_CALL(void, SSL, setOcspResponse)(TCN_STDARGS, jlong ssl, jbyteArra
         return;
     }
 
-#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     tcn_ThrowException(e, "netty-tcnative was built without OCSP support");
 
 #elif defined(TCN_OCSP_NOT_SUPPORTED)
     tcn_ThrowException(e, "OCSP stapling is not supported");
 
-#elif defined(OPENSSL_IS_BORINGSSL)
+#elif defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     uint8_t *value = OPENSSL_malloc(sizeof(uint8_t) * length);
     if (value == NULL) {
         tcn_ThrowException(e, "OPENSSL_malloc() returned null");
@@ -2479,13 +2485,13 @@ TCN_IMPLEMENT_CALL(jbyteArray, SSL, getOcspResponse)(TCN_STDARGS, jlong ssl) {
 
     TCN_CHECK_NULL(ssl_, ssl, NULL);
 
-#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     tcn_ThrowException(e, "netty-tcnative was built without OCSP support");
 
 #elif defined(TCN_OCSP_NOT_SUPPORTED)
     tcn_ThrowException(e, "OCSP stapling is not supported");
 
-#elif defined(OPENSSL_IS_BORINGSSL)
+#elif defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     const uint8_t *response = NULL;
     size_t length = 0;
 
@@ -2562,7 +2568,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getSigAlgs)(TCN_STDARGS, jlong ssl) {
 // Not supported in LibreSSL
 #if defined(LIBRESSL_VERSION_NUMBER)
     return NULL;
-#elif defined(OPENSSL_IS_BORINGSSL)
+#elif defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     // Using a different API in BoringSSL
     // https://boringssl.googlesource.com/boringssl/+/ba16a1e405c617f4179bd780ad15522fb25b0a65%5E%21/
     int i;
@@ -2649,14 +2655,14 @@ complete:
     }
     return array;
 #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(__GNUC__) || defined(__GNUG__)
-#endif // defined(OPENSSL_IS_BORINGSSL) || defined(LIBRESSL_VERSION_NUMBER)
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC) || defined(LIBRESSL_VERSION_NUMBER)
 }
 
 TCN_IMPLEMENT_CALL(void, SSL, setRenegotiateMode)(TCN_STDARGS, jlong ssl, jint mode) {
     SSL *ssl_ = J2P(ssl, SSL *);
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     tcn_Throw(e, "Not supported");
 #else
     SSL_set_renegotiate_mode(ssl_, (enum ssl_renegotiate_mode_t) mode);

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -75,13 +75,14 @@ static apr_status_t ssl_context_cleanup(void *data)
 
         tcn_get_java_env(&e);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         if (c->ssl_private_key_method != NULL) {
             if (e != NULL) {
                 (*e)->DeleteGlobalRef(e, c->ssl_private_key_method);
             }
             c->ssl_private_key_method = NULL;
         }
+
         if (c->ssl_cert_compression_zlib_algorithm != NULL) {
             if (e != NULL) {
                 (*e)->DeleteGlobalRef(e, c->ssl_cert_compression_zlib_algorithm);
@@ -107,7 +108,7 @@ static apr_status_t ssl_context_cleanup(void *data)
             c->keylog_callback = NULL;
         }
         c->keylog_callback_method = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         if (c->ssl_session_cache != NULL) {
             if (e != NULL) {
@@ -186,9 +187,10 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     tcn_ssl_ctxt_t *c = NULL;
     SSL_CTX *ctx = NULL;
 
-#ifdef OPENSSL_IS_BORINGSSL
-    // When using BoringSSL we want to use CRYPTO_BUFFER to reduce memory usage and minimize overhead as we do not need
-    // X509* at all and just need the raw bytes of the certificates to construct our Java X509Certificate.
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+    // When using BoringSSL or AWS-LC we want to use CRYPTO_BUFFER to reduce memory usage and minimize overhead as
+    // we do not need X509* at all and just need the raw bytes of the certificates to construct our Java 
+    // X509Certificate.
     //
     // See https://github.com/google/boringssl/blob/chromium-stable/PORTING.md#crypto_buffer
     ctx = SSL_CTX_new(TLS_with_buffers_method());
@@ -340,7 +342,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
         tcn_Throw(e, "Unsupported SSL protocol (%d)", protocol);
         goto cleanup;
     }
-#endif /* OPENSSL_IS_BORINGSSL */
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     if (ctx == NULL) {
         char err[ERR_LEN];
@@ -443,7 +445,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     SSL_CTX_set_default_passwd_cb(c->ctx, (pem_password_cb *) tcn_SSL_password_callback);
     SSL_CTX_set_default_passwd_cb_userdata(c->ctx, (void *) c->password);
 
-#if defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if (mode != SSL_MODE_SERVER) {
         // Set this to make the behaviour consistent with openssl / libressl
         SSL_CTX_set_allow_unknown_alpn_protos(ctx, 1);
@@ -553,12 +555,12 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCipherSuite)(TCN_STDARGS, jlong ctx,
 #else
 
     if (tlsv13 == JNI_TRUE) {
-#ifdef OPENSSL_IS_BORINGSSL
-        // BoringSSL does not support setting TLSv1.3 cipher suites explicit for now.
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+        // BoringSSL and AWS-LC do not support setting TLSv1.3 cipher suites explicit for now.
         rv = JNI_TRUE;
 #else
         rv = SSL_CTX_set_ciphersuites(c->ctx, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     } else {
         rv = SSL_CTX_set_cipher_list(c->ctx, J2S(ciphers)) == 0 ? JNI_FALSE : JNI_TRUE;
@@ -577,8 +579,11 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateChainFile)(TCN_STDARGS, j
                                                                   jstring file,
                                                                   jboolean skipfirst)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
     tcn_Throw(e, "Not supported using BoringSSL");
+    return JNI_FALSE;
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported using AWS-LC");
     return JNI_FALSE;
 #else
 
@@ -597,15 +602,18 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateChainFile)(TCN_STDARGS, j
     }
     TCN_FREE_CSTRING(file);
     return rv;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defiend(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateChainBio)(TCN_STDARGS, jlong ctx,
                                                                   jlong chain,
                                                                   jboolean skipfirst)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
     tcn_Throw(e, "Not supported using BoringSSL");
+    return JNI_FALSE;
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported using AWS-LC");
     return JNI_FALSE;
 #else
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
@@ -620,7 +628,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateChainBio)(TCN_STDARGS, jl
         return JNI_TRUE;
     }
     return JNI_FALSE;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCACertificateBio)(TCN_STDARGS, jlong ctx, jlong certs)
@@ -641,8 +649,8 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setNumTickets)(TCN_STDARGS, jlong ctx, 
 
     TCN_CHECK_NULL(c, ctx, JNI_FALSE);
 
-#ifdef OPENSSL_IS_BORINGSSL
-    // Not supported by BoringSSL 
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+    // Not supported by BoringSSL or AWS-LC
     return JNI_FALSE;
 #else
     // Only supported with GCC
@@ -688,7 +696,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setTmpDHLength)(TCN_STDARGS, jlong ctx, jin
 #endif // OPENSSL_VERSION_NUMBER < 0x30000000L
 }
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 static EVP_PKEY *load_pem_key(tcn_ssl_ctxt_t *c, const char *file)
 {
     BIO *bio = NULL;
@@ -791,14 +799,17 @@ static void free_and_reset_pass(tcn_ssl_ctxt_t *c, char* old_password, const jbo
     }
 }
 
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificate)(TCN_STDARGS, jlong ctx,
                                                          jstring cert, jstring key,
                                                          jstring password)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
     tcn_Throw(e, "Not supported using BoringSSL");
+    return JNI_FALSE;
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported using AWS-LC");
     return JNI_FALSE;
 #else
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
@@ -887,15 +898,18 @@ cleanup:
     X509_free(xcert); // this function is safe to call with NULL
     free_and_reset_pass(c, old_password, rv);
     return rv;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCertificateBio)(TCN_STDARGS, jlong ctx,
                                                          jlong cert, jlong key,
                                                          jstring password)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
     tcn_Throw(e, "Not supported using BoringSSL");
+    return JNI_FALSE;
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported using AWS-LC");
     return JNI_FALSE;
 #else
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
@@ -975,7 +989,7 @@ cleanup:
     X509_free(xcert); // this function is safe to call with NULL
     free_and_reset_pass(c, old_password, rv);
     return rv;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setNpnProtos0)(TCN_STDARGS, jlong ctx, jbyteArray next_protos,
@@ -1006,7 +1020,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setAlpnProtos0)(TCN_STDARGS, jlong ctx, jby
         jint selectorFailureBehavior)
 {
     // Only supported with GCC
-    #if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
+    #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && (defined(__GNUC__) || defined(__GNUG__))
         if (!SSL_CTX_set_alpn_protos || !SSL_CTX_set_alpn_select_cb) {
             return;
         }
@@ -1404,19 +1418,31 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSessionTicketKeys0)(TCN_STDARGS, jlong c
 
 static const char* authentication_method(const SSL* ssl) {
 {
+#if OPENSSL_VERSION_NUMBER <= 0x10001000L
     const STACK_OF(SSL_CIPHER) *ciphers = NULL;
+#endif
+    const SSL_CIPHER *cipher = NULL;
 
     switch (SSL_version(ssl))
         {
         case SSL2_VERSION:
             return SSL_TXT_RSA;
         default:
+#if OPENSSL_VERSION_NUMBER > 0x10001000L
+            cipher = SSL_get_current_cipher(ssl);
+            if (cipher == NULL) {
+                // No cipher available so return UNKNOWN.
+                return TCN_UNKNOWN_AUTH_METHOD;
+            }
+#else
             ciphers = SSL_get_ciphers(ssl);
             if (ciphers == NULL || sk_SSL_CIPHER_num(ciphers) <= 0) {
                 // No cipher available so return UNKNOWN.
                 return TCN_UNKNOWN_AUTH_METHOD;
             }
-            return tcn_SSL_cipher_authentication_method(sk_SSL_CIPHER_value(ciphers, 0));
+            cipher = sk_SSL_CIPHER_value(ciphers, 0);
+#endif
+            return tcn_SSL_cipher_authentication_method(cipher);
         }
     }
 }
@@ -1462,7 +1488,7 @@ static STACK_OF(X509)* X509_STORE_CTX_get0_untrusted(X509_STORE_CTX *ctx) {
 }
 #endif
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 static jbyteArray get_certs(JNIEnv *e, SSL* ssl, const STACK_OF(CRYPTO_BUFFER)* chain) {
     CRYPTO_BUFFER *cert = NULL;
     const int totalQueuedLength = sk_CRYPTO_BUFFER_num(chain);
@@ -1471,7 +1497,7 @@ static jbyteArray get_certs(JNIEnv *e, SSL* ssl, STACK_OF(X509)* chain) {
     X509 *cert = NULL;
     unsigned char *buf = NULL;
     const int totalQueuedLength = sk_X509_num(chain);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     tcn_ssl_state_t* state = tcn_SSL_get_app_state(ssl);
     TCN_ASSERT(state != NULL);
@@ -1496,13 +1522,13 @@ static jbyteArray get_certs(JNIEnv *e, SSL* ssl, STACK_OF(X509)* chain) {
 
     for(i = 0; i < len; i++) {
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         cert = sk_CRYPTO_BUFFER_value(chain, i);
         length = CRYPTO_BUFFER_len(cert);
 #else
         cert = sk_X509_value(chain, i);
         length = i2d_X509(cert, &buf);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         if (length <= 0 || (bArray = (*e)->NewByteArray(e, length)) == NULL) {
             NETTY_JNI_UTIL_DELETE_LOCAL(e, array);
@@ -1510,14 +1536,14 @@ static jbyteArray get_certs(JNIEnv *e, SSL* ssl, STACK_OF(X509)* chain) {
             goto complete;
         }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) CRYPTO_BUFFER_data(cert));
 #else
         (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) buf);
 
         OPENSSL_free(buf);
         buf = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         (*e)->SetObjectArrayElement(e, array, i, bArray);
 
         // Delete the local reference as we not know how long the chain is and local references are otherwise
@@ -1528,10 +1554,10 @@ static jbyteArray get_certs(JNIEnv *e, SSL* ssl, STACK_OF(X509)* chain) {
 
 complete:
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     // We need to delete the local references so we not leak memory as this method is called via callback.
     OPENSSL_free(buf);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
     // Delete the local reference as we not know how long the chain is and local references are otherwise
     // only freed once jni method returns.
@@ -1539,7 +1565,7 @@ complete:
     return array;
 }
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 // See https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_cert_verify_callback.html for return values.
 static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     /* Get Apache context back through OpenSSL context */
@@ -1623,7 +1649,7 @@ complete:
     ret = result == X509_V_OK ? 1 : 0;
     return ret;
 }
-#else // OPENSSL_IS_BORINGSSL
+#else // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert) {
     enum ssl_verify_result_t ret = ssl_verify_invalid;
@@ -1742,7 +1768,7 @@ complete:
     }
     return ret;
 }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setVerify)(TCN_STDARGS, jlong ctx, jint level, jint depth)
@@ -1752,7 +1778,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setVerify)(TCN_STDARGS, jlong ctx, jint lev
     TCN_CHECK_NULL(c, ctx, /* void */);
 
     int mode = tcn_set_verify_config(&c->verify_config, level, depth);
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if (c->verifier != NULL) {
         SSL_CTX_set_custom_verify(c->ctx, mode, tcn_SSL_cert_custom_verify);
     }
@@ -1760,7 +1786,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setVerify)(TCN_STDARGS, jlong ctx, jint lev
     // No need to set the callback for SSL_CTX_set_verify because we override the default certificate verification via SSL_CTX_set_cert_verify_callback.
     SSL_CTX_set_verify(c->ctx, mode, NULL);
     SSL_CTX_set_verify_depth(c->ctx, c->verify_config.verify_depth);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong ctx, jobject verifier)
@@ -1773,11 +1799,11 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
     if (verifier == NULL) {
         c->verifier = NULL;
         c->verifier_method = NULL;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         SSL_CTX_set_custom_verify(c->ctx, SSL_VERIFY_NONE, NULL);
 #else
         SSL_CTX_set_cert_verify_callback(c->ctx, NULL, NULL);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     } else {
         jclass verifier_class = (*e)->GetObjectClass(e, verifier);
         jmethodID method = (*e)->GetMethodID(e, verifier_class, "verify", "(J[[BLjava/lang/String;)I");
@@ -1795,12 +1821,12 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
         c->verifier = v;
         c->verifier_method = method;
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         SSL_CTX_set_custom_verify(c->ctx, tcn_set_verify_config(&c->verify_config, c->verify_config.verify_mode,
                  c->verify_config.verify_depth), tcn_SSL_cert_custom_verify);
 #else
         SSL_CTX_set_cert_verify_callback(c->ctx, SSL_cert_verify, NULL);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         // Delete the reference to the previous specified verifier if needed.
         if (oldVerifier != NULL) {
@@ -1831,14 +1857,14 @@ static jbyteArray keyTypes(JNIEnv* e, SSL* ssl) {
  * Partly based on code from conscrypt:
  * https://android.googlesource.com/platform/external/conscrypt/+/master/src/main/native/org_conscrypt_NativeCrypto.cpp
  */
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(CRYPTO_BUFFER)* names) {
     CRYPTO_BUFFER* principal = NULL;
 #else
 static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) {
     unsigned char *buf = NULL;
     X509_NAME* principal = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     jobjectArray array = NULL;
     jbyteArray bArray = NULL;;
     int i;
@@ -1851,11 +1877,11 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
         return NULL;
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     count = sk_CRYPTO_BUFFER_num(names);
 #else
     count = sk_X509_NAME_num(names);
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     if (count <= 0) {
         return NULL;
@@ -1866,7 +1892,7 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
     }
 
     for (i = 0; i < count; i++) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         principal = sk_CRYPTO_BUFFER_value(names, i);
         length = CRYPTO_BUFFER_len(principal);
 #else
@@ -1880,11 +1906,11 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
             // In case of error just return an empty byte[][]
             return (*e)->NewObjectArray(e, 0, byteArrayClass, NULL);
         }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         bArray = (*e)->NewByteArray(e, length);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
          if (bArray == NULL) {
              return NULL;
          }
@@ -1897,7 +1923,7 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
         (*e)->SetByteArrayRegion(e, bArray, 0, length, (jbyte*) buf);
         OPENSSL_free(buf);
         buf = NULL;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
         (*e)->SetObjectArrayElement(e, array, i, bArray);
 
@@ -1910,7 +1936,7 @@ static jobjectArray principalBytes(JNIEnv* e, const STACK_OF(X509_NAME)* names) 
 }
 #endif // LIBRESSL_VERSION_NUMBER
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
 #if defined(LIBRESSL_VERSION_NUMBER)
     // Not supported with LibreSSL
@@ -1949,7 +1975,7 @@ static int cert_requested(SSL* ssl, X509** x509Out, EVP_PKEY** pkeyOut) {
     return 1;
 #endif /* defined(LIBRESSL_VERSION_NUMBER) */
 }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlong ctx, jobject callback)
 {
@@ -1957,8 +1983,10 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertRequestedCallback)(TCN_STDARGS, jlon
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
     tcn_Throw(e, "Not supported using BoringSSL");
+#elif defined(OPENSSL_IS_AWSLC)
+    tcn_Throw(e, "Not supported using AWS-LC");
 #else
     jobject oldCallback = c->cert_requested_callback;
     if (callback == NULL) {
@@ -2037,11 +2065,11 @@ static int certificate_cb(SSL* ssl, void* arg) {
     } else {
         types = keyTypes(e, ssl);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
         issuers = principalBytes(e, SSL_get0_server_requested_CAs(ssl));
 #else
         issuers = principalBytes(e, SSL_get_client_CA_list(ssl));
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     }
 
     int ret = 0;
@@ -2086,7 +2114,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertificateCallback)(TCN_STDARGS, jlong 
 
 // Use weak linking with GCC as this will alow us to run the same packaged version with multiple
 // version of openssl.
-#if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && (defined(__GNUC__) || defined(__GNUG__))
     if (!SSL_CTX_set_cert_cb) {
         tcn_ThrowException(e, "Requires OpenSSL 1.0.2+");
         return;
@@ -2136,7 +2164,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertificateCallback)(TCN_STDARGS, jlong 
 }
 
 // Support for SSL_PRIVATE_KEY_METHOD.
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 static enum ssl_private_key_result_t tcn_private_key_sign_java(SSL *ssl, uint8_t *out, size_t *out_len, size_t max_out, uint16_t signature_algorithm, const uint8_t *in, size_t in_len) {
     enum ssl_private_key_result_t ret = ssl_private_key_failure;
@@ -2333,14 +2361,14 @@ const SSL_PRIVATE_KEY_METHOD private_key_method = {
     &tcn_private_key_decrypt_java,
     &tcn_private_key_complete_java
 };
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 
 TCN_IMPLEMENT_CALL(void, SSLContext, setPrivateKeyMethod0)(TCN_STDARGS, jlong ctx, jobject method) {
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
 
     TCN_CHECK_NULL(c, ctx, /* void */);
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     char* name = NULL;
     char* combinedName = NULL;
 
@@ -2398,7 +2426,7 @@ error:
     free(combinedName);
 #else
     tcn_ThrowException(e, "Requires BoringSSL");
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 static int tcn_new_session_cb(SSL *ssl, SSL_SESSION *session) {
@@ -2590,7 +2618,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setSniHostnameMatcher)(TCN_STDARGS, jlong c
     }
 }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 static void keylog_cb(const SSL* ssl, const char *line) {
     if (line == NULL) {
         return;
@@ -2625,7 +2653,7 @@ static void keylog_cb(const SSL* ssl, const char *line) {
     (*e)->CallVoidMethod(e, state->ctx->keylog_callback, state->ctx->keylog_callback_method,
                 P2J(ssl), outputLine);
 }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setKeyLogCallback)(TCN_STDARGS, jlong ctx, jobject callback)
 {
@@ -2633,7 +2661,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setKeyLogCallback)(TCN_STDARGS, jlong c
 
     TCN_CHECK_NULL(c, ctx, JNI_FALSE);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     jobject oldCallback = c->keylog_callback;
     if (callback == NULL) {
         c->keylog_callback = NULL;
@@ -2667,7 +2695,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setKeyLogCallback)(TCN_STDARGS, jlong c
     return JNI_TRUE;
 #else
     return JNI_FALSE;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jboolean, SSLContext, setSessionIdContext)(TCN_STDARGS, jlong ctx, jbyteArray sidCtx)
@@ -2723,7 +2751,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, getSslCtx)(TCN_STDARGS, jlong ctx)
 }
 
 
-#if !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 static const int OCSP_CLIENT_ACK = 1;
 static const int OCSP_SERVER_ACK = SSL_TLSEXT_ERR_OK;
@@ -2742,7 +2770,7 @@ static int openssl_ocsp_callback(SSL *ssl, void *arg) {
     return *(const int*)arg;
 }
 
-#endif /* !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL) */
+#endif /* !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
 
 /**
  * Enables OCSP stapling for the given SSLContext
@@ -2753,13 +2781,13 @@ TCN_IMPLEMENT_CALL(void, SSLContext, enableOcsp)(TCN_STDARGS, jlong ctx, jboolea
 
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_NO_OCSP) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     tcn_ThrowException(e, "netty-tcnative was built without OCSP support");
 
 #elif defined(TCN_OCSP_NOT_SUPPORTED)
     tcn_ThrowException(e, "OCSP stapling is not supported");
 
-#elif !defined(OPENSSL_IS_BORINGSSL)
+#elif !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     //
     // The client and server use slightly different return values to signal
     // error and success to OpenSSL. We're going to do something naughty to
@@ -2790,7 +2818,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, disableOcsp)(TCN_STDARGS, jlong ctx) {
     TCN_CHECK_NULL(c, ctx, /* void */);
 
 // This does nothing in BoringSSL
-#if !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_NO_OCSP) && !defined(TCN_OCSP_NOT_SUPPORTED) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     SSL_CTX_set_tlsext_status_cb(c->ctx, NULL);
     SSL_CTX_set_tlsext_status_arg(c->ctx, NULL);
 #endif
@@ -2840,7 +2868,7 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, addCertificateCompressionAlgorithm0)(TCN_ST
         return 0;
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     jclass algorithmClass = (*e)->GetObjectClass(e, algorithm);
     if (algorithmClass == NULL) {
@@ -2920,7 +2948,7 @@ TCN_IMPLEMENT_CALL(jint, SSLContext, addCertificateCompressionAlgorithm0)(TCN_ST
 #else
     tcn_Throw(e, "TLS Cert Compression only supported by BoringSSL");
     return 0;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 // JNI Method Registration Table Begin

--- a/openssl-dynamic/src/main/c/sslsession.c
+++ b/openssl-dynamic/src/main/c/sslsession.c
@@ -74,7 +74,7 @@ TCN_IMPLEMENT_CALL(jboolean, SSLSession, upRef)(TCN_STDARGS, jlong session) {
     TCN_CHECK_NULL(session_, session, JNI_FALSE);
 
     // Only supported with GCC
-    #if !defined(OPENSSL_IS_BORINGSSL) && (defined(__GNUC__) || defined(__GNUG__))
+    #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && (defined(__GNUC__) || defined(__GNUG__))
         if (!SSL_SESSION_up_ref) {
             return JNI_FALSE;
         }
@@ -98,13 +98,13 @@ TCN_IMPLEMENT_CALL(void, SSLSession, free)(TCN_STDARGS, jlong session) {
 
 TCN_IMPLEMENT_CALL(jboolean, SSLSession, shouldBeSingleUse)(TCN_STDARGS, jlong session) {
 // Only supported by BoringSSL atm
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_SESSION *session_ = J2P(session, SSL_SESSION *);
     TCN_CHECK_NULL(session_, session, JNI_FALSE);
     return SSL_SESSION_should_be_single_use(session_) == 0 ? JNI_FALSE : JNI_TRUE;
 #else 
     return JNI_FALSE;
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 // JNI Method Registration Table Begin


### PR DESCRIPTION
Hello,

I'm an engineer at AWS working on AWS-LC, AWS's open-source fork of Google's BoringSSL. We would like to propose adding AWS-LC support to netty-tcnative, alongside its existing support for OpenSSL, BoringSSL, and LibreSSL.

AWS-LC shares a similar API surface area to the existing BoringSSL integration within your library, while providing additional benefits for users.
We are committed to backwards compatibility and maintain extensive CI testing infrastructure that continuously validates compatibility with many open-source projects.
We plan to add netty-tcnative compatibility testing to this suite to ensure ongoing compatibility.

Some of the highlights offered by this integration:

1. Performance optimizations specifically targeted for modern CPU architectures, including AWS Graviton processors, and Intel x86-64 with AVX-512 instructions
2. Formal verification of critical cryptographic primitives, with ongoing investment in expanding verification coverage.
3. FIPS 140-3 compliance support through a dedicated FIPS build mode.

Given netty-tcnative's existing support for BoringSSL, integrating AWS-LC is relatively straightforward.
This integration would provide netty users with a well-supported path to leverage AWS-LC's improvements in performance, security,
and compliance without requiring them to maintain custom patches or modifications.

The this integration supports all current netty-tcnative functionality that is supported for the BoringSSL integration.

Currently this pull request targets users who build the netty-tcnative JARs themselves following the [How to build ](https://netty.io/wiki/forked-tomcat-native.html#how-to-build) instructions. This would allow users wanting to use AWS-LC to do so successfully.

At this time I don't see an explicit need to offer static compilations of AWS-LC bundled in a jar file (similar to the BoringSSL integration). I noticed
that the current LibreSSL static build is not published, so I wasn't sure if maintaining these static variants is a goal in the long-term, but would be open
to discuss further if you'd like.

Once this PR is merged in I can publish the corresponding PR to netty to make necessary adjustments there for the netty-tcnative with aws-lc integration to work as expected and have additional testing as necessary.