### PR TITLE
Correctly keep track of array len and number of certs when using async verifier

### DIFF
--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -409,6 +409,10 @@ struct tcn_ssl_state_t {
     tcn_ssl_ctxt_t *ctx;
     tcn_ssl_task_t* ssl_task;
     tcn_ssl_verify_config_t verify_config;
+    // Saved at async task creation time so the retry path can reproduce the
+    // len < sk_CRYPTO_BUFFER_num(chain) check (both locals are 0/NULL there).
+    int task_array_len;
+    int task_chain_num;
 };
 
 #define TCN_GET_SSL_CTX(ssl, C)                             \

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1707,7 +1707,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 
         // If we failed to verify for an unknown reason (currently this happens if we can't find a common root) then we should
         // fail with the same status as recommended in the OpenSSL docs https://www.openssl.org/docs/man1.0.2/ssl/SSL_set_verify.html
-        if (result == X509_V_ERR_UNSPECIFIED && len < sk_CRYPTO_BUFFER_num(chain)) {
+        if (result == X509_V_ERR_UNSPECIFIED && state->task_array_len < state->task_chain_num) {
             result = X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
         }
         goto complete;
@@ -1747,6 +1747,8 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
         if ((state->ssl_task = tcn_ssl_task_new(e, task)) == NULL) {
             goto complete;
         }
+        state->task_array_len = len;
+        state->task_chain_num = sk_CRYPTO_BUFFER_num(chain);
 
          // Signal back that we want to suspend the handshake.
         ret = ssl_verify_retry;


### PR DESCRIPTION
Motivation:

We didn't correct keep state when using the async verifier

Modifications:

Keep track of the array length and number of certs in the chain so we can use them in retry path

Result:

The X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY substitution will now fire correctly when the async verifier returns X509_V_ERR_UNSPECIFIED due to a truncated chain.
