### PR TITLE
Add missing <openssl/sha.h> include

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -65,6 +65,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/hmac.h>
 #include <openssl/dh.h>
+#include <openssl/sha.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000
 #include <openssl/core_names.h>
 #endif


### PR DESCRIPTION
ssl_private.h depends on SHA_DIGEST_LENGTH, which is defined in <openssl/sha.h>. netty-tcnative is currently relying on the header getting transitively included elsewhere.

BoringSSL is looking to reduce transitive includes of <openssl/sha.h> to help some systems better audit uses of legacy algorithms like SHA-1. This change keeps netty-tcnative compatible with those changes.