### PR TITLE
Update jni-util version to clarify licensing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.9.Final</jniUtilVersion>
+    <jniUtilVersion>0.0.10.Final</jniUtilVersion>
     <javaDefaultModuleName>io.netty.internal.tcnative</javaDefaultModuleName>
     <javaModuleName>${javaDefaultModuleName}</javaModuleName>
     <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>


### PR DESCRIPTION
Motivation:

A new jni-util version was released which replaced some code which had no clear licensing.

Modifications:

Upgrade to latest version

Result:

Clear licensing of jni-util depndency