### PR TITLE
Clear certificate chain in setKeyMaterial.

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2333,7 +2333,6 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         return;
     }
 
-
     // The first cert was loaded via SSL_use_certificate so skip it.
     for (i = 1; i < numCerts; ++i) {
 

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2316,6 +2316,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         }
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     // Clear the chain; the loop below appends certificates to the
     // chain, and in TLS 1.3, this can be called again after the
     // server sends a HelloRetryRequest. Without clearing the
@@ -2332,6 +2333,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         }
         return;
     }
+#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
     // The first cert was loaded via SSL_use_certificate so skip it.
     for (i = 1; i < numCerts; ++i) {

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2316,6 +2316,24 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         }
     }
 
+    // Clear the chain; the loop below appends certificates to the
+    // chain, and in TLS 1.3, this can be called again after the
+    // server sends a HelloRetryRequest. Without clearing the
+    // certificate chain that results in duplicate entries.
+    if (tcn_SSL_clear_chain_certs(ssl_) != 1) {
+        int errCode = ERR_get_error();
+        if (errCode == 0) {
+            tcn_Throw(e, "Could not clear certificate chain (unknown)");
+        } else {
+            ERR_error_string_n(errCode, err, ERR_LEN);
+            ERR_clear_error();
+
+            tcn_Throw(e, "Could not clear certificate chain (%s)", err);
+        }
+        return;
+    }
+
+
     // The first cert was loaded via SSL_use_certificate so skip it.
     for (i = 1; i < numCerts; ++i) {
 

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2316,7 +2316,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         }
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
     // Clear the chain; the loop below appends certificates to the
     // chain, and in TLS 1.3, this can be called again after the
     // server sends a HelloRetryRequest. Without clearing the
@@ -2333,7 +2333,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
         }
         return;
     }
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
     // The first cert was loaded via SSL_use_certificate so skip it.
     for (i = 1; i < numCerts; ++i) {

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2320,7 +2320,7 @@ TCN_IMPLEMENT_CALL(void, SSL, setKeyMaterial)(TCN_STDARGS, jlong ssl, jlong chai
     // chain, and in TLS 1.3, this can be called again after the
     // server sends a HelloRetryRequest. Without clearing the
     // certificate chain that results in duplicate entries.
-    if (tcn_SSL_clear_chain_certs(ssl_) != 1) {
+    if (SSL_clear_chain_certs(ssl_) != 1) {
         int errCode = ERR_get_error();
         if (errCode == 0) {
             tcn_Throw(e, "Could not clear certificate chain (unknown)");

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -473,7 +473,6 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #define tcn_SSL_add1_chain_cert(ssl, x509) SSL_add1_chain_cert(ssl, x509)
 #define tcn_SSL_add0_chain_cert(ssl, x509) SSL_add0_chain_cert(ssl, x509)
-#define tcn_SSL_clear_chain_certs(ssl) SSL_clear_chain_certs(ssl)
 #endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 #define tcn_SSL_get0_certificate_types(ssl, clist) SSL_get0_certificate_types(ssl, clist)

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -473,6 +473,7 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #define tcn_SSL_add1_chain_cert(ssl, x509) SSL_add1_chain_cert(ssl, x509)
 #define tcn_SSL_add0_chain_cert(ssl, x509) SSL_add0_chain_cert(ssl, x509)
+#define tcn_SSL_clear_chain_certs(ssl) SSL_clear_chain_certs(ssl)
 #endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 
 #define tcn_SSL_get0_certificate_types(ssl, clist) SSL_get0_certificate_types(ssl, clist)


### PR DESCRIPTION
Fixes #985.

Netty calls SSL.setKeyMaterial in its server-side certificate callback (https://docs.openssl.org/3.6/man3/SSL_CTX_set_cert_cb/ but the same going back to 1.0.2). OpenSSL invokes certificate callbacks after the server receives a ClientHello.

TLS 1.2 TLS sessions usually had one ClientHello, so this callback would usually run once. TLS 1.3, however, might begin a session with multiple ClientHellos as the result of
HelloRetryRequests. SSL.setKeyMaterial adds chained certificates (intermediates and roots) to the per-connection SSL struct with SSL_add1_chain_certs. This function appends certificates, so every time a ClientHello arrives, setKeyMaterial would re-add the same chain. Finicky clients fail if they receive the same intermediate twice.

This change allows netty-tcnative to talk TLS 1.3 with these clients. It clears the SSL struct's certificate chain (that is, everything after the certificate assigned with SSL_use_certificate) on every setKeyMaterial call. Multiple ClientHellos will result in the same key meterial appearing in Certificate responses.

Note that this should improve correctness for TLS 1.2, as well, since renegotiation for e.g. rekeying would have suffered from the same duplicate intermediates issue.