### PR TITLE
Upgrade Windows GHA images to Windows Server 2022

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -77,7 +77,7 @@ jobs:
 
 
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: windows-x86_64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -118,7 +118,7 @@ jobs:
           include-hidden-files: true
 
   stage-snapshot-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: stage-snapshot-windows-x86_64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -74,7 +74,7 @@ jobs:
             **/hs_err*.log
 
   build-pr-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: windows-x86_64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -165,7 +165,7 @@ jobs:
         run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty-tcnative main
 
   stage-release-windows-x86_64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: stage-release-windows-x86_64
     needs: prepare-release
     permissions:

--- a/vs2010.vcxproj.static.template
+++ b/vs2010.vcxproj.static.template
@@ -27,24 +27,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Motivation:
We are currently using the Windows 2019 images, which will reach end-of-life on June 30, 2025.

Modification:
Change the windows images in our GHA workflows from `windows-2019` to `windows-2022`.

Result:
More up to date windows build agents.