### PR TITLE
Always clear global reference to the verifier

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1845,11 +1845,11 @@ TCN_IMPLEMENT_CALL(void, SSLContext, setCertVerifyCallback)(TCN_STDARGS, jlong c
 #else
         SSL_CTX_set_cert_verify_callback(c->ctx, SSL_cert_verify, NULL);
 #endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+    }
 
-        // Delete the reference to the previous specified verifier if needed.
-        if (oldVerifier != NULL) {
-            (*e)->DeleteGlobalRef(e, oldVerifier);
-        }
+    // Delete the reference to the previous specified verifier if needed.
+    if (oldVerifier != NULL) {
+        (*e)->DeleteGlobalRef(e, oldVerifier);
     }
 }
 


### PR DESCRIPTION
Motivation:

All other similar setters (setCertificateCallback, setSniHostnameMatcher, setKeyLogCallback, setCertRequestedCallback, setSSLSessionCache) correctly place the DeleteGlobalRef outside the if/else.
This one is inconsistent and leaks the old verifier when the callback is cleared by passing NULL.

Modifications:

Always clear the global reference

Result:

Correctly clear global reference
