### PR TITLE
Fix codeql analyze job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -80,7 +80,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool libtool-bin make tar libapr1-dev libssl-dev cmake perl ninja-build
 
     - name: Build project
-      run: ./mvnw clean package -pl openssl-dynamic -DskipTests=true
+      run: ./mvnw clean package -am -pl openssl-dynamic -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Motivation:

We need to ensure we also build modules that openssl-dynamic depend on as otherwise the analyze might fail as it can not find the snapshot

Modifications:

Add -am to the build command

Result:

Analyze job doesnt fail anymore