### PR TITLE
Add SSL.getGroupName(...) which returns the name of the used by ssl's most recently completed handshake

### DIFF
--- a/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
+++ b/openssl-classes/src/main/java/io/netty/internal/tcnative/SSL.java
@@ -1003,4 +1003,13 @@ public final class SSL {
      * @throws Exception if an error occurred
      */
     public static native long getSelectedCredential(long ssl) throws Exception;
+
+    /**
+     * Get the name of the group used by ssl's most recently completed handshake, or {@code null} if not applicable.
+     *
+     * @param ssl   the SSL instance (SSL *)
+     * @return      the name of the group or {@code null}
+     * @throws Exception if an error occurred
+     */
+    public static native String getGroupName(long ssl) throws Exception;
 }

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1600,7 +1600,7 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getGroupName)(TCN_STDARGS, jlong ssl) {
 
     TCN_CHECK_NULL(ssl_, ssl, JNI_FALSE);
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x30200000L)
     return NULL;
 #else
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1595,6 +1595,31 @@ TCN_IMPLEMENT_CALL(jint, SSL, getMaxWrapOverhead)(TCN_STDARGS, jlong ssl)
 #endif
 }
 
+TCN_IMPLEMENT_CALL(jstring, SSL, getGroupName)(TCN_STDARGS, jlong ssl) {
+    SSL *ssl_ = J2P(ssl, SSL *);
+
+    TCN_CHECK_NULL(ssl_, ssl, JNI_FALSE);
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+    return NULL;
+#else
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+    int id = SSL_get_group_id(ssl_);
+    if (id == 0) {
+        return NULL;
+    }
+
+    const char* name = SSL_get_group_name(id);
+#else
+    const char* name =SSL_get0_group_name(ssl_);
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+    if (name == NULL) {
+        return NULL;
+    }
+    return (*e)->NewStringUTF(e, name);
+#endif // defined(LIBRESSL_VERSION_NUMBER)
+}
+
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)
 {
     STACK_OF(SSL_CIPHER) *sk = NULL;
@@ -2810,7 +2835,8 @@ static const JNINativeMethod method_table[] = {
   { TCN_METHOD_TABLE_ENTRY(isSessionReused, (J)Z, SSL) },
   { TCN_METHOD_TABLE_ENTRY(setRenegotiateMode, (JI)V, SSL) },
   { TCN_METHOD_TABLE_ENTRY(addCredential, (JJ)V, SSL) },
-  { TCN_METHOD_TABLE_ENTRY(getSelectedCredential, (J)J, SSL) }
+  { TCN_METHOD_TABLE_ENTRY(getSelectedCredential, (J)J, SSL) },
+  { TCN_METHOD_TABLE_ENTRY(getGroupName, (J)Ljava/lang/String;, SSL) }
 };
 
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -1600,9 +1600,6 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getGroupName)(TCN_STDARGS, jlong ssl) {
 
     TCN_CHECK_NULL(ssl_, ssl, JNI_FALSE);
 
-#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x30200000L)
-    return NULL;
-#else
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     int id = SSL_get_group_id(ssl_);
     if (id == 0) {
@@ -1610,14 +1607,19 @@ TCN_IMPLEMENT_CALL(jstring, SSL, getGroupName)(TCN_STDARGS, jlong ssl) {
     }
 
     const char* name = SSL_get_group_name(id);
-#else
-    const char* name =SSL_get0_group_name(ssl_);
-#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if (name == NULL) {
         return NULL;
     }
     return (*e)->NewStringUTF(e, name);
-#endif // defined(LIBRESSL_VERSION_NUMBER)
+#elif defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x30200000L)
+    return NULL;
+#else
+    const char* name =SSL_get0_group_name(ssl_);
+    if (name == NULL) {
+        return NULL;
+    }
+    return (*e)->NewStringUTF(e, name);
+#endif // defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 }
 
 TCN_IMPLEMENT_CALL(jobjectArray, SSL, getCiphers)(TCN_STDARGS, jlong ssl)


### PR DESCRIPTION
Motivation:

We need to be able to get the group name to verify if PQC was used

Modifications:

Add method that returns the group name

Result:

Be able to obtain the used group
