### PR TITLE
Fix linux-x86_64 openssl-dynamic to link against OpenSSL 3.x

### DIFF
--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -66,8 +66,7 @@ RUN set -x && \
   # no-asm: devtoolset-9 on CentOS 6 cannot reliably compile OpenSSL's hand-tuned x86_64 assembly
   ./Configure linux-x86_64 --prefix=/opt/openssl-$OPENSSL_VERSION --libdir=lib shared no-asm no-apps && \
   make -j1 install_sw) && \
-  rm -rf openssl-$OPENSSL_VERSION openssl-$OPENSSL_VERSION.tar.gz && \
-  ln -sf /opt/openssl-$OPENSSL_VERSION /usr/local/ssl
+  rm -rf openssl-$OPENSSL_VERSION openssl-$OPENSSL_VERSION.tar.gz
 
 RUN rm -rf $SOURCE_DIR
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -68,8 +68,7 @@ RUN set -x && \
   # no-asm: the custom GCC on Debian 7 cannot reliably compile OpenSSL's hand-tuned x86_64 assembly
   ./Configure linux-x86_64 --prefix=/opt/openssl-$OPENSSL_VERSION --libdir=lib shared no-asm no-apps && \
   make -j1 install_sw) && \
-  rm -rf openssl-$OPENSSL_VERSION openssl-$OPENSSL_VERSION.tar.gz && \
-  ln -sf /opt/openssl-$OPENSSL_VERSION /usr/local/ssl
+  rm -rf openssl-$OPENSSL_VERSION openssl-$OPENSSL_VERSION.tar.gz
 
 RUN rm -rf $SOURCE_DIR
 

--- a/docker/docker-compose.centos-6.yaml
+++ b/docker/docker-compose.centos-6.yaml
@@ -28,11 +28,11 @@ services:
 
   build-clean:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package"
+    command: /bin/bash -cl "./mvnw clean package -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   build:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package"
+    command: /bin/bash -cl "./mvnw clean package -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   stage-snapshot:
     <<: *common
@@ -42,7 +42,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic,boringssl-static clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   stage-release:
     <<: *common
@@ -52,7 +52,7 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pstage -am -pl openssl-dynamic,boringssl-static clean javadoc:jar package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pstage -am -pl openssl-dynamic,boringssl-static clean javadoc:jar package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   deploy:
     <<: *common
@@ -62,7 +62,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
-    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   shell:
     <<: *common

--- a/docker/docker-compose.debian.yaml
+++ b/docker/docker-compose.debian.yaml
@@ -28,7 +28,7 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package"
+    command: /bin/bash -cl "./mvnw clean package -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   deploy-dynamic-only:
     <<: *common
@@ -38,11 +38,11 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ..:/code
-    command: /bin/bash -cl "./mvnw -am -pl openssl-dynamic clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -am -pl openssl-dynamic clean deploy -DskipTests=true -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   build-dynamic-only:
     <<: *common
-    command: /bin/bash -cl "./mvnw -am -pl openssl-dynamic clean package"
+    command: /bin/bash -cl "./mvnw -am -pl openssl-dynamic clean package -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   stage-snapshot:
     <<: *common
@@ -52,7 +52,7 @@ services:
       - ~/.m2/repository:/root/.m2/repository
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Pstage -am -pl openssl-dynamic clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipTests=true -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   stage-release:
     <<: *common
@@ -66,7 +66,7 @@ services:
       - ~/.m2/settings.xml:/root/.m2/settings.xml
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pstage -am -pl openssl-dynamic clean javadoc:jar package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pstage -am -pl openssl-dynamic clean javadoc:jar package gpg:sign org.sonatype.central:central-publishing-maven-plugin:publish -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} -DopensslHome=/opt/openssl-$$OPENSSL_VERSION"
 
   shell:
     <<: *common

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -414,8 +414,8 @@
       </build>
     </profile>
 
-    <!-- Activated by -DopensslHome=DIR; overrides configureArgs to pass --with-ssl so the
-         native configure picks up OpenSSL 3.x built from source instead of the system 1.0.x. -->
+    <!-- Activated by -DopensslHome=DIR; passes the custom OpenSSL install path to configure
+         so the native build picks up OpenSSL 3.x from source instead of the system 1.0.x. -->
     <profile>
       <id>with-openssl-home</id>
       <activation>

--- a/openssl-dynamic/pom.xml
+++ b/openssl-dynamic/pom.xml
@@ -413,5 +413,40 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Activated by -DopensslHome=DIR; overrides configureArgs to pass --with-ssl so the
+         native configure picks up OpenSSL 3.x built from source instead of the system 1.0.x. -->
+    <profile>
+      <id>with-openssl-home</id>
+      <activation>
+        <property>
+          <name>opensslHome</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>hawtjni-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <configureArgs>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>--with-ssl=${opensslHome}</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+                <phase>compile</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The previous fix (PR #986) built OpenSSL 3.x from source and symlinked /usr/local/ssl -> /opt/openssl-$VERSION, expecting tcnative's configure to find it via the default search path. This didn't work: the native build was still picking up the system OpenSSL 1.0.x.

Fix: pass -DopensslHome explicitly to every build command in the centos6 and debian7 docker-compose files, and add a Maven profile in openssl-dynamic/pom.xml that activates on -DopensslHome and forwards --with-ssl to configure. Remove the now-unnecessary symlink.

Verified the RPATH for each to verify fixed:
  │ linux-x86_64-fedora (centos6)   │ libssl.so.3               │ /opt/openssl-3.6.1/lib       │   ✅   │
  │ linux-aarch_64-fedora (centos7) │ libssl.so.3               │ /opt/openssl-3.6.1-share/lib │   ✅   │
  │ linux-x86_64 (debian7)          │ libssl.so.3               │ /opt/openssl-3.6.1/lib       │   ✅