### PR TITLE
Correctly build boringssl-static for linux aarch64

### DIFF
--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -717,6 +717,22 @@
       </properties>
 
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <dependencies>
+                <!-- Provides the 'requireFilesContent' enforcer rule. -->
+                <dependency>
+                  <groupId>com.ceilfors.maven.plugin</groupId>
+                  <artifactId>enforcer-rules</artifactId>
+                  <version>1.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-enforcer-plugin</artifactId>
@@ -735,6 +751,15 @@
                       <property>os.detected.classifier</property>
                       <regex>^linux-x86_64.*</regex>
                     </requireProperty>
+                    <requireFilesContent>
+                      <message>
+                        Cross compile and Release process must be performed on RHEL 7.6 or its derivatives.
+                      </message>
+                      <files>
+                        <file>/etc/redhat-release</file>
+                      </files>
+                      <content>release 7.6</content>
+                    </requireFilesContent>
                   </rules>
                   <ignoreCache>true</ignoreCache>
                 </configuration>

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 centos:7.9.2009
+FROM --platform=linux/amd64 centos:7.6.1810
 
 ARG gcc_version=10.2-2020.11
 ARG openssl_version=1_1_1d
@@ -15,7 +15,10 @@ RUN mkdir $SOURCE_DIR
 WORKDIR $SOURCE_DIR
 
 # Update to use the vault
-RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/7.9.2009\//g' /etc/yum.repos.d/CentOS-Base.repo
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/7.6.1810\//g' /etc/yum.repos.d/CentOS-Base.repo
+
+# We want to have git 2.x for the maven scm plugin and also for boringssl
+RUN yum install -y https://opensource.blueoptima.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
 
 # Install requirements
 RUN  set -x && \

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -345,6 +345,18 @@
                 </archive>
               </configuration>
             </plugin>
+            <plugin>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <dependencies>
+                <!-- Provides the 'requireFilesContent' enforcer rule. -->
+                <dependency>
+                  <groupId>com.ceilfors.maven.plugin</groupId>
+                  <artifactId>enforcer-rules</artifactId>
+                  <version>1.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
           </plugins>
         </pluginManagement>
 
@@ -366,6 +378,15 @@
                       <property>os.detected.classifier</property>
                       <regex>^linux-x86_64.*</regex>
                     </requireProperty>
+                    <requireFilesContent>
+                      <message>
+                        Cross compile and Release process must be performed on RHEL 7.6 or its derivatives.
+                      </message>
+                      <files>
+                        <file>/etc/redhat-release</file>
+                      </files>
+                      <content>release 7.6</content>
+                    </requireFilesContent>
                     <requireProperty>
                       <property>aprArmHome</property>
                       <message>The folder of APR for aarch64 must be specified by hand. Please try -DaprArmHome=</message>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
   <properties>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <checkstyle.skip>true</checkstyle.skip>
-    <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
+    <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
@@ -161,6 +161,14 @@
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${enforcer.plugin.version}</version>
+          <dependencies>
+            <!-- Provides the 'requireFilesContent' enforcer rule. -->
+            <dependency>
+              <groupId>com.ceilfors.maven.plugin</groupId>
+              <artifactId>enforcer-rules</artifactId>
+              <version>1.2.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.fusesource.hawtjni</groupId>
@@ -839,10 +847,27 @@
                       <property>os.detected.classifier</property>
                       <regex>^linux-x86_64$</regex>
                     </requireProperty>
+                    <requireFilesContent>
+                      <message>
+                        Release process must be performed on RHEL 6.8 or its derivatives.
+                      </message>
+                      <files>
+                        <file>/etc/redhat-release</file>
+                      </files>
+                      <content>release 6.</content>
+                    </requireFilesContent>
                   </rules>
                 </configuration>
               </execution>
             </executions>
+            <dependencies>
+              <!-- Provides the 'requireFilesContent' enforcer rule. -->
+              <dependency>
+                <groupId>com.ceilfors.maven.plugin</groupId>
+                <artifactId>enforcer-rules</artifactId>
+                <version>1.2.0</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Motivation:

This reverts commit 689e4d57de6011e8711a6281b983f004097a658a as it broke the cross-compilation.

Modifications:

Revert "Fix creation of docker image for cross compilation (#956)"

Result:
Fixes https://github.com/netty/netty-tcnative/issues/974