### PR TITLE
Open up SslCredential API to AWS-LC

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -973,11 +973,11 @@ public final class SSL {
 
     /**
      * Add an SSL_CREDENTIAL to the SSL instance.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_add1_credential">SSL_add1_credential</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param ssl the SSL instance (SSL *)
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @throws Exception if an error occurred
@@ -986,11 +986,11 @@ public final class SSL {
 
     /**
      * Get the selected credential from an SSL instance.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_get0_selected_credential">SSL_get0_selected_credential</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param ssl the SSL instance (SSL *)
      * @return the selected credential (SSL_CREDENTIAL *) or {@code 0} if none
      * @throws Exception if an error occurred

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLContext.java
@@ -777,11 +777,11 @@ public final class SSLContext {
 
     /**
      * Add an SSL_CREDENTIAL to the SSL_CTX instance.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CTX_add1_credential">SSL_CTX_add1_credential</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param ctx the SSL_CTX instance (SSL_CTX *)
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @throws Exception if an error occurred

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLCredential.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSLCredential.java
@@ -16,16 +16,16 @@
 package io.netty.internal.tcnative;
 
 /**
- * SSL_CREDENTIAL management for BoringSSL.
- * 
+ * SSL_CREDENTIAL management for BoringSSL and AWS-LC.
+ *
  * This class provides methods to create and manage SSL_CREDENTIAL objects,
- * which are used to configure credentials for SSL/TLS connections in BoringSSL.
- * 
- * <p>This API is only supported when using BoringSSL. For usage instructions and detailed
- * documentation, see the 
+ * which are used to configure credentials for SSL/TLS connections in BoringSSL and AWS-LC.
+ *
+ * <p>This API is only supported when using BoringSSL or AWS-LC. For usage instructions and detailed
+ * documentation, see the
  * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_free">BoringSSL SSL_CREDENTIAL documentation</a>.
  * </p>
- * 
+ *
  * <p>SSL_CREDENTIAL objects allow fine-grained control over certificate and private key
  * configuration, including support for multiple credentials, delegated credentials,
  * and SPAKE2+ authentication.</p>
@@ -36,11 +36,11 @@ public final class SSLCredential {
 
     /**
      * Create a new X509 SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_new_x509">SSL_CREDENTIAL_new_x509</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @return the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @throws Exception if an error occurred
      */
@@ -48,11 +48,11 @@ public final class SSLCredential {
 
     /**
      * Increment the reference count of an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_up_ref">SSL_CREDENTIAL_up_ref</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @throws Exception if an error occurred
      */
@@ -60,11 +60,11 @@ public final class SSLCredential {
 
     /**
      * Free an SSL_CREDENTIAL and decrement its reference count.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_free">SSL_CREDENTIAL_free</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @throws Exception if an error occurred
      */
@@ -72,11 +72,11 @@ public final class SSLCredential {
 
     /**
      * Set the private key for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_private_key">SSL_CREDENTIAL_set1_private_key</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param key the private key (EVP_PKEY *)
      * @throws Exception if an error occurred
@@ -86,7 +86,7 @@ public final class SSLCredential {
     /**
      * Set the certificate chain for an SSL_CREDENTIAL.
      *
-     * <p>This is a BoringSSL-specific feature. See
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_cert_chain">SSL_CREDENTIAL_set1_cert_chain</a>
      * for detailed documentation.</p>
      *
@@ -98,11 +98,11 @@ public final class SSLCredential {
 
     /**
      * Set the OCSP response for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_ocsp_response">SSL_CREDENTIAL_set1_ocsp_response</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param response the OCSP response bytes
      * @throws Exception if an error occurred
@@ -111,11 +111,11 @@ public final class SSLCredential {
 
     /**
      * Set the signing algorithm preferences for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_signing_algorithm_prefs">SSL_CREDENTIAL_set1_signing_algorithm_prefs</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param prefs the signing algorithm preferences
      * @throws Exception if an error occurred
@@ -124,11 +124,11 @@ public final class SSLCredential {
 
     /**
      * Set the certificate properties for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_certificate_properties">SSL_CREDENTIAL_set1_certificate_properties</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param properties the certificate properties
      * @throws Exception if an error occurred
@@ -137,11 +137,11 @@ public final class SSLCredential {
 
     /**
      * Set the signed certificate timestamp list for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_signed_cert_timestamp_list">SSL_CREDENTIAL_set1_signed_cert_timestamp_list</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param sctList the signed certificate timestamp list
      * @throws Exception if an error occurred
@@ -150,11 +150,11 @@ public final class SSLCredential {
 
     /**
      * Set whether the issuer must match for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set_must_match_issuer">SSL_CREDENTIAL_set_must_match_issuer</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param mustMatch {@code true} if issuer must match, {@code false} otherwise
      * @throws Exception if an error occurred
@@ -163,11 +163,11 @@ public final class SSLCredential {
 
     /**
      * Set the trust anchor ID for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature for trust anchor configuration. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature for trust anchor configuration. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_trust_anchor_id">SSL_CREDENTIAL_set1_trust_anchor_id</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param id the trust anchor ID
      * @throws Exception if an error occurred
@@ -176,11 +176,11 @@ public final class SSLCredential {
 
     /**
      * Create a new delegated SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature for delegated credential support. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature for delegated credential support. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_new_delegated">SSL_CREDENTIAL_new_delegated</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @return the delegated SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @throws Exception if an error occurred
      */
@@ -188,11 +188,11 @@ public final class SSLCredential {
 
     /**
      * Set the delegated credential for an SSL_CREDENTIAL.
-     * 
-     * <p>This is a BoringSSL-specific feature for delegated credential configuration. See 
+     *
+     * <p>This is a BoringSSL/AWS-LC-specific feature for delegated credential configuration. See
      * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CREDENTIAL_set1_delegated_credential">SSL_CREDENTIAL_set1_delegated_credential</a>
      * for detailed documentation.</p>
-     * 
+     *
      * @param cred the SSL_CREDENTIAL instance (SSL_CREDENTIAL *)
      * @param delegatedCred the delegated credential bytes
      * @throws Exception if an error occurred

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2674,7 +2674,7 @@ TCN_IMPLEMENT_CALL(void, SSL, addCredential)(TCN_STDARGS, jlong ssl, jlong cred)
     SSL *ssl_ = J2P(ssl, SSL *);
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* credential = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(credential, credential, /* void */);
 
@@ -2690,7 +2690,7 @@ TCN_IMPLEMENT_CALL(jlong, SSL, getSelectedCredential)(TCN_STDARGS, jlong ssl) {
     SSL *ssl_ = J2P(ssl, SSL *);
     TCN_CHECK_NULL(ssl_, ssl, 0);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     const SSL_CREDENTIAL* credential = SSL_get0_selected_credential(ssl_);
     if (credential == NULL) {
         return 0;

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -519,7 +519,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 #endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 // SSL_CREDENTIAL API runtime detection for FIPS compatibility
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 // Use weak symbols to detect if SSL_CREDENTIAL API is available at runtime
 // FIPS BoringSSL builds (fips-20230428 and earlier) don't have these symbols
 __attribute__((weak)) extern SSL_CREDENTIAL* SSL_CREDENTIAL_new_x509(void);
@@ -554,6 +554,6 @@ __attribute__((unused)) static inline int check_credential_api(JNIEnv* e) {
     tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL API not available.");
     return 0;
 }
-#endif // OPENSSL_IS_BORINGSSL
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 #endif /* SSL_PRIVATE_H */

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2949,7 +2949,7 @@ TCN_IMPLEMENT_CALL(void, SSLContext, addCredential)(TCN_STDARGS, jlong ctx, jlon
     tcn_ssl_ctxt_t *c = J2P(ctx, tcn_ssl_ctxt_t *);
     TCN_CHECK_NULL(c, ctx, /* void */);
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* credential = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(credential, credential, /* void */);
 

--- a/openssl-dynamic/src/main/c/sslcredential.c
+++ b/openssl-dynamic/src/main/c/sslcredential.c
@@ -30,7 +30,7 @@
 #define SSLCREDENTIAL_CLASSNAME "io/netty/internal/tcnative/SSLCredential"
 
 // Helper functions
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 static void throw_openssl_error(JNIEnv* env, const char* msg) {
     unsigned long err = ERR_get_error();
     char err_buf[ERR_LEN] = {0};
@@ -44,7 +44,7 @@ static void throw_openssl_error(JNIEnv* env, const char* msg) {
 // Core SSL_CREDENTIAL functions
 TCN_IMPLEMENT_CALL(jlong, SSLCredential, newX509)(TCN_STDARGS) {
     if (!check_credential_api(e)) return 0;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* cred = SSL_CREDENTIAL_new_x509();
     TCN_CHECK_NULL(cred, credential, 0);
     return (jlong)(intptr_t)cred;
@@ -55,7 +55,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLCredential, newX509)(TCN_STDARGS) {
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, upRef)(TCN_STDARGS, jlong cred) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     SSL_CREDENTIAL_up_ref(c);
@@ -64,7 +64,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, upRef)(TCN_STDARGS, jlong cred) {
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, free)(TCN_STDARGS, jlong cred) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     if (c != NULL) {
         SSL_CREDENTIAL_free(c);
@@ -75,10 +75,10 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, free)(TCN_STDARGS, jlong cred) {
 // SSL_CREDENTIAL configuration methods
 TCN_IMPLEMENT_CALL(void, SSLCredential, setPrivateKey)(TCN_STDARGS, jlong cred, jlong key) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     EVP_PKEY* pkey = (EVP_PKEY*)(intptr_t)key;
-    
+
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(pkey, privateKey, /* void */);
 
@@ -90,7 +90,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setPrivateKey)(TCN_STDARGS, jlong cred, 
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setCertChain)(TCN_STDARGS, jlong cred, jlong certChainStack) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
 
@@ -122,7 +122,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setCertChain)(TCN_STDARGS, jlong cred, j
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setOcspResponse)(TCN_STDARGS, jlong cred, jbyteArray ocsp) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(ocsp, ocspData, /* void */);
@@ -152,7 +152,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setOcspResponse)(TCN_STDARGS, jlong cred
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setSigningAlgorithmPrefs)(TCN_STDARGS, jlong cred, jintArray prefs) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(prefs, preferencesArray, /* void */);
@@ -176,7 +176,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setSigningAlgorithmPrefs)(TCN_STDARGS, j
     }
 
     int result = SSL_CREDENTIAL_set1_signing_algorithm_prefs(c, native_prefs, len);
-    
+
     // Clean up
     (*e)->ReleaseIntArrayElements(e, prefs, prefs_data, JNI_ABORT);
     OPENSSL_free(native_prefs);
@@ -189,7 +189,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setSigningAlgorithmPrefs)(TCN_STDARGS, j
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setCertificateProperties)(TCN_STDARGS, jlong cred, jbyteArray cert_props) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(cert_props, certificateProperties, /* void */);
@@ -219,7 +219,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setCertificateProperties)(TCN_STDARGS, j
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setSignedCertTimestampList)(TCN_STDARGS, jlong cred, jbyteArray sct_list) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(sct_list, sctList, /* void */);
@@ -249,7 +249,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setSignedCertTimestampList)(TCN_STDARGS,
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setMustMatchIssuer)(TCN_STDARGS, jlong cred, jboolean match) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     SSL_CREDENTIAL_set_must_match_issuer(c, match == JNI_TRUE ? 1 : 0);
@@ -259,7 +259,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setMustMatchIssuer)(TCN_STDARGS, jlong c
 // Trust anchor configuration
 TCN_IMPLEMENT_CALL(void, SSLCredential, setTrustAnchorId)(TCN_STDARGS, jlong cred, jbyteArray id) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(id, trustAnchorId, /* void */);
@@ -286,7 +286,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setTrustAnchorId)(TCN_STDARGS, jlong cre
 // Delegated credentials
 TCN_IMPLEMENT_CALL(jlong, SSLCredential, newDelegated)(TCN_STDARGS) {
     if (!check_credential_api(e)) return 0;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* credential = SSL_CREDENTIAL_new_delegated();
     if (credential == NULL) {
         throw_openssl_error(e, "Failed to create delegated SSL_CREDENTIAL");
@@ -300,7 +300,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLCredential, newDelegated)(TCN_STDARGS) {
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setDelegatedCredential)(TCN_STDARGS, jlong cred, jbyteArray dc) {
     if (!check_credential_api(e)) return;
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(dc, delegatedCredential, /* void */);


### PR DESCRIPTION
Motivation:

Allow users of AWS-LC to leverage the new SslCredential API.

Modifications:

Update docs and feature flags to allow SslCredential calls.

Result:

Users of AWS-LC can leverage the new SslCredential API.

Implements https://github.com/netty/netty/pull/15919#discussion_r2788573973