### PR TITLE
Clear exception if happens during keylog_cb

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/KeyLogCallback.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/KeyLogCallback.java
@@ -38,6 +38,8 @@ public interface KeyLogCallback {
      * <p>
      * <strong>Warning:</strong> The log output will contain secret key material, and can be used to decrypt
      * TLS sessions! The log output should be handled with the same care given to the private keys.
+     * <p>
+     * This method is expected to never throw any {@link Throwable} as everything will just be silently discarded.
      *
      * @param ssl  the SSL instance
      * @param line an array of the key types on client-mode or {@code null} on server-mode.

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2670,6 +2670,10 @@ static void keylog_cb(const SSL* ssl, const char *line) {
     // Execute the java callback
     (*e)->CallVoidMethod(e, state->ctx->keylog_callback, state->ctx->keylog_callback_method,
                 P2J(ssl), outputLine);
+    // Clear the exception if any was thrown as otherwise we might corrupt the JNI state
+    if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
+        (*e)->ExceptionClear(e);
+    }
 }
 #endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 


### PR DESCRIPTION
Motivation:

If our java method throws in the keylog function we need to clear the exception as otherwise we might end up corrupting the JNI state

Modifications:

- Cheack if exception was thrown and if so clear it

Result:

No more risk of corrupted JNI state
