### PR TITLE
Fix build of libressl-static on newer CMAKE versions

### DIFF
--- a/libressl-static/pom.xml
+++ b/libressl-static/pom.xml
@@ -345,6 +345,7 @@
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
                           <arg value="-DCMAKE_ASM_FLAGS=-Wa,--noexecstack" />
                           <arg value="-DCMAKE_C_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer -fPIC" />
+                          <arg value="-DCMAKE_POLICY_VERSION_MINIMUM=3.5" />
                           <arg value="${cmakeOsxDeploymentTarget}" />
                           <arg value="-GNinja" />
                           <arg value="${libresslSourceDir}" />


### PR DESCRIPTION
Motivation:

To be able to build libressl-static with newer cmake versions we need to pass in some more flags

Modifications:

Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5

Result:

Compilation of libressl-static works again even on cmake 4.x