### PR TITLE
Guard against GetStringUTFChars(...) return NULL

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1645,6 +1645,9 @@ TCN_IMPLEMENT_CALL(jboolean, SSL, setCurvesList0)(TCN_STDARGS, jlong ssl, jstrin
         return JNI_FALSE;
     }
     const char *nativeString = (*e)->GetStringUTFChars(e, curves, 0);
+    if (nativeString == NULL) {
+        return JNI_FALSE;
+    }
     int ret = tcn_SSL_set1_curves_list(ssl_, nativeString);
     (*e)->ReleaseStringUTFChars(e, curves, nativeString);
 
@@ -1958,6 +1961,9 @@ TCN_IMPLEMENT_CALL(void, SSL, setHostNameValidation)(TCN_STDARGS, jlong ssl, jin
     }
 
     const char *hostname = (*e)->GetStringUTFChars(e, hostnameString, JNI_FALSE);
+    if (hostname == NULL) {
+        return;
+    }
 
     if (X509_VERIFY_PARAM_set1_host(param, hostname, hostnameLen) != 1) {
         char err[ERR_LEN];

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2862,6 +2862,9 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, setCurvesList0)(TCN_STDARGS, jlong ctx,
         return JNI_FALSE;
     }
     const char *nativeString = (*e)->GetStringUTFChars(e, curves, 0);
+    if (nativeString == NULL) {
+        return JNI_FALSE;
+    }
     int ret = tcn_SSL_CTX_set1_curves_list(c->ctx, nativeString);
     (*e)->ReleaseStringUTFChars(e, curves, nativeString);
 


### PR DESCRIPTION
Motivation:

GetStringUTFChars(...) might return NULL if we run out of memory. Let's handle it and not crash by return early.

Modifications:

Add missign NULL checks

Result:

More robust code
