### PR TITLE
Add new method authenticationMethodsPacked to avoid string and array allocation

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.java
@@ -181,4 +181,9 @@ final class NativeStaticallyReferencedJniMethods {
     static native int tlsExtCertCompressionZlib();
     static native int tlsExtCertCompressionBrotli();
     static native int tlsExtCertCompressionZstd();
+
+    static native int sslAuthRsa();
+    static native int sslAuthDss();
+    static native int sslAuthNull();
+    static native int sslAuthEcdsa();
 }

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -673,6 +673,32 @@ public final class SSL {
     public static native String[] authenticationMethods(long ssl);
 
     /**
+     * Return the authentication methods packed into an {@code int}, avoiding {@code String[]} allocation.
+     * Each bit corresponds to an OpenSSL {@code SSL_a*} authentication constant (see sslutils.c):
+     * <p>
+     * Common (produced by all code paths):
+     * <ul>
+     *     <li>{@code 0x0001} (SSL_aRSA)   - RSA authentication (RSA, DHE_RSA, ECDHE_RSA)</li>
+     *     <li>{@code 0x0002} (SSL_aDSS)   - DSS authentication (DHE_DSS)</li>
+     *     <li>{@code 0x0004} (SSL_aNULL)  - no auth / anonymous (DH_anon, ECDH_anon)</li>
+     *     <li>{@code 0x0040} (SSL_aECDSA) - ECDSA authentication (ECDHE_ECDSA)</li>
+     * </ul>
+     * Legacy (only possible on OpenSSL &lt; 1.1.0):
+     * <ul>
+     *     <li>{@code 0x0008} (SSL_aDH)     - Fixed DH auth</li>
+     *     <li>{@code 0x0010} (SSL_aECDH)   - Fixed ECDH auth</li>
+     *     <li>{@code 0x0020} (SSL_aKRB5)   - KRB5 auth</li>
+     *     <li>{@code 0x0080} (SSL_aPSK)    - PSK auth</li>
+     *     <li>{@code 0x0100} (SSL_aGOST94) - GOST R 34.10-94 auth</li>
+     *     <li>{@code 0x0200} (SSL_aGOST01) - GOST R 34.10-2001 auth</li>
+     * </ul>
+     *
+     * @param ssl the SSL instance (SSL*)
+     * @return the packed authentication methods as a bitmask
+     */
+    public static native int authenticationMethodsPacked(long ssl);
+
+    /**
      * Set BIO of PEM-encoded Server CA Certificates
      * <p>
      * This directive sets the optional all-in-one file where you can assemble the

--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -124,6 +124,16 @@ public final class SSL {
     public static final int SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS = sslCertCompressionDirectionDecompress();
     public static final int SSL_CERT_COMPRESSION_DIRECTION_BOTH = sslCertCompressionDirectionBoth();
 
+    /**
+     * Authentication method bits returned by {@link #authenticationMethodsPacked(long)}. Each constant
+     * corresponds to an OpenSSL {@code SSL_a*} authentication algorithm (see {@code sslutils.c}) and is
+     * initialized from native code so the Java and C definitions can not drift apart.
+     */
+    public static final int SSL_A_RSA = sslAuthRsa();
+    public static final int SSL_A_DSS = sslAuthDss();
+    public static final int SSL_A_NULL = sslAuthNull();
+    public static final int SSL_A_ECDSA = sslAuthEcdsa();
+
     /* Return OpenSSL version number */
     public static native int version();
 
@@ -674,27 +684,21 @@ public final class SSL {
 
     /**
      * Return the authentication methods packed into an {@code int}, avoiding {@code String[]} allocation.
-     * Each bit corresponds to an OpenSSL {@code SSL_a*} authentication constant (see sslutils.c):
-     * <p>
-     * Common (produced by all code paths):
+     * The returned value is a bitmask; each bit corresponds to one of the {@code SSL_A_*} constants
+     * defined in this class:
      * <ul>
-     *     <li>{@code 0x0001} (SSL_aRSA)   - RSA authentication (RSA, DHE_RSA, ECDHE_RSA)</li>
-     *     <li>{@code 0x0002} (SSL_aDSS)   - DSS authentication (DHE_DSS)</li>
-     *     <li>{@code 0x0004} (SSL_aNULL)  - no auth / anonymous (DH_anon, ECDH_anon)</li>
-     *     <li>{@code 0x0040} (SSL_aECDSA) - ECDSA authentication (ECDHE_ECDSA)</li>
+     *     <li>{@link #SSL_A_RSA}   - RSA authentication (RSA, DHE_RSA, ECDHE_RSA)</li>
+     *     <li>{@link #SSL_A_DSS}   - DSS authentication (DHE_DSS)</li>
+     *     <li>{@link #SSL_A_NULL}  - no auth / anonymous (DH_anon, ECDH_anon)</li>
+     *     <li>{@link #SSL_A_ECDSA} - ECDSA authentication (ECDHE_ECDSA)</li>
      * </ul>
-     * Legacy (only possible on OpenSSL &lt; 1.1.0):
-     * <ul>
-     *     <li>{@code 0x0008} (SSL_aDH)     - Fixed DH auth</li>
-     *     <li>{@code 0x0010} (SSL_aECDH)   - Fixed ECDH auth</li>
-     *     <li>{@code 0x0020} (SSL_aKRB5)   - KRB5 auth</li>
-     *     <li>{@code 0x0080} (SSL_aPSK)    - PSK auth</li>
-     *     <li>{@code 0x0100} (SSL_aGOST94) - GOST R 34.10-94 auth</li>
-     *     <li>{@code 0x0200} (SSL_aGOST01) - GOST R 34.10-2001 auth</li>
-     * </ul>
+     * On OpenSSL &lt; 1.1.0 additional legacy bits (e.g. {@code SSL_aDH 0x0008}, {@code SSL_aECDH 0x0010},
+     * {@code SSL_aKRB5 0x0020}, {@code SSL_aPSK 0x0080}, {@code SSL_aGOST94 0x0100},
+     * {@code SSL_aGOST01 0x0200}) may also be set, as they are passed through directly from OpenSSL's
+     * {@code algorithm_auth}.
      *
      * @param ssl the SSL instance (SSL*)
-     * @return the packed authentication methods as a bitmask
+     * @return the packed authentication methods as a bitmask of {@code SSL_A_*} values
      */
     public static native int authenticationMethodsPacked(long ssl);
 

--- a/openssl-dynamic/src/main/c/native_constants.c
+++ b/openssl-dynamic/src/main/c/native_constants.c
@@ -636,6 +636,22 @@ TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, tlsExtCertCompres
     return TLSEXT_cert_compression_zstd;
 }
 
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslAuthRsa)(TCN_STDARGS) {
+    return (jint) TCN_SSL_aRSA;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslAuthDss)(TCN_STDARGS) {
+    return (jint) TCN_SSL_aDSS;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslAuthNull)(TCN_STDARGS) {
+    return (jint) TCN_SSL_aNULL;
+}
+
+TCN_IMPLEMENT_CALL(jint, NativeStaticallyReferencedJniMethods, sslAuthEcdsa)(TCN_STDARGS) {
+    return (jint) TCN_SSL_aECDSA;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslOpCipherServerPreference, ()I, NativeStaticallyReferencedJniMethods) },
@@ -770,7 +786,11 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(sslCertCompressionDirectionBoth, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionZlib, ()I, NativeStaticallyReferencedJniMethods) },
   { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionBrotli, ()I, NativeStaticallyReferencedJniMethods) },
-  { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionZstd, ()I, NativeStaticallyReferencedJniMethods) }
+  { TCN_METHOD_TABLE_ENTRY(tlsExtCertCompressionZstd, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslAuthRsa, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslAuthDss, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslAuthNull, ()I, NativeStaticallyReferencedJniMethods) },
+  { TCN_METHOD_TABLE_ENTRY(sslAuthEcdsa, ()I, NativeStaticallyReferencedJniMethods) }
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1998,6 +1998,107 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
     return array;
 }
 
+/* Bits for algorithm_auth, same as defined in sslutils.c */
+#define TCN_SSL_aRSA    0x00000001L
+#define TCN_SSL_aDSS    0x00000002L
+#define TCN_SSL_aNULL   0x00000004L
+#define TCN_SSL_aECDSA  0x00000040L
+#define TCN_SSL_aALL    (TCN_SSL_aRSA | TCN_SSL_aDSS | TCN_SSL_aNULL | TCN_SSL_aECDSA)
+
+/**
+ * Returns authentication methods packed into an int, avoiding String[] allocation.
+ * Uses the same bit values as OpenSSL's algorithm_auth constants (see sslutils.c):
+ *
+ * Common (produced by all code paths):
+ *   0x0001 (SSL_aRSA)    - RSA authentication (RSA, DHE_RSA, ECDHE_RSA)
+ *   0x0002 (SSL_aDSS)    - DSS authentication (DHE_DSS)
+ *   0x0004 (SSL_aNULL)   - no auth / anonymous (DH_anon, ECDH_anon)
+ *   0x0040 (SSL_aECDSA)  - ECDSA authentication (ECDHE_ECDSA)
+ *
+ * Legacy (only possible on OpenSSL < 1.1.0, passed through from algorithm_auth):
+ *   0x0008 (SSL_aDH)     - Fixed DH auth
+ *   0x0010 (SSL_aECDH)   - Fixed ECDH auth
+ *   0x0020 (SSL_aKRB5)   - KRB5 auth
+ *   0x0080 (SSL_aPSK)    - PSK auth
+ *   0x0100 (SSL_aGOST94) - GOST R 34.10-94 auth
+ *   0x0200 (SSL_aGOST01) - GOST R 34.10-2001 auth
+ */
+TCN_IMPLEMENT_CALL(jint, SSL, authenticationMethodsPacked)(TCN_STDARGS, jlong ssl) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+    const STACK_OF(SSL_CIPHER) *ciphers = NULL;
+    int len;
+    int i;
+    jint packed = 0;
+
+    TCN_CHECK_NULL(ssl_, ssl, 0);
+
+    ciphers = SSL_get_ciphers(ssl_);
+    len = sk_SSL_CIPHER_num(ciphers);
+
+    for (i = 0; i < len; i++) {
+        const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
+
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+        // BoringSSL/AWS-LC: classify by exact kx_name
+        const char *name = SSL_CIPHER_get_kx_name(cipher);
+        if (name == NULL) {
+            continue;
+        }
+        // TLS 1.3 ciphers report "GENERIC" and appear first in the list — skip early
+        if (strcmp(name, "GENERIC") == 0) {
+            continue;
+        }
+        if (strcmp(name, "RSA") == 0 ||
+            strcmp(name, "DHE_RSA") == 0 ||
+            strcmp(name, "ECDHE_RSA") == 0) {
+            packed |= TCN_SSL_aRSA;
+        } else if (strcmp(name, "ECDHE_ECDSA") == 0) {
+            packed |= TCN_SSL_aECDSA;
+        } else if (strcmp(name, "DH_anon") == 0 ||
+                   strcmp(name, "ECDH_anon") == 0) {
+            packed |= TCN_SSL_aNULL;
+        } else if (strcmp(name, "DHE_DSS") == 0) {
+            packed |= TCN_SSL_aDSS;
+        }
+        // All common bits set — no point continuing
+        if ((packed & TCN_SSL_aALL) == TCN_SSL_aALL) {
+            break;
+        }
+
+#elif OPENSSL_VERSION_NUMBER >= 0x10100000L && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+        // OpenSSL 1.1.0+ / LibreSSL 2.7.0+: use NID-based API
+        switch (SSL_CIPHER_get_auth_nid(cipher)) {
+            case NID_auth_rsa:
+                packed |= TCN_SSL_aRSA;
+                break;
+#ifndef LIBRESSL_VERSION_NUMBER
+            case NID_auth_dss:
+                packed |= TCN_SSL_aDSS;
+                break;
+#endif
+            case NID_auth_null:
+                packed |= TCN_SSL_aNULL;
+                break;
+            case NID_auth_ecdsa:
+                packed |= TCN_SSL_aECDSA;
+                break;
+        }
+        // All common bits set — no point continuing
+        if ((packed & TCN_SSL_aALL) == TCN_SSL_aALL) {
+            break;
+        }
+
+#else
+        // Older OpenSSL (< 1.1.0): read algorithm_auth directly from struct.
+        // May include legacy bits (SSL_aDH, SSL_aECDH, SSL_aKRB5, etc.)
+        // not produced by the BoringSSL/OpenSSL 1.1+ code paths above.
+        packed |= (jint) cipher->algorithm_auth;
+#endif
+    }
+
+    return packed;
+}
+
 TCN_IMPLEMENT_CALL(void, SSL, setCertificateBio)(TCN_STDARGS, jlong ssl,
                                                          jlong cert, jlong key,
                                                          jstring password)
@@ -2761,6 +2862,7 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(setTlsExtHostName0, (JLjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setHostNameValidation, (JILjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(authenticationMethods, (J)[Ljava/lang/String;, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(authenticationMethodsPacked, (J)I, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setCertificateBio, (JJJLjava/lang/String;)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setCertificateChainBio, (JJZ)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(loadPrivateKeyFromEngine, (Ljava/lang/String;Ljava/lang/String;)J, SSL) },

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1998,30 +1998,10 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
     return array;
 }
 
-/* Bits for algorithm_auth, same as defined in sslutils.c */
-#define TCN_SSL_aRSA    0x00000001L
-#define TCN_SSL_aDSS    0x00000002L
-#define TCN_SSL_aNULL   0x00000004L
-#define TCN_SSL_aECDSA  0x00000040L
-#define TCN_SSL_aALL    (TCN_SSL_aRSA | TCN_SSL_aDSS | TCN_SSL_aNULL | TCN_SSL_aECDSA)
-
-/**
+/*
  * Returns authentication methods packed into an int, avoiding String[] allocation.
- * Uses the same bit values as OpenSSL's algorithm_auth constants (see sslutils.c):
- *
- * Common (produced by all code paths):
- *   0x0001 (SSL_aRSA)    - RSA authentication (RSA, DHE_RSA, ECDHE_RSA)
- *   0x0002 (SSL_aDSS)    - DSS authentication (DHE_DSS)
- *   0x0004 (SSL_aNULL)   - no auth / anonymous (DH_anon, ECDH_anon)
- *   0x0040 (SSL_aECDSA)  - ECDSA authentication (ECDHE_ECDSA)
- *
- * Legacy (only possible on OpenSSL < 1.1.0, passed through from algorithm_auth):
- *   0x0008 (SSL_aDH)     - Fixed DH auth
- *   0x0010 (SSL_aECDH)   - Fixed ECDH auth
- *   0x0020 (SSL_aKRB5)   - KRB5 auth
- *   0x0080 (SSL_aPSK)    - PSK auth
- *   0x0100 (SSL_aGOST94) - GOST R 34.10-94 auth
- *   0x0200 (SSL_aGOST01) - GOST R 34.10-2001 auth
+ * The TCN_SSL_a* bits are defined in ssl_private.h (shared with native_constants.c, which exposes
+ * them to Java as SSL.SSL_A_* constants). See SSL#authenticationMethodsPacked for the full bit list.
  */
 TCN_IMPLEMENT_CALL(jint, SSL, authenticationMethodsPacked)(TCN_STDARGS, jlong ssl) {
     SSL *ssl_ = J2P(ssl, SSL *);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -123,6 +123,19 @@
 
 extern const char* TCN_UNKNOWN_AUTH_METHOD;
 
+/*
+ * Bits for the packed authentication methods returned by SSL.authenticationMethodsPacked(...).
+ * These use the same values as OpenSSL's algorithm_auth constants (see sslutils.c) so the legacy
+ * (OpenSSL < 1.1.0) code path can pass cipher->algorithm_auth through directly. They are defined
+ * here as the single source of truth: ssl.c uses them to build the bitmask and native_constants.c
+ * exposes them to Java via NativeStaticallyReferencedJniMethods.
+ */
+#define TCN_SSL_aRSA    0x00000001L
+#define TCN_SSL_aDSS    0x00000002L
+#define TCN_SSL_aNULL   0x00000004L
+#define TCN_SSL_aECDSA  0x00000040L
+#define TCN_SSL_aALL    (TCN_SSL_aRSA | TCN_SSL_aDSS | TCN_SSL_aNULL | TCN_SSL_aECDSA)
+
 /* ECC: make sure we have at least 1.0.0 */
 #if !defined(OPENSSL_NO_EC) && defined(TLSEXT_ECPOINTFORMAT_uncompressed)
 #define HAVE_ECC              1


### PR DESCRIPTION
Currently, `authenticationMethods()` allocates multiple strings and a string array during initial connection. This could be avoided with a new method, where we pack all auth methods into a single int. This will also simplify code on the Netty side (2 switch statements could be removed in `OpenSslKeyMaterialManager.setKeyMaterialServerSide`).

<img width="1224" height="262" alt="image" src="https://github.com/user-attachments/assets/cf69d23d-2b4d-4e8b-92fa-07dad828cc5c" />
