### PR TITLE
Delete local references while processing the loop to fill the singature algorithms

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2670,6 +2670,7 @@ TCN_IMPLEMENT_CALL(jobjectArray, SSL, getSigAlgs)(TCN_STDARGS, jlong ssl) {
         }
 
         (*e)->SetObjectArrayElement(e, array, i, algString);
+        (*e)->DeleteLocalRef(e, algString);
     }
 
 complete:
@@ -2709,6 +2710,7 @@ complete:
             return NULL;
         }
         (*e)->SetObjectArrayElement(e, array, i, algString);
+        (*e)->DeleteLocalRef(e, algString);
     }
     return array;
 #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(__GNUC__) || defined(__GNUG__)


### PR DESCRIPTION
Motivation:

The number of the signature algorithms are dictated by the remote peer and so we should ensure we not "overflow" the local stack when creating local references in the JNI layer.

Modifications:

Delete the local reference the the string as soon as we dont need it anymore

Result:

Fixes https://github.com/netty/netty-tcnative/issues/994
