### PR TITLE
Delete local reference when creating a lot in a loop to ensure we not overflow

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1631,6 +1631,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
             return NULL;
         }
         (*e)->SetObjectArrayElement(e, array, i, c_name);
+        (*e)->DeleteLocalRef(e, c_name);
     }
     return array;
 }
@@ -1994,6 +1995,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, authenticationMethods)(TCN_STDARGS, jlong 
             return NULL;
         }
         (*e)->SetObjectArrayElement(e, array, i, methodString);
+        (*e)->DeleteLocalRef(e, methodString);
     }
     return array;
 }


### PR DESCRIPTION
Motivation:

JNI has a maximum limit of how many local reference you can put on the stack so we should better ensure we never overflow this limit. This is especially important
when creating these in loops as it is impossible to know how many iterations we have. In practice this should be no problem in our code but better fix it.

Modifications:

- Delete local references when created in loops

Result:

More robust code
