### PR TITLE
Add GraalVM native-image metadata for tcnative

### DIFF
--- a/boringssl-static/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-boringssl-static/resource-config.json
+++ b/boringssl-static/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-boringssl-static/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources":{
+    "includes":[
+      {
+        "condition": {
+          "typeReachable": "io.netty.internal.tcnative.Library"
+        },
+        "pattern":"META-INF/native/(lib)?netty_tcnative_.*\\.(so|jnilib|dll)"
+      }
+    ]},
+  "bundles":[]
+}

--- a/openssl-classes/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-classes/jni-config.json
+++ b/openssl-classes/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-classes/jni-config.json
@@ -1,0 +1,296 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.AsyncSSLPrivateKeyMethodAdapter",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.AsyncTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.Buffer",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateCallbackTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateCompressionAlgo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateRequestedCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateVerifier",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateVerifierTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.KeyLogCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.Library",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.ResultCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SessionTicketKey",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SniHostNameMatcher",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSL",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLContext",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLCredential",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethod",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLSession",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLSessionCache",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLTask$TaskCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "java.lang.String",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "java.lang.Exception",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "java.lang.IllegalArgumentException",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "java.lang.NullPointerException",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "java.lang.OutOfMemoryError",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "byte[]"
+  }
+]

--- a/openssl-classes/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-classes/native-image.properties
+++ b/openssl-classes/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-classes/native-image.properties
@@ -1,0 +1,15 @@
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Args = --initialize-at-run-time=io.netty.internal.tcnative

--- a/openssl-classes/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-classes/reflect-config.json
+++ b/openssl-classes/src/main/resources/META-INF/native-image/io.netty/netty-tcnative-classes/reflect-config.json
@@ -1,0 +1,245 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.AsyncSSLPrivateKeyMethodAdapter",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.AsyncTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.Buffer",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateCallbackTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateCompressionAlgo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateRequestedCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateVerifier",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.CertificateVerifierTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.KeyLogCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.Library",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.ResultCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SessionTicketKey",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SniHostNameMatcher",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSL",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLContext",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLCredential",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethod",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLSession",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLSessionCache",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLTask",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.internal.tcnative.SSL"
+    },
+    "name": "io.netty.internal.tcnative.SSLTask$TaskCallback",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]


### PR DESCRIPTION
## Motivation

_Note: the follow-up PR to this one is https://github.com/netty/netty/pull/17131_

`OpenSsl.isAvailable()` returns `true` on the JVM but `false` in a GraalVM native image (https://github.com/netty/netty/issues/11088), so apps silently fall back to the JDK SSL provider.

`netty-tcnative` ships no `META-INF/native-image` metadata, so the native library never gets embedded, the JNI classes go unregistered, and the tcnative classes initialize at build time instead of runtime. Shipping the metadata in the artifacts keeps it version-matched out of the box.

## Modifications

Added native-image metadata across the `tcnative` artifacts:

* **`netty-tcnative-classes`:**
  * `native-image.properties`: initializes `io.netty.internal.tcnative` classes at runtime.
  * `jni-config.json`: registers all `tcnative` classes for JNI, plus the standard Java types native code creates or throws.
  * `reflect-config.json`: mirrors the reflection registration for `tcnative` classes.

* **`netty-tcnative-boringssl-static`:**
  * `resource-config.json`: embeds the native binaries (`.so`, `.jnilib`, `.dll`) so `NativeLibraryLoader` can extract and load them at runtime.

## Result

`OpenSsl.isAvailable()` now returns `true` inside native images, and BoringSSL loads without issues. Tested alongside the companion Netty PR on Mandrel 25.0.1 (macOS aarch64).
