### PR TITLE
Fix data race by setting info callback on SSL instance

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -930,6 +930,15 @@ static void free_ssl_state(JNIEnv* e, tcn_ssl_state_t* state) {
     OPENSSL_free(state);
 }
 
+static void ssl_info_callback(const SSL *ssl, int where, int ret) {
+    tcn_ssl_state_t* state = NULL;
+    if (0 != (where & SSL_CB_HANDSHAKE_START)) {
+        if ((state = tcn_SSL_get_app_state(ssl)) != NULL) {
+            state->handshakeCount++;
+        }
+    }
+}
+
 TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
                                                    jlong ctx /* tcn_ssl_ctxt_t * */,
                                                    jboolean server) {

--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -952,6 +952,8 @@ TCN_IMPLEMENT_CALL(jlong /* SSL * */, SSL, newSSL)(TCN_STDARGS,
 
     // Set the app_data2 before all the others because it may be used in SSL_free.
     tcn_SSL_set_app_state(ssl, state);
+    // Add callback to keep track of handshakes.
+    SSL_set_info_callback(ssl, ssl_info_callback);
 
     if (server) {
         SSL_set_accept_state(ssl);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -463,6 +463,8 @@ int         tcn_SSL_callback_next_protos(SSL *, const unsigned char **, unsigned
 int         tcn_SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 int         tcn_SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 const char *tcn_SSL_cipher_authentication_method(const SSL_CIPHER *);
+void        ssl_info_callback(const SSL *ssl, int where, int ret);
+
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert);

--- a/openssl-dynamic/src/main/c/ssl_private.h
+++ b/openssl-dynamic/src/main/c/ssl_private.h
@@ -463,7 +463,6 @@ int         tcn_SSL_callback_next_protos(SSL *, const unsigned char **, unsigned
 int         tcn_SSL_callback_select_next_proto(SSL *, unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 int         tcn_SSL_callback_alpn_select_proto(SSL *, const unsigned char **, unsigned char *, const unsigned char *, unsigned int, void *);
 const char *tcn_SSL_cipher_authentication_method(const SSL_CIPHER *);
-void        ssl_info_callback(const SSL *ssl, int where, int ret);
 
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -182,14 +182,6 @@ static apr_status_t ssl_context_cleanup(void *data)
     return APR_SUCCESS;
 }
 
-void ssl_info_callback(const SSL *ssl, int where, int ret) {
-    tcn_ssl_state_t* state = NULL;
-    if (0 != (where & SSL_CB_HANDSHAKE_START)) {
-        if ((state = tcn_SSL_get_app_state(ssl)) != NULL) {
-            state->handshakeCount++;
-        }
-    }
-}
 
 /* Initialize server context */
 TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mode)

--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -182,7 +182,7 @@ static apr_status_t ssl_context_cleanup(void *data)
     return APR_SUCCESS;
 }
 
-static void ssl_info_callback(const SSL *ssl, int where, int ret) {
+void ssl_info_callback(const SSL *ssl, int where, int ret) {
     tcn_ssl_state_t* state = NULL;
     if (0 != (where & SSL_CB_HANDSHAKE_START)) {
         if ((state = tcn_SSL_get_app_state(ssl)) != NULL) {
@@ -458,8 +458,7 @@ TCN_IMPLEMENT_CALL(jlong, SSLContext, make)(TCN_STDARGS, jint protocol, jint mod
     SSL_CTX_set_default_passwd_cb(c->ctx, (pem_password_cb *) tcn_SSL_password_callback);
     SSL_CTX_set_default_passwd_cb_userdata(c->ctx, (void *) c->password);
 
-    // Add callback to keep track of handshakes.
-    SSL_CTX_set_info_callback(c->ctx, ssl_info_callback);
+
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     if (mode != SSL_MODE_SERVER) {


### PR DESCRIPTION
Set the SSL info callback on the specific SSL instance rather than the shared SSL context. This avoids concurrent modification/access of the shared context during connection establishment and handshake processing, which was causing data races.