### PR TITLE
Make the Linux artifacts loadable on musl (Alpine) again

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -142,3 +142,105 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+
+  # Same verification as ci-pr.yml, plus the gcompat variants. Those are here rather than on every
+  # PR because their job is not to pass but to make a bare failure diagnostic: if bare fails and
+  # gcompat passes, the artifact has re-acquired a dependency on the compatibility shim, which is
+  # how 2.0.65 appeared to work. This workflow also runs on the weekly schedule, which is where
+  # the extra minutes belong. See docs/musl-compatibility.md.
+  musl-verify:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Both runners are pinned: there is no ubuntu-latest-arm, so pairing ubuntu-latest with
+          # a pinned arm label would drift apart as soon as ubuntu-latest moves on.
+          - setup: alpine-x86_64
+            os: ubuntu-24.04
+            jars: build-centos6-x86_64-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-aarch64
+            os: ubuntu-24.04-arm
+            jars: build-centos7-aarch64-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
+            build-service: runtime-setup
+            run-service: verify
+          # The invariant leg: an Alpine JDK that ships no `libgcc` package of its own, so
+          # `apk del .elftools` really does leave libgcc absent. eclipse-temurin's JDK depends on
+          # libgcc, so the bare legs above cannot prove the artifact loads without it.
+          - setup: alpine-x86_64-nolibgcc
+            os: ubuntu-24.04
+            jars: build-centos6-x86_64-jars
+            variant: nolibgcc
+            extra-pkgs: ""
+            drop-elftools: "1"
+            jdk-image: amazoncorretto:21-alpine
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-aarch64-nolibgcc
+            os: ubuntu-24.04-arm
+            jars: build-centos7-aarch64-jars
+            variant: nolibgcc
+            extra-pkgs: ""
+            drop-elftools: "1"
+            jdk-image: amazoncorretto:21-alpine
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-x86_64-gcompat
+            os: ubuntu-24.04
+            jars: build-centos6-x86_64-jars
+            variant: gcompat
+            extra-pkgs: gcompat
+            drop-elftools: "0"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-aarch64-gcompat
+            os: ubuntu-24.04-arm
+            jars: build-centos7-aarch64-jars
+            variant: gcompat
+            extra-pkgs: gcompat
+            drop-elftools: "0"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: glibc-control-x86_64
+            os: ubuntu-24.04
+            jars: build-centos6-x86_64-jars
+            variant: glibc-control
+            extra-pkgs: ""
+            drop-elftools: "0"
+            build-service: control-runtime-setup
+            run-service: control-verify
+
+    runs-on: ${{ matrix.os }}
+    name: musl-verify ${{ matrix.setup }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.jars }}
+          path: musl-verify-jars
+
+      - name: Build verification image
+        env:
+          MUSL_VARIANT: ${{ matrix.variant }}
+          MUSL_EXTRA_PKGS: ${{ matrix.extra-pkgs }}
+          MUSL_JDK_IMAGE: ${{ matrix.jdk-image }}
+        run: docker compose -f docker/docker-compose.alpine.yaml build ${{ matrix.build-service }}
+
+      - name: Verify the artifact under ${{ matrix.variant }}
+        env:
+          MUSL_VARIANT: ${{ matrix.variant }}
+          MUSL_EXTRA_PKGS: ${{ matrix.extra-pkgs }}
+          MUSL_DROP_ELFTOOLS: ${{ matrix.drop-elftools }}
+          MUSL_JDK_IMAGE: ${{ matrix.jdk-image }}
+          MUSL_JARS_DIR: musl-verify-jars
+        run: docker compose -f docker/docker-compose.alpine.yaml run --rm ${{ matrix.run-service }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -143,11 +143,7 @@ jobs:
             **/target/surefire-reports/
             **/hs_err*.log
 
-  # Same verification as ci-pr.yml, plus the gcompat variants. Those are here rather than on every
-  # PR because their job is not to pass but to make a bare failure diagnostic: if bare fails and
-  # gcompat passes, the artifact has re-acquired a dependency on the compatibility shim, which is
-  # how 2.0.65 appeared to work. This workflow also runs on the weekly schedule, which is where
-  # the extra minutes belong. See docs/musl-compatibility.md.
+  # Same verification as ci-pr.yml, on the same legs. See docs/musl-compatibility.md.
   musl-verify:
     needs: build
     strategy:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -200,6 +200,11 @@ jobs:
   # during dlopen rather than an UnsatisfiedLinkError. See docs/musl-compatibility.md.
   #
   # `needs` cannot depend on a single matrix leg, so this waits for all of build-pr.
+  #
+  # The gcompat legs are not expected to change the answer -- libc.so.6 is one of the names musl
+  # resolves internally, so gcompat's symlink is never read. They earn their place by making a
+  # bare failure diagnostic: if bare fails and gcompat passes, the artifact has re-acquired a
+  # dependency on the compatibility shim, which is exactly how 2.0.65 appeared to work.
   musl-verify:
     needs: build-pr
     strategy:
@@ -244,6 +249,22 @@ jobs:
             extra-pkgs: ""
             drop-elftools: "1"
             jdk-image: amazoncorretto:21-alpine
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-x86_64-gcompat
+            os: ubuntu-24.04
+            jars: build-pr-centos6-x86_64-jars
+            variant: gcompat
+            extra-pkgs: gcompat
+            drop-elftools: "0"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-aarch64-gcompat
+            os: ubuntu-24.04-arm
+            jars: build-pr-centos7-aarch64-jars
+            variant: gcompat
+            extra-pkgs: gcompat
+            drop-elftools: "0"
             build-service: runtime-setup
             run-service: verify
           # Control: anything failing on Alpine must pass here, or the check is at fault rather

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -192,3 +192,94 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+
+  # Verify that the glibc-built Linux artifacts really load under musl. This consumes the jars
+  # the build jobs above already upload, so nothing is rebuilt. The static half of this invariant
+  # is enforced inside the build by scripts/check_musl_compat.sh; what only a real musl system can
+  # show is whether the library loads, because on aarch64 the historical failure was a JVM SIGSEGV
+  # during dlopen rather than an UnsatisfiedLinkError. See docs/musl-compatibility.md.
+  #
+  # `needs` cannot depend on a single matrix leg, so this waits for all of build-pr.
+  musl-verify:
+    needs: build-pr
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Both runners are pinned: there is no ubuntu-latest-arm, so pairing ubuntu-latest with
+          # a pinned arm label would drift apart as soon as ubuntu-latest moves on. The host only
+          # supplies Docker here, so pinning costs nothing.
+          - setup: alpine-x86_64
+            os: ubuntu-24.04
+            jars: build-pr-centos6-x86_64-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-aarch64
+            os: ubuntu-24.04-arm
+            jars: build-pr-centos7-aarch64-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
+            build-service: runtime-setup
+            run-service: verify
+          # The invariant leg: an Alpine JDK that ships no `libgcc` package of its own, so
+          # `apk del .elftools` really does leave libgcc absent. eclipse-temurin's JDK depends on
+          # libgcc, so the bare legs above cannot prove the artifact loads without it.
+          - setup: alpine-x86_64-nolibgcc
+            os: ubuntu-24.04
+            jars: build-pr-centos6-x86_64-jars
+            variant: nolibgcc
+            extra-pkgs: ""
+            drop-elftools: "1"
+            jdk-image: amazoncorretto:21-alpine
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-aarch64-nolibgcc
+            os: ubuntu-24.04-arm
+            jars: build-pr-centos7-aarch64-jars
+            variant: nolibgcc
+            extra-pkgs: ""
+            drop-elftools: "1"
+            jdk-image: amazoncorretto:21-alpine
+            build-service: runtime-setup
+            run-service: verify
+          # Control: anything failing on Alpine must pass here, or the check is at fault rather
+          # than the artifact.
+          - setup: glibc-control-x86_64
+            os: ubuntu-24.04
+            jars: build-pr-centos6-x86_64-jars
+            variant: glibc-control
+            extra-pkgs: ""
+            drop-elftools: "0"
+            build-service: control-runtime-setup
+            run-service: control-verify
+
+    runs-on: ${{ matrix.os }}
+    name: musl-verify ${{ matrix.setup }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.jars }}
+          path: musl-verify-jars
+
+      - name: Build verification image
+        env:
+          MUSL_VARIANT: ${{ matrix.variant }}
+          MUSL_EXTRA_PKGS: ${{ matrix.extra-pkgs }}
+          MUSL_JDK_IMAGE: ${{ matrix.jdk-image }}
+        run: docker compose -f docker/docker-compose.alpine.yaml build ${{ matrix.build-service }}
+
+      - name: Verify the artifact under ${{ matrix.variant }}
+        env:
+          MUSL_VARIANT: ${{ matrix.variant }}
+          MUSL_EXTRA_PKGS: ${{ matrix.extra-pkgs }}
+          MUSL_DROP_ELFTOOLS: ${{ matrix.drop-elftools }}
+          MUSL_JDK_IMAGE: ${{ matrix.jdk-image }}
+          MUSL_JARS_DIR: musl-verify-jars
+        run: docker compose -f docker/docker-compose.alpine.yaml run --rm ${{ matrix.run-service }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ cmake-*
 
 # exclude file created by the flatten plugin
 .flattened-pom.xml
+
+/musl-verify-jars/

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -313,6 +313,26 @@
                       </then>
                     </if>
 
+                    <!-- Assert the invariants the steps above establish, on the final bytes and
+                         before the jar is assembled. Bound here rather than to verify because every
+                         build, deploy and staging command is "clean package <plugin>:goal" and so
+                         never reaches verify, and unlike surefire this is not disabled by
+                         -DskipTests - which is what gives the cross-compiled aarch64 artifact its
+                         only automated check. See docs/musl-compatibility.md -->
+                    <if>
+                      <and>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <equals arg1="${muslCheck.skip}" arg2="false" />
+                      </and>
+                      <then>
+                        <exec executable="sh" failonerror="true" dir="${project.basedir}/..">
+                          <arg value="scripts/check_musl_compat.sh" />
+                          <arg value="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/libnetty_tcnative.so" />
+                          <arg value="static" />
+                        </exec>
+                      </then>
+                    </if>
+
                     <copy todir="${nativeJarWorkdir}">
                       <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
@@ -653,6 +673,26 @@
                       </then>
                     </if>
 
+                    <!-- Assert the invariants the steps above establish, on the final bytes and
+                         before the jar is assembled. Bound here rather than to verify because every
+                         build, deploy and staging command is "clean package <plugin>:goal" and so
+                         never reaches verify, and unlike surefire this is not disabled by
+                         -DskipTests - which is what gives the cross-compiled aarch64 artifact its
+                         only automated check. See docs/musl-compatibility.md -->
+                    <if>
+                      <and>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <equals arg1="${muslCheck.skip}" arg2="false" />
+                      </and>
+                      <then>
+                        <exec executable="sh" failonerror="true" dir="${project.basedir}/..">
+                          <arg value="scripts/check_musl_compat.sh" />
+                          <arg value="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/libnetty_tcnative.so" />
+                          <arg value="static" />
+                        </exec>
+                      </then>
+                    </if>
+
                     <copy todir="${nativeJarWorkdir}">
                       <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
@@ -973,6 +1013,27 @@
                           <arg value="--remove-needed" />
                           <arg value="ld-linux-aarch64.so.1" />
                           <arg value="libnetty_tcnative.so" />
+                        </exec>
+                      </then>
+                    </if>
+
+                    <!-- Assert the invariants the steps above establish, on the final bytes and
+                         before the jar is assembled. Bound here rather than to verify because every
+                         build, deploy and staging command is "clean package <plugin>:goal" and so
+                         never reaches verify, and unlike surefire this is not disabled by
+                         -DskipTests - which is what gives the cross-compiled aarch64 artifact its
+                         only automated check. See docs/musl-compatibility.md -->
+                    <if>
+                      <and>
+                        <equals arg1="${os.detected.name}" arg2="linux" />
+                        <equals arg1="${muslCheck.skip}" arg2="false" />
+                      </and>
+                      <then>
+                        <exec executable="sh" failonerror="true" dir="${project.basedir}/..">
+                          <env key="TOOL_PREFIX" value="aarch64-none-linux-gnu-" />
+                          <arg value="scripts/check_musl_compat.sh" />
+                          <arg value="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/libnetty_tcnative.so" />
+                          <arg value="static" />
                         </exec>
                       </then>
                     </if>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -579,10 +579,25 @@
                     <echo message="Setup flags to use during linking" />
 
                     <!-- If we compile on linux we need to adjust the ldflags to correct link libstdc++ -->
+                    <!-- The libgcc archives must come *after* libstdc++.a: it is what pulls in the
+                         _Unwind_* symbols, and libgcc_eh.a is what defines them. Linking them
+                         statically is what keeps libgcc_s.so.1 out of DT_NEEDED - `gcc_s.` is not a
+                         musl-reserved stem, so on Alpine that entry is a real file lookup, and it
+                         fails on any image without the `libgcc` package. Alpine JDK images differ on
+                         shipping it: eclipse-temurin does, amazoncorretto and many vendor images do
+                         not, so the dependency is not safe, merely invisible on some images.
+
+                         NOTE: spell this as `-l:` and never `-static-libgcc`. GNU libtool links the
+                         shared library via archive_cmds, which expands only $libobjs $deplibs
+                         $compiler_flags; `-l*` is parsed into deplibs, but `-static-lib*` falls into
+                         func_mode_link's catch-all `-* | +*)` branch and reaches only the *program*
+                         link path, so gcc never sees it. `grep dependency_libs
+                         target/native-build/libnetty_tcnative.la` shows what actually survived.
+                         See docs/musl-compatibility.md. -->
                     <if>
                       <equals arg1="${os.detected.name}" arg2="linux" />
                       <then>
-                        <property name="hawtjniLdflags" value="-L${boringsslHome} -lssl -lcrypto -static-libstdc++ -l:libstdc++.a" />
+                        <property name="hawtjniLdflags" value="-L${boringsslHome} -lssl -lcrypto -l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a" />
                       </then>
                       <else>
                         <property name="hawtjniLdflags" value="${ldflags}" />
@@ -613,6 +628,26 @@
                       <then>
                         <exec executable="strip" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
                           <arg value="--strip-debug" />
+                          <arg value="libnetty_tcnative.so" />
+                        </exec>
+                      </then>
+                    </if>
+
+                    <!-- Drop the DT_NEEDED on ld-linux-<arch>.so. It gets recorded because
+                         __tls_get_addr lives in glibc's loader, but musl defines that symbol itself,
+                         so only the filename lookup fails - on Alpine the library is unloadable
+                         purely because of this entry. Removing it is a no-op on glibc, where the
+                         loader is already mapped. patchelf exits 0 when the entry is absent, so this
+                         is safe on architectures that never had it. Same approach as async-profiler.
+                         See https://github.com/netty/netty-tcnative/issues/907 -->
+                    <if>
+                      <equals arg1="${os.detected.name}" arg2="linux" />
+                      <then>
+                        <exec executable="patchelf" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
+                          <arg value="--remove-needed" />
+                          <arg value="ld-linux-x86-64.so.2" />
+                          <arg value="--remove-needed" />
+                          <arg value="ld-linux-aarch64.so.1" />
                           <arg value="libnetty_tcnative.so" />
                         </exec>
                       </then>
@@ -925,6 +960,23 @@
                       </then>
                     </if>
 
+                    <!-- Same ld-linux DT_NEEDED removal as the default profile, so both released
+                         Linux artifacts get it. patchelf is arch-agnostic, so the x86_64 host tool
+                         edits the cross-built aarch64 object fine, and it exits 0 when the entry is
+                         absent. See docs/musl-compatibility.md -->
+                    <if>
+                      <equals arg1="${os.detected.name}" arg2="linux" />
+                      <then>
+                        <exec executable="patchelf" failonerror="true" dir="${nativeLibOnlyDir}/META-INF/native/linux${archBits}/" resolveexecutable="true">
+                          <arg value="--remove-needed" />
+                          <arg value="ld-linux-x86-64.so.2" />
+                          <arg value="--remove-needed" />
+                          <arg value="ld-linux-aarch64.so.1" />
+                          <arg value="libnetty_tcnative.so" />
+                        </exec>
+                      </then>
+                    </if>
+
                     <copy todir="${nativeJarWorkdir}">
                       <zipfileset src="${defaultJarFile}" excludes="META-INF/versions/**/module-info.class" />
                     </copy>
@@ -992,7 +1044,16 @@
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslSourceDir}/include</configureArg>
-                    <configureArg>LDFLAGS=-L${boringsslHome} -lssl -lcrypto -static-libstdc++ -l:libstdc++.a</configureArg>
+                    <!-- Keep in sync with the boringssl-static-default profile: the two Linux
+                         profiles duplicate the whole native build, so a change to one does not apply
+                         to the other. The libgcc archives must follow libstdc++.a, and must be
+                         spelled `-l:` rather than -static-libgcc because libtool drops the latter -
+                         see the comment on hawtjniLdflags in that profile. On aarch64 this also pulls
+                         libgcc's init_have_lse_atomics constructor into the library, whose
+                         __getauxval reference is satisfied by musl_compat.c - an unresolved symbol in
+                         an ELF constructor SIGSEGVs the JVM inside dlopen rather than raising
+                         UnsatisfiedLinkError, so that fallback is load-bearing here. -->
+                    <configureArg>LDFLAGS=-L${boringsslHome} -lssl -lcrypto -l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>
                     <configureArg>CC=aarch64-none-linux-gnu-gcc</configureArg>
                   </configureArgs>

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -658,7 +658,9 @@
                          so only the filename lookup fails - on Alpine the library is unloadable
                          purely because of this entry. Removing it is a no-op on glibc, where the
                          loader is already mapped. patchelf exits 0 when the entry is absent, so this
-                         is safe on architectures that never had it. Same approach as async-profiler.
+                         is safe on architectures that never had it. async-profiler does exactly the
+                         same thing when packaging its single glibc+musl binary:
+                         https://github.com/async-profiler/async-profiler/blob/bb8f0476a1804ac77b48b84a3905fb26e9ca7428/Makefile#L156
                          See https://github.com/netty/netty-tcnative/issues/907 -->
                     <if>
                       <equals arg1="${os.detected.name}" arg2="linux" />

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,39 @@
+# Runtime image for verifying that a built Linux artifact loads under musl.
+#
+# This image does NOT build netty-tcnative -- it consumes an artifact built elsewhere by one of
+# the glibc images, which is the whole point: the released jar is glibc-built and is expected to
+# work on musl. Nothing here runs Maven, so the os.detected.classifier enforcer rules never come
+# into play.
+#
+# The base is deliberately a stock JDK image with no compatibility shim: no gcompat and no
+# libc6-compat, so /lib/libc.so.6 does not exist. That is what "bare" below means. If a future base
+# image starts shipping gcompat, the bare variant silently stops testing anything -- verify.sh
+# prints the installed compat packages on every run so that shows up in the log.
+#
+# The default base does ship libgcc and libstdc++, and that is NOT representative: Alpine JDK
+# images differ on it (Amazon Corretto and various vendor images carry no `libgcc` package), which
+# is precisely how a libgcc_s.so.1 DT_NEEDED shipped unnoticed for eight releases.
+#
+# Two knobs are needed to test that honestly, because there are two ways libgcc sneaks in:
+#   - MUSL_DROP_ELFTOOLS=1 makes verify.sh uninstall the binutils below, which depend on libgcc;
+#   - jdk_image must name a JDK that does not itself depend on libgcc. eclipse-temurin does, so on
+#     that base `apk del` cannot remove it and the leg proves nothing about this invariant.
+#     amazoncorretto:21-alpine does not, and still provides javac and jar.
+# See docs/musl-compatibility.md §4b.
+ARG jdk_image=eclipse-temurin:21-jdk-alpine
+FROM ${jdk_image}
+
+# binutils for readelf/nm. It provides no libc symbols, so it cannot mask a missing one -- but it
+# does pull `libgcc` in as a dependency, which would mask exactly the failure this image exists to
+# detect. Installed as a virtual package so verify.sh can remove it, and libgcc with it, once the
+# ELF inspection is done and only the runtime checks remain.
+RUN apk add --no-cache --virtual .elftools binutils
+
+# Set per variant rather than baked in, so each package set is measured independently.
+# Empty is the invariant; "gcompat" exists to make a bare failure diagnostic, because a fix that
+# accidentally depends on the shim passes there and fails bare. That is exactly how 2.0.65
+# appeared to work.
+ARG EXTRA_PKGS=""
+RUN if [ -n "$EXTRA_PKGS" ]; then apk add --no-cache $EXTRA_PKGS; fi
+
+WORKDIR /code

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -10,6 +10,7 @@ ENV CMAKE_VERSION $CMAKE_VERSION_BASE.4
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 ENV MAVEN_VERSION 3.9.1
+ENV PATCHELF_VERSION 0.18.0
 
 # Update as we need to use the vault now.
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/6.10\//g' /etc/yum.repos.d/CentOS-Base.repo
@@ -67,6 +68,17 @@ RUN set -x && \
   ./Configure linux-x86_64 --prefix=/opt/openssl-$OPENSSL_VERSION --libdir=lib shared no-asm no-apps && \
   make -j1 install_sw) && \
   rm -rf openssl-$OPENSSL_VERSION openssl-$OPENSSL_VERSION.tar.gz
+
+# patchelf is used post-link to drop the DT_NEEDED on ld-linux-x86-64.so.2 so the artifact
+# also loads under musl. CentOS 6 is EOL and has no EPEL, so install the upstream prebuilt
+# static binary rather than going through yum.
+# --no-check-certificate for the same reason as the OpenSSL download above.
+RUN wget -q --no-check-certificate https://github.com/NixOS/patchelf/releases/download/$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION-x86_64.tar.gz \
+ && mkdir -p /opt/patchelf-$PATCHELF_VERSION \
+ && tar zxf patchelf-$PATCHELF_VERSION-x86_64.tar.gz -C /opt/patchelf-$PATCHELF_VERSION \
+ && ln -s /opt/patchelf-$PATCHELF_VERSION/bin/patchelf /usr/local/bin/patchelf \
+ && rm -f patchelf-$PATCHELF_VERSION-x86_64.tar.gz \
+ && patchelf --version
 
 RUN rm -rf $SOURCE_DIR
 

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -22,7 +22,7 @@ RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.cent
 # Install requirements
 RUN  set -x && \
   yum -y install epel-release && \
-  yum -y install wget tar git make autoconf automake libtool openssl-devel ninja-build gcc-c++ patch unzip zip which perl perl-IPC-Cmd perl-Time-Piece
+  yum -y install wget tar git make autoconf automake libtool openssl-devel ninja-build gcc-c++ patch unzip zip which perl perl-IPC-Cmd perl-Time-Piece patchelf
 
 # Install Java
 RUN yum install -y java-1.8.0-openjdk-devel golang

--- a/docker/Dockerfile.musl-control
+++ b/docker/Dockerfile.musl-control
@@ -1,0 +1,12 @@
+# glibc control for the musl verification. Same verify.sh, same artifact, different libc.
+#
+# Its job is to tell "the library is broken on musl" apart from "the check is broken": anything
+# that fails on Alpine must pass here, or the harness is at fault rather than the artifact.
+ARG jdk_image=eclipse-temurin:21-jdk-jammy
+FROM ${jdk_image}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends binutils \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code

--- a/docker/README.md
+++ b/docker/README.md
@@ -41,3 +41,39 @@ docker compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-
 
 etc, etc
 
+
+## Alpine/musl verification of an already-built artifact
+
+Unlike the images above, this one does not build netty-tcnative. It checks that a Linux artifact
+built by one of the glibc images still loads under musl, which is the contract the released jars
+have: there is no `-musl` classifier. Build first, then:
+
+```
+docker compose -f docker/docker-compose.alpine.yaml build runtime-setup
+docker compose -f docker/docker-compose.alpine.yaml run --rm verify
+```
+
+`MUSL_JARS_DIR` selects where to search for the jars (default: the whole tree), so the same
+command works against a directory of downloaded release jars.
+
+To confirm a fix does not secretly depend on the compatibility shim, run the same check with
+gcompat installed. It must give the same answer as the bare run — `libc.so.6` is one of the
+names musl's loader satisfies internally, so gcompat's `/lib/libc.so.6 -> libgcompat.so.0`
+symlink is never read:
+
+```
+MUSL_VARIANT=gcompat MUSL_EXTRA_PKGS=gcompat \
+  docker compose -f docker/docker-compose.alpine.yaml build runtime-setup
+MUSL_VARIANT=gcompat MUSL_EXTRA_PKGS=gcompat \
+  docker compose -f docker/docker-compose.alpine.yaml run --rm verify
+```
+
+The glibc control. Anything that fails on Alpine must pass here, otherwise the check is at fault
+rather than the artifact:
+
+```
+docker compose -f docker/docker-compose.alpine.yaml build control-runtime-setup
+docker compose -f docker/docker-compose.alpine.yaml run --rm control-verify
+```
+
+See `docs/musl-compatibility.md`.

--- a/docker/docker-compose.alpine.yaml
+++ b/docker/docker-compose.alpine.yaml
@@ -1,0 +1,57 @@
+version: "3"
+
+# Verifies an already-built Linux artifact under musl. Unlike the other compose files here this
+# one does not build netty-tcnative: it needs both the boringssl-static classifier jar and the
+# netty-tcnative-classes jar, which live in different module target directories, so MUSL_JARS_DIR
+# is searched recursively and defaults to the whole tree.
+# See docker/README.md and docs/musl-compatibility.md.
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-alpine:${MUSL_VARIANT:-bare}
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.alpine
+      args:
+        EXTRA_PKGS: "${MUSL_EXTRA_PKGS:-}"
+        # eclipse-temurin's JDK depends on libgcc, so `apk del` cannot take it away there and that
+        # base can never prove the artifact loads without it. Point this at an Alpine JDK that
+        # carries no libgcc (amazoncorretto:21-alpine) for the leg that tests exactly that.
+        jdk_image: "${MUSL_JDK_IMAGE:-eclipse-temurin:21-jdk-alpine}"
+
+  common: &common
+    image: netty-tcnative-alpine:${MUSL_VARIANT:-bare}
+    depends_on: [runtime-setup]
+    environment:
+      - MUSL_VARIANT=${MUSL_VARIANT:-bare}
+      # Set to 1 on the bare legs: uninstalls binutils, and libgcc with it, before the runtime
+      # checks. Leave unset for the gcompat legs, whose point is to load with the shim present.
+      - MUSL_DROP_ELFTOOLS=${MUSL_DROP_ELFTOOLS:-0}
+    volumes:
+      - ..:/code:delegated
+    working_dir: /code
+
+  verify:
+    <<: *common
+    command: /bin/sh -c "docker/musl-verify/verify.sh ${MUSL_JARS_DIR:-.}"
+
+  shell:
+    <<: *common
+    entrypoint: /bin/sh
+
+  control-runtime-setup:
+    image: netty-tcnative-musl-control:glibc
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.musl-control
+
+  control-verify:
+    image: netty-tcnative-musl-control:glibc
+    depends_on: [control-runtime-setup]
+    environment:
+      - MUSL_VARIANT=glibc-control
+    volumes:
+      - ..:/code:delegated
+    working_dir: /code
+    command: /bin/sh -c "docker/musl-verify/verify.sh ${MUSL_JARS_DIR:-.}"

--- a/docker/musl-verify/MuslLoadCheck.java
+++ b/docker/musl-verify/MuslLoadCheck.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+/**
+ * Checks that a Linux {@code libnetty_tcnative.so} built against glibc can be loaded and
+ * initialized by the libc of the machine running this class. Written for Alpine/musl, with a
+ * glibc run as the control.
+ *
+ * <p>Deliberately depends on nothing but the JDK and {@code netty-tcnative-classes}:
+ * netty-tcnative has no dependency on netty-handler, so {@code OpenSsl.isAvailable()} is not
+ * available here and the raw {@code io.netty.internal.tcnative} API is the whole surface.
+ *
+ * <p>One level per JVM, chosen by the first argument, so that a hard crash in an early level
+ * cannot hide a later one. On aarch64 the historical failure was a SIGSEGV inside
+ * {@code JVM_LoadLibrary} rather than an exception, so the caller must also treat a JVM that
+ * dies without printing a RESULT line as a failure -- see verify.sh.
+ *
+ * <p>Compiled with a modern javac but kept to Java 8 syntax to match the rest of the project.
+ */
+public final class MuslLoadCheck {
+
+    private static boolean failed;
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.err.println("usage: MuslLoadCheck <load|init|context> <path-to-.so>");
+            System.exit(2);
+        }
+        String level = args[0];
+        String soPath = args[1];
+
+        try {
+            // Every level needs the library loaded; the load itself is level "load".
+            load(soPath);
+            if (!"load".equals(level)) {
+                init();
+                if ("context".equals(level)) {
+                    context();
+                }
+            }
+        } catch (Throwable t) {
+            // A missing symbol surfaces here as the musl loader's own text, e.g.
+            // "Error relocating <lib>: __getauxval: symbol not found".
+            result(level, false, rootMessage(t));
+        }
+        System.exit(failed ? 1 : 0);
+    }
+
+    private static void load(String soPath) {
+        File so = new File(soPath);
+        if (!so.isFile()) {
+            throw new IllegalStateException("not a file: " + soPath);
+        }
+        System.load(so.getAbsolutePath());
+        result("load", true, "System.load ok: " + so.getName());
+    }
+
+    private static void init() throws Exception {
+        // Library.initialize() delegates to initialize("provided", null), which loads nothing
+        // further and then runs initialize0() and SSL.initialize(). This is where APR and
+        // BoringSSL actually start up, and it is the step boringssl-static's own NativeTest
+        // never reaches.
+        if (!io.netty.internal.tcnative.Library.initialize()) {
+            throw new IllegalStateException("Library.initialize() returned false");
+        }
+        result("init", true, "ssl=" + io.netty.internal.tcnative.SSL.versionString());
+    }
+
+    private static void context() throws Exception {
+        // Construct and free a real SSL context and a memory BIO. Cheap, but it is the first
+        // thing that exercises BoringSSL beyond its own initialization.
+        long ctx = io.netty.internal.tcnative.SSLContext.make(
+                io.netty.internal.tcnative.SSL.SSL_PROTOCOL_ALL,
+                io.netty.internal.tcnative.SSL.SSL_MODE_SERVER);
+        if (ctx == 0L) {
+            throw new IllegalStateException("SSLContext.make returned 0");
+        }
+        long bio = 0L;
+        try {
+            bio = io.netty.internal.tcnative.SSL.newMemBIO();
+            if (bio == 0L) {
+                throw new IllegalStateException("SSL.newMemBIO returned 0");
+            }
+            result("context", true, "SSLContext and memory BIO constructed");
+        } finally {
+            if (bio != 0L) {
+                io.netty.internal.tcnative.SSL.freeBIO(bio);
+            }
+            io.netty.internal.tcnative.SSLContext.free(ctx);
+        }
+    }
+
+    private static void result(String level, boolean pass, String detail) {
+        if (!pass) {
+            failed = true;
+        }
+        System.out.println("RESULT\t" + level + '\t' + (pass ? "PASS" : "FAIL") + '\t' + detail);
+    }
+
+    /**
+     * Walks to the deepest cause and flattens it onto one line. Note Library tries each entry in
+     * its NAMES list and accumulates a message per attempt, so the same musl relocation error can
+     * appear twice in one UnsatisfiedLinkError -- that is one failure, not two.
+     */
+    private static String rootMessage(Throwable t) {
+        Throwable root = t;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        String msg = root.getMessage();
+        if (msg == null || msg.isEmpty()) {
+            msg = root.toString();
+        }
+        return root.getClass().getSimpleName() + ": " + msg.replace('\n', ' ').replace('\r', ' ');
+    }
+
+    private MuslLoadCheck() {
+    }
+}

--- a/docker/musl-verify/verify.sh
+++ b/docker/musl-verify/verify.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+# ----------------------------------------------------------------------------
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
 # Verify a built Linux boringssl-static artifact under the libc of THIS container.
 #
 # Run it on Alpine to prove the glibc-built jar really loads on musl, and on a glibc image as

--- a/docker/musl-verify/verify.sh
+++ b/docker/musl-verify/verify.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+# Verify a built Linux boringssl-static artifact under the libc of THIS container.
+#
+# Run it on Alpine to prove the glibc-built jar really loads on musl, and on a glibc image as
+# the control -- anything that fails on Alpine but also fails here means the harness is broken,
+# not the library. Complements scripts/check_musl_compat.sh, which runs inside the build and can
+# only inspect the ELF: this one has the real libc present, so it can resolve DT_NEEDED for
+# real, diff undefined symbols against what is actually exported, and above all execute the
+# thing. See docs/musl-compatibility.md.
+#
+# usage: verify.sh <dir-containing-the-built-jars>
+# env:   MUSL_VARIANT  label for the log, e.g. bare / gcompat / glibc-control
+# exit:  0 all checks passed / 1 at least one failed / 2 usage or setup error
+set -u
+
+IN="${1:-}"
+if [ -z "$IN" ] || [ ! -d "$IN" ]; then
+  echo "usage: $0 <dir-containing-the-built-jars>" >&2
+  exit 2
+fi
+VARIANT="${MUSL_VARIANT:-unknown}"
+HERE=$(dirname "$0")
+
+case "$(uname -m)" in
+  aarch64) CLS=linux-aarch_64 ;;
+  x86_64)  CLS=linux-x86_64 ;;
+  *) echo "$0: unsupported architecture $(uname -m)" >&2; exit 2 ;;
+esac
+
+# Discover rather than hardcode a path: upload-artifact computes a least-common-ancestor, so the
+# directory layout inside a downloaded artifact depends on how many modules produced jars.
+# -sources and -javadoc jars are both published, hence the exclusions.
+NATIVE_JAR=$(find "$IN" -name "netty-tcnative-boringssl-static-*-$CLS.jar" \
+                        ! -name '*-sources.jar' ! -name '*-javadoc.jar' | head -1)
+CLASSES_JAR=$(find "$IN" -name 'netty-tcnative-classes-*.jar' \
+                        ! -name '*-sources.jar' ! -name '*-javadoc.jar' | head -1)
+if [ -z "$NATIVE_JAR" ]; then
+  echo "$0: no netty-tcnative-boringssl-static $CLS jar under $IN" >&2
+  exit 2
+fi
+if [ -z "$CLASSES_JAR" ]; then
+  echo "$0: no netty-tcnative-classes jar under $IN" >&2
+  exit 2
+fi
+
+# find returns paths relative to $IN, and both the unpack step and javac run from elsewhere.
+abspath() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *)  printf '%s\n' "$PWD/${1#./}" ;;
+  esac
+}
+NATIVE_JAR=$(abspath "$NATIVE_JAR")
+CLASSES_JAR=$(abspath "$CLASSES_JAR")
+HERE=$(abspath "$HERE")
+
+echo "=================================================================="
+echo " arch     : $(uname -m)  ($CLS)"
+echo " variant  : $VARIANT"
+echo " libc     : $(apk info -v musl 2>/dev/null | head -1 || ldd --version 2>&1 | head -1)"
+echo " compat   : $(apk info 2>/dev/null | grep -Ex 'gcompat|libc6-compat|libgcc|libstdc\+\+' | sort | tr '\n' ' ')"
+echo " java     : $(java -version 2>&1 | head -1)"
+echo " jar      : $(basename "$NATIVE_JAR")"
+echo "=================================================================="
+
+FAILURES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "   FAIL: $1"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+(cd "$WORK" && jar xf "$NATIVE_JAR" META-INF/native) || { echo "$0: cannot unpack $NATIVE_JAR" >&2; exit 2; }
+SO=$(find "$WORK/META-INF/native" -name '*.so' | head -1)
+[ -n "$SO" ] || { echo "$0: no .so inside $NATIVE_JAR" >&2; exit 2; }
+
+# ---------------------------------------------------------------- ldd: the loader's own verdict
+# On Alpine `ldd` IS the musl loader, so this reports the real relocation errors with no JVM in
+# the way. Authoritative for dynamic linking, and worth printing even when it succeeds.
+echo "-- ldd"
+LDD_OUT=$(ldd "$SO" 2>&1)
+echo "$LDD_OUT" | sed 's/^/   /' | head -30
+if echo "$LDD_OUT" | grep -qE 'Error loading shared library|Error relocating|not found'; then
+  fail "ldd reports unresolved libraries or relocations"
+fi
+
+# ---------------------------------------------------------------- DT_NEEDED, resolved for real
+# On the build host this can only be judged against a hardcoded allowlist. Here the loader is
+# present, so ask it: resolution is read back out of the ldd output above rather than guessing at
+# library paths, which differ between musl (/lib) and glibc multiarch (/lib/<triplet>).
+echo "-- DT_NEEDED"
+MUSL_LDSO="/lib/ld-musl-$(uname -m).so.1"
+for lib in $(readelf -d "$SO" 2>/dev/null | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p'); do
+  case "$lib" in
+    # ldso/dynlink.c: static const char reserved[] = "c.pthread.rt.m.dl.util.xnet.";
+    # musl satisfies these from itself and never looks at the filesystem, which is also why
+    # installing gcompat does not help: it ships /lib/libc.so.6 -> libgcompat.so.0, but
+    # libc.so.6 is reserved so that symlink is never read.
+    libc.so*|libpthread.so*|librt.so*|libm.so*|libdl.so*|libutil.so*|libxnet.so*)
+      if [ -e "$MUSL_LDSO" ]; then
+        echo "   ok        $lib (musl-reserved)"
+      else
+        echo "   ok        $lib"
+      fi ;;
+    *)
+      resolved=$(echo "$LDD_OUT" | awk -v l="$lib" '$1 == l && $2 == "=>" { print $3; exit }')
+      if [ -n "$resolved" ] && [ "$resolved" != "not" ]; then
+        echo "   ok        $lib -> $resolved"
+      else
+        fail "$lib in DT_NEEDED is neither musl-reserved nor resolvable on this system"
+      fi ;;
+  esac
+done
+
+# ---------------------------------------------------------------- undefined vs really exported
+# Reported, not fatal: with lazy binding an undefined GLOBAL that nothing calls never aborts.
+# netty-transport-native-epoll ships __xpg_strerror_r this way and runs fine on bare Alpine.
+# The execution checks below are what actually decide the outcome.
+echo "-- undefined GLOBAL symbols not exported by anything installed"
+UND=$(mktemp); AVAIL=$(mktemp)
+nm -D --undefined-only "$SO" 2>/dev/null | awk '$1 == "U" { print $2 }' | sed 's/@.*//' | sort -u > "$UND"
+for provider in "$MUSL_LDSO" /usr/lib/libgcc_s.so.1 /usr/lib/libstdc++.so.6 /lib/libgcompat.so.0 /usr/lib/libc.so.6; do
+  [ -e "$provider" ] && nm -D --defined-only "$provider" 2>/dev/null | awk '{ print $NF }' | sed 's/@.*//'
+done | sort -u > "$AVAIL"
+MISSING=$(comm -23 "$UND" "$AVAIL")
+if [ -z "$MISSING" ]; then
+  echo "   none"
+else
+  echo "$MISSING" | sed 's/^/   WARN /'
+fi
+rm -f "$UND" "$AVAIL"
+
+# ------------------------------------------------------- drop the ELF tools (and libgcc with them)
+# Everything above needs binutils; nothing below does. binutils depends on libgcc, so on an image
+# whose JDK does not itself require libgcc, installing it silently satisfies a libgcc_s.so.1
+# DT_NEEDED and the bare leg stops testing what it claims to. Removing it here means the execution
+# checks -- the ones that actually decide the outcome -- run against the package set a stock Alpine
+# JDK image really has. Guarded on apk so the Debian glibc-control image skips this untouched.
+if [ "${MUSL_DROP_ELFTOOLS:-0}" = "1" ] && command -v apk >/dev/null 2>&1; then
+  echo "-- dropping ELF tools so the runtime checks see no libgcc"
+  apk del .elftools >/dev/null 2>&1 || echo "   WARN: could not remove the .elftools virtual package"
+  echo "   compat now: $(apk info 2>/dev/null | grep -Ex 'gcompat|libc6-compat|libgcc|libstdc\+\+' | sort | tr '\n' ' ')"
+  for lib in /usr/lib/libgcc_s.so.1 /usr/lib/libstdc++.so.6; do
+    if [ -e "$lib" ]; then
+      echo "   note: $lib is still present (the JDK itself depends on it)"
+    else
+      echo "   ok: $lib is absent"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------- execute
+echo "-- load and initialize"
+CLASSES="$WORK/classes"
+mkdir -p "$CLASSES"
+javac -nowarn -d "$CLASSES" -cp "$CLASSES_JAR" "$HERE/MuslLoadCheck.java" \
+  || { echo "$0: cannot compile MuslLoadCheck" >&2; exit 2; }
+
+# Keep core dumps and hs_err files out of the mounted work tree: a SIGSEGV here writes hundreds
+# of megabytes, and on aarch64 that was the normal outcome before the fix.
+ulimit -c 0 2>/dev/null || true
+JVM_OPTS="-ea -Xcheck:jni -XX:-CreateCoredumpOnCrash -XX:ErrorFile=$WORK/hs_err_%p.log"
+
+# A hard JVM crash prints no RESULT line. Synthesise a failure for it rather than letting a
+# missing line read as success -- this is the single most important behaviour in this script.
+run_level() {
+    level="$1"
+    out=$(java $JVM_OPTS -cp "$CLASSES:$CLASSES_JAR" MuslLoadCheck "$level" "$SO" 2>&1)
+    rc=$?
+    if echo "$out" | grep -q '^RESULT'; then
+        echo "$out" | grep '^RESULT' | sed 's/^/   /'
+    else
+        printf '   RESULT\t%s\tFAIL\tJVM died without a result line (exit=%s)\n' "$level" "$rc"
+        echo "$out" | grep -E '^#  (SIGSEGV|SIGBUS|SIGILL)|^# C  \[' | sed 's/^/     crash| /'
+    fi
+    if [ "$rc" -ne 0 ]; then
+        fail "level '$level' exited $rc"
+    fi
+}
+
+run_level load
+run_level init
+run_level context
+
+echo "------------------------------------------------------------------"
+if [ "$FAILURES" -ne 0 ]; then
+  echo "musl-verify: FAIL ($FAILURES check(s)) on $(uname -m)/$VARIANT"
+  exit 1
+fi
+echo "musl-verify: PASS on $(uname -m)/$VARIANT"

--- a/docs/musl-compatibility.md
+++ b/docs/musl-compatibility.md
@@ -9,7 +9,8 @@ Background: <https://github.com/netty/netty-tcnative/issues/907>,
 <https://github.com/netty/netty-tcnative/issues/152>,
 <https://github.com/netty/netty/issues/15112>. The approach mirrors
 [async-profiler#952](https://github.com/async-profiler/async-profiler/issues/952), which ships
-one binary for both libcs.
+one binary for both libcs; its packaging step strips the same `ld-linux` entries with the same
+tool ([Makefile#L156](https://github.com/async-profiler/async-profiler/blob/bb8f0476a1804ac77b48b84a3905fb26e9ca7428/Makefile#L156)).
 
 ---
 

--- a/docs/musl-compatibility.md
+++ b/docs/musl-compatibility.md
@@ -180,6 +180,26 @@ On Alpine, `ldd` *is* the musl loader, so this reports the real errors with no J
 ldd "$SO"     # look for "Error loading shared library" / "Error relocating"
 ```
 
+**Beware what your inspection tools drag in.** `apk add binutils` — needed for the `readelf`/`nm`
+checks in §4a — depends on `libgcc`, so installing it satisfies a `libgcc_s.so.1` `DT_NEEDED` and
+turns a bare image into a non-bare one. `docker/Dockerfile.alpine` therefore installs binutils as
+the virtual package `.elftools`, and `verify.sh` removes it (with `libgcc`) before the execution
+checks when `MUSL_DROP_ELFTOOLS=1`. If you inspect by hand, do the `readelf` work in one container
+and the load test in a clean one.
+
+**And beware what the JDK itself drags in.** On `eclipse-temurin:21-jdk-alpine` the JDK *depends*
+on `libgcc`, so `apk del` cannot remove it there — the `bare` legs run with libgcc present no
+matter what, and cannot police invariant 1's `libgcc_s.so.1` clause. That is what the separate
+`nolibgcc` CI legs are for: same harness on `amazoncorretto:21-alpine`, whose JDK pulls no libgcc,
+so the runtime checks really do run without it. Run it locally with:
+
+```sh
+MUSL_VARIANT=nolibgcc MUSL_JDK_IMAGE=amazoncorretto:21-alpine MUSL_DROP_ELFTOOLS=1 \
+  docker compose -f docker/docker-compose.alpine.yaml build runtime-setup
+MUSL_VARIANT=nolibgcc MUSL_DROP_ELFTOOLS=1 MUSL_JARS_DIR=<dir> \
+  docker compose -f docker/docker-compose.alpine.yaml run --rm verify
+```
+
 ### 4c. Runtime check on bare Alpine
 
 ```sh

--- a/docs/musl-compatibility.md
+++ b/docs/musl-compatibility.md
@@ -1,0 +1,433 @@
+# Keeping netty-tcnative loadable on musl (Alpine Linux)
+
+The released Linux artifacts are built against glibc. They are nevertheless expected to load
+**on musl too**, from the same jar — there is no `-musl` classifier and adding one is not the
+plan. This document records the rules that make that work, how to verify them, and the dead
+ends, so the property is not lost again by accident.
+
+Background: <https://github.com/netty/netty-tcnative/issues/907>,
+<https://github.com/netty/netty-tcnative/issues/152>,
+<https://github.com/netty/netty/issues/15112>. The approach mirrors
+[async-profiler#952](https://github.com/async-profiler/async-profiler/issues/952), which ships
+one binary for both libcs.
+
+---
+
+## 1. The one rule that explains most failures
+
+musl's dynamic linker satisfies a **fixed list of libc alias names from musl itself**, without
+ever looking at the filesystem — `ldso/dynlink.c`:
+
+```c
+/* Catch and block attempts to reload the implementation itself */
+if (name[0]=='l' && name[1]=='i' && name[2]=='b') {
+    static const char reserved[] = "c.pthread.rt.m.dl.util.xnet.";
+```
+
+So a `DT_NEEDED` entry is safe **iff** it is `lib` + one of those stems + `.`:
+
+| `DT_NEEDED` | on bare Alpine | why |
+|---|---|---|
+| `libc.so.6`, `libpthread.so.0`, `librt.so.1`, `libdl.so.2`, `libm.so.6` | **fine** | reserved, resolved internally by musl |
+| `ld-linux-x86-64.so.2`, `ld-linux-aarch64.so.1` | **hard failure** | does not start with `lib` → real file lookup → absent |
+| `libgcc_s.so.1` | **hard failure** unless the image happens to ship Alpine's `libgcc` package | `gcc_s.` is not in the reserved list |
+| `libcrypt.so.1` | only with `gcompat` installed | not reserved; Alpine's gcompat symlinks it to `libgcompat.so.0` |
+
+Three consequences that are easy to get wrong:
+
+- **"the JDK image provides `libgcc`" is not a safe assumption.** Alpine JDK images disagree, and
+  the difference is invisible until it is not:
+
+  | image | ships `libgcc`? |
+  |---|---|
+  | `eclipse-temurin:21-jdk-alpine` | yes |
+  | `amazoncorretto:21-alpine` | **no** |
+  | many vendor/derived `*-jdk-alpine` images | **no** |
+
+  So `libgcc_s.so.1` is *not* an acceptable `DT_NEEDED` — it is only an invisible one on the
+  particular image the verification happens to run on. It is now linked statically instead
+  (`-l:libgcc.a -l:libgcc_eh.a`, see §6) and rejected by `scripts/check_musl_compat.sh`. Note also
+  that `apk add binutils` pulls `libgcc` in as a dependency, so an image that installs binutils to
+  *inspect* the artifact thereby stops being able to *detect* this class of bug — see §4b.
+
+- **`gcompat` being installed does not mean it is loaded.** gcompat ships
+  `/lib/libc.so.6 -> libgcompat.so.0`, but `libc.so.6` is reserved, so musl short-circuits it
+  and that symlink is never read. Only a *non-reserved* `DT_NEEDED` actually pulls
+  `libgcompat.so.0` into the process. This is exactly why 2.0.65 worked on Alpine by accident
+  (it carried `libcrypt.so.1`) and 2.0.73 did not.
+- **A missing symbol is not always a catchable error.** See §2.
+
+---
+
+## 2. The three failure classes, and their signatures
+
+### Class A — unreserved `DT_NEEDED`
+
+```
+Error loading shared library ld-linux-x86-64.so.2: No such file or directory
+```
+Surfaces as `UnsatisfiedLinkError`. Recoverable by the application.
+
+`ld-linux-*` gets recorded because **`__tls_get_addr` lives in glibc's loader**, and dynamic
+TLS is pulled in by `libstdc++.a`. Note musl *does* define `__tls_get_addr` itself — only the
+filename lookup fails, never the symbol. That is why simply dropping the entry is correct and
+sufficient.
+
+Whether this entry appears depends on the **toolchain and link path**, not on the architecture
+or the version alone. Observed:
+
+| build | `ld-linux-*` in `DT_NEEDED`? |
+|---|---|
+| official x86_64 (CentOS 6), 2.0.73–2.0.81 | **yes** |
+| official aarch64 cross (CentOS 7, ARM GCC 10.2), 2.0.82-SNAPSHOT | no |
+| native aarch64 glibc 2.28 / GCC 8, 2.0.82-SNAPSHOT | **yes** |
+| native aarch64 glibc 2.28 / GCC 8, 2.0.76-SNAPSHOT | no |
+
+So the same source can gain or lose the entry from a compiler or dependency change on either
+architecture. Do not treat "this arch does not have it" as a stable property: the removal runs
+unconditionally in both release profiles, and is a harmless no-op where the entry is absent,
+rather than being applied only where it was last observed.
+
+### Class B — glibc-internal symbol musl does not export
+
+```
+Error relocating <lib>.so: __getauxval: symbol not found
+```
+
+| symbol | comes from | musl has it? |
+|---|---|---|
+| `__getauxval` | libgcc AArch64 outline-atomics probe | no (only `getauxval`) |
+| `fopen64` | APR built with `-D_LARGEFILE64_SOURCE` | no — musl 1.2.4 (Alpine 3.19+) removed the LFS64 aliases |
+| `__isinf`, `__isnan` | APR-era glibc math aliases | no |
+| `__strdup` | APR | no |
+| `__pthread_key_create` | APR | no — but it is imported **WEAK**, so it may stay unresolved harmlessly |
+
+### Class C — Class B inside an ELF init constructor → **JVM crash, not an exception**
+
+The dangerous one. `__getauxval` is called from libgcc's `init_have_lse_atomics`, which is an
+`.init_array` constructor and therefore runs **during `dlopen`**:
+
+```
+C  [libnetty_tcnative_linux_aarch_64.so+0x2466c]  init_have_lse_atomics+0xc
+C  [ld-musl-aarch64.so.1+0x6cedc]  dlopen+0xc4
+V  [libjvm.so+0x8f5c8c]  JVM_LoadLibrary+0x88
+```
+
+The JVM dies with SIGSEGV and writes a core. The application cannot catch it and cannot fall
+back to the JDK SSL provider. Any unresolved symbol reachable from a constructor is in this
+class, so **do not assume "unresolved but never called" is safe** — check whether a
+constructor touches it.
+
+---
+
+## 3. Invariants to preserve
+
+For every released Linux `.so`, on a **bare** Alpine image (no `gcompat`, no `libc6-compat`):
+
+1. No `DT_NEEDED` outside the musl-reserved set. No exceptions — in particular not
+   `libgcc_s.so.1`, which is why the unwinder is linked statically.
+2. No undefined **GLOBAL** symbol that musl does not export. (Undefined **WEAK** is fine.)
+   No undefined `_Unwind_*` in particular: those come from `libstdc++.a`, and leaving them
+   undefined is precisely what puts `libgcc_s.so.1` back into `DT_NEEDED`.
+3. `System.load()` succeeds, `OpenSsl.isAvailable()` is true, and a real TLS handshake
+   completes.
+4. No behaviour change on glibc — identical negotiated cipher suite.
+
+---
+
+## 4. How to verify
+
+### 4a. Static check on the built library (fast, catches most things)
+
+Run inside a container with `binutils`. `$SO` is the built library, e.g.
+`boringssl-static/target/native-lib-only/META-INF/native/linux64/libnetty_tcnative.so`.
+
+```sh
+# 1. DT_NEEDED — anything not in the reserved set is a problem, libgcc_s.so.1 included
+readelf -d "$SO" | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p'
+
+# 1b. the unwinder must be linked in statically; this must print 0
+nm -D --undefined-only "$SO" | awk '$1 == "U" { print $2 }' | grep -c '^_Unwind_'
+
+# 2. undefined GLOBAL symbols not provided by musl.
+#    -W is essential: without it readelf truncates names and appends "[...]".
+readelf -W --dyn-syms "$SO" | awk '$7=="UND" && $5=="GLOBAL" {print $8}' | sed 's/@.*//' | sort -u \
+  > /tmp/und
+nm -D --defined-only /lib/ld-musl-$(uname -m).so.1 | awk '{print $NF}' | sed 's/@.*//' | sort -u \
+  > /tmp/have
+comm -23 /tmp/und /tmp/have     # must be empty (modulo libstdc++/libgcc_s symbols)
+```
+
+Also confirm the build really is static-BoringSSL — a stale `target/` can silently produce a
+library linked against the *host's shared* OpenSSL (see §7):
+
+```sh
+readelf -d "$SO" | grep -E 'libssl\.so|libcrypto\.so' && echo "NOT a static BoringSSL build"
+objdump -f boringssl-static/target/boringssl-main/build/libssl.a | grep -m1 architecture
+readelf -h "$SO" | grep Machine        # must match the intended target
+```
+
+In a **cross** build the `objdump -f` line reports `architecture: UNKNOWN!`, because the host
+binutils is reading a foreign-architecture archive. That is not a failure — check
+`readelf -h "$SO" | grep Machine` instead, and rely on the absence of `libssl.so`/`libcrypto.so`
+from `DT_NEEDED` for the static-linking question.
+
+### 4b. Ground truth: musl's own loader
+
+On Alpine, `ldd` *is* the musl loader, so this reports the real errors with no JVM involved:
+
+```sh
+ldd "$SO"     # look for "Error loading shared library" / "Error relocating"
+```
+
+### 4c. Runtime check on bare Alpine
+
+```sh
+docker run --rm -v "$PWD":/w -w /w eclipse-temurin:21-jdk-alpine sh -c '
+  java -cp "netty-common.jar:netty-buffer.jar:netty-transport.jar:netty-resolver.jar:\
+netty-codec.jar:netty-codec-base.jar:netty-handler.jar:netty-tcnative-classes.jar:\
+netty-tcnative-boringssl-static-<ver>-linux-<arch>.jar:." YourCheck'
+```
+
+The check must go further than loading. Minimum bar, in order of strength:
+
+1. `System.load()` on the extracted `.so`
+2. `io.netty.handler.ssl.OpenSsl.isAvailable()`
+3. **a full TLS handshake** — an in-memory `SSLEngine` pair (OpenSSL-backed server with a
+   self-signed cert, OpenSSL-backed client) driven to completion, then application data
+   round-tripped both ways
+
+Only (3) would catch a library that loads but whose crypto is broken.
+
+Two TLS 1.3 behaviours will make a naive handshake test report false failures:
+- the client reaches `NOT_HANDSHAKING` while the server still sits in `NEED_UNWRAP` waiting
+  for optional post-handshake traffic — treat an idle `NEED_UNWRAP` as settled;
+- the first post-handshake record is a `NewSessionTicket`, so a single `unwrap` legitimately
+  produces zero application bytes — loop until application data appears.
+
+### 4d. Regression check on glibc
+
+Run the same three checks on `eclipse-temurin:21-jdk-jammy` and compare the negotiated
+protocol/cipher against a released version. It must be identical.
+
+---
+
+## 5. Where the compatibility code lives
+
+| file | role |
+|---|---|
+| `openssl-dynamic/src/main/c/musl_compat.c` | weak fallbacks for the Class B symbols. Applies to **every** profile, since it is a source file. |
+| `boringssl-static/pom.xml`, antrun `native-jar` target | post-link `patchelf --remove-needed ld-linux-*` (Class A). Present in **both** release profiles: `boringssl-static-default` (x86_64) and `linux-aarch64`. |
+| `docker/Dockerfile.centos6` | installs `patchelf` from the upstream prebuilt **static** binary — CentOS 6 is EOL with no EPEL, and `objcopy` cannot remove a `DT_NEEDED`. Needs `--no-check-certificate`, same as the OpenSSL download: the CA bundle cannot verify modern GitHub TLS. |
+| `docker/Dockerfile.cross_compile_aarch64` | installs `patchelf` from EPEL 7 (available there, unlike CentOS 6) |
+
+Note the two release profiles duplicate the whole native build, so **a change to one does not
+apply to the other**. `linux-aarch64` cross-compiles from an x86_64 host; patchelf is
+arch-agnostic and edits the aarch64 object correctly from there (verified), whereas the
+`strip` in that profile has to use the cross-prefixed `aarch64-none-linux-gnu-strip`.
+
+### Rules for `musl_compat.c`
+
+- **Do not guard with `#ifndef __GLIBC__`.** The release images *are* glibc; the definitions
+  must be compiled into exactly the artifacts that need them. `__attribute__((weak))` is what
+  prevents collision with glibc's own definitions at link time.
+- Mark every definition `__attribute__((weak, visibility("default")))`. The build uses
+  `-fvisibility=hidden` (`native-package/configure.ac`), and `openssl-dynamic` resolves
+  against `libapr`/`libcrypto` at runtime, so hidden is not sufficient there.
+  `-Wl,--exclude-libs,ALL` (`m4/tcnative.m4`) only hides symbols coming *out of static
+  archives*, so our own stay exported.
+- The build uses `-Werror -Wunused`. Guard feature macros with `#ifndef` — the build already
+  passes `-D_LARGEFILE64_SOURCE` (`m4/custom.m4`) and redefining it is an error.
+- Implement each fallback in terms of the portable name (`__getauxval` → `getauxval`,
+  `fopen64` → `fopen`, `__strdup` → `strdup`, …), which exists on both libcs.
+
+### Adding new C files
+
+No autotools change is needed: hawtjni scans `src/main/c` and generates `Makefile.am` itself.
+Only the Windows `vs2010.vcxproj.static.template` has an explicit source list.
+
+---
+
+## 6. Dead ends — do not re-try these
+
+| attempt | why it fails |
+|---|---|
+| `-static-libgcc` **spelled that way** | libtool discards it, silently. See "Linking the unwinder statically" below — use `-l:libgcc.a -l:libgcc_eh.a` instead, which does work. |
+| `-ftls-model=initial-exec` to avoid `__tls_get_addr` | unsafe in a `dlopen`'d library — can fail at load once the static TLS block is exhausted. Strip the `DT_NEEDED` instead. |
+| a `linux-x86_64-musl` classifier | unnecessary; the goal is one binary. It would also need runtime libc detection, which netty tried (`#11722`) and reverted 3 days later (`#11738`) because `/proc/self/maps` false-positives when gcompat is present. |
+| relying on `gcompat` | does not help at all on aarch64 for ≥2.0.73 (still SIGSEGV), because nothing pulls `libgcompat.so.0` in. See §1. |
+| removing `-D_LARGEFILE64_SOURCE` (`m4/custom.m4`) to kill `fopen64` | this *is* the root cause and would be the cleaner fix, but it changes APR's build configuration — needs its own evaluation. Not done. |
+
+### Linking the unwinder statically, and why the spelling matters
+
+`libstdc++.a` pulls in the `_Unwind_*` family, and the only two providers are `libgcc_eh.a`
+(static) and `libgcc_s.so.1` (shared). Leaving them undefined is what records the `libgcc_s.so.1`
+`DT_NEEDED`. The obvious fix is `-static-libgcc` — and it does not work, for a reason worth
+knowing because it generalises to every flag in this build.
+
+**libtool does not pass the flag to the compiler.** GNU libtool 2.4.6 builds a shared library with
+`archive_cmds`, which expands only `$libobjs $deplibs $compiler_flags`. In `func_mode_link`, `-l*`
+is parsed into `deplibs`, but `-static-libgcc` / `-static-libstdc++` match neither the
+pass-through allowlist nor any specific case and fall into the catch-all `-* | +*)` branch, which
+appends them **only** to `compile_command`/`finalize_command` — the paths used to link *programs*.
+So `gcc -shared` never sees them. To confirm it on any build tree, put both spellings on the same
+`LDFLAGS` line and read what survived:
+
+```sh
+grep dependency_libs boringssl-static/target/native-build/libnetty_tcnative.la
+# dependency_libs=' -L.../boringssl-main/build -lssl -lcrypto -l:libstdc++.a -lrt -lpthread -ldl'
+```
+
+`-l:libstdc++.a` is there; `-static-libstdc++`, passed alongside it, is not. Only the `-l:` form
+ever does any work here.
+
+**The fix** is therefore to name the archives directly, after `libstdc++.a` (which is what pulls
+the `_Unwind_*` references in):
+
+```
+LDFLAGS=... -l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a
+```
+
+`libgcc_eh.a` defines the `_Unwind_*` family; with them resolved, the driver's trailing
+`--as-needed -lgcc_s` records no `DT_NEEDED`. Measured identical on GCC 4.9.4, 9.5.0 (x86_64) and
+10.5.0 (aarch64) — the shipping toolchains are devtoolset-9 (9.3.1) and ARM GCC 10.2.1:
+
+| link | `DT_NEEDED` | undefined `_Unwind_*` |
+|---|---|---|
+| `-l:libstdc++.a` alone | `libgcc_s.so.1 libc.so.6` | 11 |
+| `+ -l:libgcc.a -l:libgcc_eh.a` | `libc.so.6` | 0 |
+
+**One consequence on aarch64.** Static `libgcc.a` brings `init_have_lse_atomics` — the
+outline-atomics probe — into the library as an `.init_array` constructor, and it references
+`__getauxval`. That is a Class C symbol (§2): unresolved, it SIGSEGVs the JVM inside `dlopen`. It
+is satisfied by the weak, default-visibility fallback in `musl_compat.c`, and
+`check_musl_compat.sh` fails the build if that ever stops being true. Do not remove that fallback
+on the grounds that "nothing references it" — with static libgcc, something does.
+
+---
+
+## 7. Build-system traps
+
+The APR and BoringSSL steps guard on **directory existence**, not validity or architecture:
+
+```
+[echo] APR was already build, skipping the build step.
+[echo] BoringSSL was already build, skipping the build step.
+```
+
+- A run that fails partway leaves an empty `target/apr`; every later run then skips building
+  APR and fails far downstream with `configure: error: the --with-apr parameter is incorrect`.
+- Worse, building a **second architecture in the same tree** silently produces a wrong
+  artifact: reusing an aarch64 `target/boringssl-main` for an x86_64 build leaves
+  `libssl.a`/`libcrypto.a` as aarch64 archives, the linker skips them as incompatible and
+  falls back to the host's *shared* system OpenSSL. It builds and packages successfully.
+
+**Always `rm -rf <module>/target` when switching architecture or after a failed run**, and run
+the §4a `DT_NEEDED` check on the output.
+
+### libtool silently drops link flags it does not recognise
+
+The native library is linked by GNU libtool (`AC_PROG_LIBTOOL` in `native-package/configure.ac`),
+not by a bare `gcc` command, and libtool filters `LDFLAGS`. Only flags it classifies survive into
+the `gcc -shared` line: `-l*` and `-L*` become `deplibs`, `-Wl,*` becomes `compiler_flags`, and a
+fixed allowlist (`-O*`, `-g*`, `-flto*`, `-fstack-protector*`, `-m*`, `-pthread`, …) passes
+through. **Everything else is discarded without a warning.**
+
+Practical rules:
+
+- Prefer `-l:libfoo.a` over driver flags like `-static-libgcc` / `-static-libstdc++`. The `-l:`
+  form is passed through; the `-static-lib*` ones are not (§6).
+- Anything that must reach the *linker* can be forced with `-Wl,...`; anything that must reach the
+  *compiler driver* has no reliable route through `LDFLAGS` at all — set `CC` instead.
+- **Verify, do not assume.** `grep dependency_libs target/native-build/libnetty_tcnative.la` shows
+  exactly what survived, without re-running the build.
+
+A known casualty: the `boringssl-static-asan` profile's `-fsanitize=address` in `<ldflags>` never
+reaches the link on Linux — partly because libtool would drop it, and partly because that profile
+only overrides properties consumed by `boringssl-static-default`, whose Linux branch hardcodes
+`hawtjniLdflags` and ignores `${ldflags}` entirely. Not fixed; noted so it is not mistaken for a
+working ASan build.
+
+### Building the official images needs the right host
+
+`docker/Dockerfile.centos6` **cannot be built on a modern-kernel host**. CentOS 6.10 userspace
+needs the legacy `vsyscall` page, which recent kernels disable by default, so most of its
+binaries die with SIGSEGV (exit 139). It fails on upstream's very first `sed -i`, before any of
+this project's own steps. Symptom worth recognising: trivial binaries such as `/bin/true` and
+`sed --version` succeed while `sed -i`, plain `sed`, and `yum --version` all crash — which makes
+it look like a broken image rather than a host problem. The host needs `vsyscall=emulate` on the
+kernel command line (a reboot), or use a host/CI runner that already has it.
+
+`docker/Dockerfile.cross_compile_aarch64` (CentOS 7) builds fine on a modern kernel. Note the
+EPEL `ninja-build` GPG-key line in its output is a warning, not a failure.
+
+If you ever need an x86_64 build on a host you cannot reboot, a CentOS 7 image on the same base
+as the aarch64 cross one works, but note two things it needs that the cross image does not: an
+SCL **devtoolset** — the CentOS 7 system gcc is 4.8.5, too old for BoringSSL, and the cross image
+sidesteps that by compiling with the ARM toolchain — and **`no-asm`** for OpenSSL, because
+CentOS 7's binutils 2.27 cannot assemble OpenSSL 3.6's AVX-512 sources (same workaround, same
+reason, as the CentOS 6 image). Be aware it also raises the artifact's glibc floor; measure it
+rather than assuming the host's version:
+
+```sh
+readelf -V <lib> | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1
+```
+
+A CentOS 7-built x86_64 artifact measured `GLIBC_2.16`, against `<= GLIBC_2.12` from CentOS 6 —
+so that route drops RHEL/CentOS 6 and Ubuntu 12.04. `pom.xml` documents releasing x86_64 from
+RHEL 6 precisely to keep that reach, so this is a deliberate trade, not a free fix.
+
+### The release image is glibc 2.12 — mind what headers you use
+
+`docker/Dockerfile.centos6` is **glibc 2.12**, which predates a lot. `<sys/auxv.h>` and
+`getauxval()` only arrived in glibc 2.16, so including that header unconditionally is a *fatal*
+error on the x86_64 release image:
+
+```
+musl_compat.c: fatal error: sys/auxv.h: No such file or directory
+```
+
+`musl_compat.c` therefore probes with `__has_include` and falls back to reading
+`/proc/self/auxv` directly. Note the fallback is kept rather than compiling `__getauxval` out on
+old glibc: dropping it would leave the artifact unprotected the moment an x86_64 toolchain starts
+emitting `__getauxval`, which is exactly how the aarch64 breakage arose.
+
+Every other toolchain tried — glibc 2.17, 2.28, 2.35 and musl — has the header, so this only
+shows up on the real release image. Build there before trusting a portability claim.
+
+### Old glibc headers macro-define the names we override
+
+glibc 2.17's `<string.h>` defines `__strdup` as a function-like **macro** under `_GNU_SOURCE`, so
+defining it expands into the macro body:
+
+```
+musl_compat.c:87:23: error: expected identifier or '(' before '__extension__'
+```
+
+Newer glibc (2.28, 2.35) only *declares* it, so gcc 8, gcc 11 and the ARM GCC 10.2 cross build
+all accept the file without the `#undef` block in `musl_compat.c`. **Do not remove those
+`#undef`s because the toolchain in front of you is happy without them** — build on the oldest
+supported glibc before concluding the file compiles cleanly.
+
+Other notes:
+- `patchelf --remove-needed` exits 0 when the entry is absent, so one invocation listing both
+  `ld-linux-x86-64.so.2` and `ld-linux-aarch64.so.1` is safe on either architecture.
+- A post-link antrun step cannot be bound to the `compile` phase — plugin ordering puts antrun
+  *before* hawtjni. Use the `native-jar` target (phase `package`) or `process-classes`.
+- Ant's `<exec>` does not echo silent commands, so absence of `strip`/`patchelf` output in the
+  log does **not** mean they did not run. Verify on the artifact instead.
+- Link flags are set per profile and are duplicated: the x86_64 default profile sets
+  `hawtjniLdflags` in the `ldflags-setup` antrun execution, while the `linux-aarch64` profile
+  hardcodes `LDFLAGS` in its hawtjni `configureArgs`. Changing one does not change the other.
+
+---
+
+## 8. Checklist for a change that touches native linking
+
+- [ ] §4a static check passes on **both** `linux-x86_64` and `linux-aarch_64`
+- [ ] no `libssl.so`/`libcrypto.so` in `DT_NEEDED` (still a static BoringSSL build)
+- [ ] §4c runtime check passes on **bare** Alpine, including a real handshake
+- [ ] §4d glibc regression: identical negotiated cipher suite vs. the previous release
+- [ ] built in a clean tree (`rm -rf target`), not an incremental one
+- [ ] if a new symbol was added to `musl_compat.c`: it is `weak` + `visibility("default")`,
+      compiles under `-Werror`, and is confirmed to go from `UND` to defined in the output

--- a/openssl-dynamic/src/main/c/musl_compat.c
+++ b/openssl-dynamic/src/main/c/musl_compat.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Fallbacks for glibc-internal symbols that musl (Alpine Linux) does not export, so that
+ * the single glibc-built shared library also loads under musl.
+ *
+ * These are deliberately compiled in on a GLIBC host -- the release images are CentOS
+ * 6/7 -- so there must be no `#ifndef __GLIBC__` guard here or the definitions would be
+ * compiled out of exactly the artifacts that need them. `weak` is what keeps them from
+ * colliding with glibc's own definitions at link time; the linker satisfies references
+ * from libgcc.a / APR with these definitions instead of leaving them undefined, which is
+ * what removes the runtime failure.
+ *
+ * `visibility("default")` is required because the build uses -fvisibility=hidden
+ * (see native-package/configure.ac). Hidden would be enough for the fully static
+ * boringssl-static build, but openssl-dynamic links libapr/libcrypto dynamically and
+ * those resolve at runtime.
+ *
+ * The one that is genuinely load-fatal is __getauxval: libgcc's AArch64 outline-atomics
+ * probe (init_have_lse_atomics) calls it from an ELF init constructor, so an unresolved
+ * __getauxval crashes the JVM with SIGSEGV inside dlopen rather than raising
+ * UnsatisfiedLinkError. The rest are currently latent -- they sit in lazy PLT slots that
+ * nothing calls -- and are provided so they cannot become fatal later.
+ *
+ * See https://github.com/netty/netty-tcnative/issues/907
+ */
+
+#ifdef __linux__
+
+/* Guarded: the build already passes -D_LARGEFILE64_SOURCE (native-package/m4/custom.m4),
+ * and redefining it is an error under -Werror. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
+#endif
+
+#include <fcntl.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+ * <sys/auxv.h> and getauxval() only exist from glibc 2.16. The x86_64 release image is
+ * CentOS 6 (glibc 2.12), where including it is a fatal error, so this must stay conditional.
+ */
+#if defined(__has_include)
+#  if __has_include(<sys/auxv.h>)
+#    define TCN_HAVE_SYS_AUXV 1
+#  endif
+#endif
+#ifdef TCN_HAVE_SYS_AUXV
+#  include <sys/auxv.h>
+#endif
+
+#define TCN_MUSL_COMPAT __attribute__((weak, visibility("default")))
+
+/*
+ * Some glibc versions define these internal names as function-like MACROS rather than only
+ * declaring them -- glibc 2.17's <string.h> does this for __strdup under _GNU_SOURCE, so a
+ * definition here expands into the macro body and fails to compile ("expected identifier or
+ * '(' before '__extension__'"). Undefine them first. Newer glibc (2.28, 2.35) only declares
+ * them, so this is invisible there: it must not be removed just because one toolchain is
+ * happy without it.
+ */
+#undef __getauxval
+#undef __isinf
+#undef __isnan
+#undef __strdup
+#undef fopen64
+
+/*
+ * glibc exports getauxval and the __-prefixed alias; musl exports only getauxval.
+ * (gcompat supplies __getauxval, which is why tcnative 2.0.65 happened to work on Alpine:
+ * it carried a DT_NEEDED on libcrypt.so.1, which Alpine symlinks to libgcompat.so.0.)
+ *
+ * Where getauxval() is unavailable -- glibc < 2.16, i.e. the CentOS 6 release image -- read
+ * /proc/self/auxv directly rather than dropping the fallback. The alternative would leave the
+ * artifact without it the moment a toolchain starts emitting __getauxval on x86_64, which is
+ * how the aarch64 breakage happened in the first place.
+ */
+#ifndef TCN_HAVE_SYS_AUXV
+static unsigned long tcn_auxv_lookup(unsigned long type) {
+    unsigned long entry[2];
+    unsigned long value = 0;
+    int fd = open("/proc/self/auxv", O_RDONLY);
+    if (fd < 0) {
+        return 0;
+    }
+    while (read(fd, entry, sizeof(entry)) == (ssize_t) sizeof(entry)) {
+        if (entry[0] == type) {
+            value = entry[1];
+            break;
+        }
+        if (entry[0] == 0) { /* AT_NULL terminates the vector */
+            break;
+        }
+    }
+    close(fd);
+    return value;
+}
+#endif
+
+TCN_MUSL_COMPAT unsigned long __getauxval(unsigned long type) {
+#ifdef TCN_HAVE_SYS_AUXV
+    return getauxval(type);
+#else
+    return tcn_auxv_lookup(type);
+#endif
+}
+
+/*
+ * musl 1.2.4 (Alpine 3.19+) removed the LFS64 aliases; off_t is unconditionally 64-bit
+ * there, so forwarding to fopen is exact rather than a narrowing.
+ */
+TCN_MUSL_COMPAT FILE *fopen64(const char *path, const char *mode) {
+    return fopen(path, mode);
+}
+
+/* glibc-internal math aliases emitted via APR's configure-era headers. */
+TCN_MUSL_COMPAT int __isinf(double value) {
+    return isinf(value);
+}
+
+TCN_MUSL_COMPAT int __isnan(double value) {
+    return isnan(value);
+}
+
+/* glibc-internal alias APR links against directly. */
+TCN_MUSL_COMPAT char *__strdup(const char *str) {
+    return strdup(str);
+}
+
+#endif /* __linux__ */

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
     <msvcSslLibDirs>${sslHome}/lib</msvcSslLibDirs>
     <msvcSslLibs>libssl.lib;libcrypto.lib</msvcSslLibs>
     <strip.skip>false</strip.skip>
+    <muslCheck.skip>false</muslCheck.skip>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <macOsxDeploymentTarget>MACOSX_DEPLOYMENT_TARGET=10.9</macOsxDeploymentTarget>
     <cmakeOsxDeploymentTarget>-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9</cmakeOsxDeploymentTarget>

--- a/scripts/check_musl_compat.sh
+++ b/scripts/check_musl_compat.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+# ----------------------------------------------------------------------------
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
 # Fail the build if a Linux native library would not load under musl (Alpine).
 #
 # The released Linux artifacts are glibc-built, but the same jar is expected to work on musl --

--- a/scripts/check_musl_compat.sh
+++ b/scripts/check_musl_compat.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+# Fail the build if a Linux native library would not load under musl (Alpine).
+#
+# The released Linux artifacts are glibc-built, but the same jar is expected to work on musl --
+# there is no -musl classifier and no plan for one. That silently stopped being true after
+# 2.0.65 and went unnoticed for eight releases (netty-tcnative#907, #152, netty#15112). Two
+# distinct things break it, and neither is visible on a glibc builder:
+#
+#  1. A DT_NEEDED entry musl cannot resolve. musl's loader satisfies a fixed set of libc alias
+#     names from musl itself, without ever touching the filesystem -- ldso/dynlink.c:
+#         static const char reserved[] = "c.pthread.rt.m.dl.util.xnet.";
+#     Everything else is a real file lookup. "ld-linux-<arch>.so.*" does not begin with "lib",
+#     so it is looked up as a file and is simply absent on Alpine.
+#
+#  2. An undefined GLOBAL symbol musl does not export -- e.g. __getauxval, where musl has only
+#     getauxval. That one is referenced from libgcc's init_have_lse_atomics, an .init_array
+#     constructor that runs during dlopen, so on aarch64 the JVM dies with SIGSEGV inside
+#     JVM_LoadLibrary instead of raising a catchable UnsatisfiedLinkError -- the application
+#     cannot fall back to the JDK provider. Undefined WEAK symbols are fine; they resolve to 0.
+#
+# Only (1) and a regression of the musl_compat.c fallbacks are treated as errors. A general
+# undefined-GLOBAL scan is reported but does not fail the build, because it cannot decide
+# reachability: with lazy PLT binding an unresolved symbol that nothing calls never aborts.
+# netty-transport-native-epoll is the proof -- it imports __xpg_strerror_r as an undefined
+# GLOBAL and nevertheless loads and runs on bare Alpine on both architectures, because the
+# symbol sits on an error path. Failing on that shape would make this check cry wolf. What it
+# cannot rule out is the constructor case above, which is why the runtime check on real Alpine
+# is a separate and non-optional part of the verification.
+#
+# Runs on the build host with binutils only, so it also covers the cross-compiled aarch64
+# artifact, which is built with -DskipTests and is otherwise never verified at all. Bound to the
+# package phase (not verify) because every build, deploy and staging command is "clean package
+# <plugin>:goal" and stops before verify; unlike surefire, antrun is unaffected by -DskipTests.
+#
+# usage: check_musl_compat.sh <path-to-.so> [static|dynamic]
+# env:   TOOL_PREFIX  binutils prefix for cross-built objects, e.g. aarch64-none-linux-gnu-
+# exit:  0 ok / 1 would fail on musl / 2 usage error
+#
+# See docs/musl-compatibility.md for the full rules, the verification ladder and the dead ends.
+
+set -u
+
+SO="${1:-}"
+PROFILE="${2:-static}"
+if [ -z "$SO" ] || [ ! -f "$SO" ]; then
+  echo "usage: $0 <path-to-.so> [static|dynamic]" >&2
+  exit 2
+fi
+
+READELF="${TOOL_PREFIX:-}readelf"
+NM="${TOOL_PREFIX:-}nm"
+
+# DT_NEEDED names musl resolves internally (the reserved[] stems above). Nothing else is allowed
+# for boringssl-static -- notably not libgcc_s.so.1: `gcc_s.` is not a reserved stem, so it is a
+# real file lookup, and Alpine JDK images disagree about shipping the `libgcc` package that would
+# satisfy it (eclipse-temurin does, amazoncorretto and many vendor images do not). The build links
+# libgcc.a/libgcc_eh.a statically instead; see boringssl-static/pom.xml and check 4 below.
+RESERVED='^lib(c|pthread|rt|m|dl|util|xnet)\.so'
+case "$PROFILE" in
+  static)
+    # boringssl-static links everything else statically, so nothing beyond RESERVED is allowed.
+    # Must be a pattern that cannot match rather than '': `grep -Eq ""` matches every input and
+    # would silently disable check 1 altogether.
+    EXTRA='^$' ;;
+  dynamic)
+    # openssl-dynamic deliberately links against the system OpenSSL and APR. Those are not
+    # musl-reserved, so this artifact needs `apk add openssl apr` on Alpine -- that is by design
+    # and is not what this check is about. ld-linux is still never acceptable.
+    # NOTE: this branch currently has no caller anywhere in the tree (openssl-dynamic is not
+    # gated), so its libgcc_s.so.1 allowance is untested and deliberately left as-is.
+    EXTRA='^(libgcc_s\.so\.1|libssl\.so|libcrypto\.so|libapr-1\.so)' ;;
+  *)
+    echo "$0: unknown profile '$PROFILE' (expected static or dynamic)" >&2
+    exit 2 ;;
+esac
+
+# The __-prefixed symbols musl really does export. Regenerate on any Alpine machine with:
+#   nm -D --defined-only /lib/ld-musl-$(uname -m).so.1 | awk '$3 ~ /^__/ { print $3 }' | sort -u
+MUSL_UNDERSCORE_SYMS='
+__assert_fail __cxa_atexit __cxa_finalize __cxa_thread_atexit_impl
+__ctype_b_loc __ctype_get_mb_cur_max __ctype_tolower_loc __ctype_toupper_loc
+__errno_location __fpclassify __fpclassifyf __fpclassifyl
+__h_errno_location __libc_start_main __signbit __signbitf __signbitl
+__stack_chk_fail __stack_chk_guard __tls_get_addr
+'
+
+# The fallbacks openssl-dynamic/src/main/c/musl_compat.c defines. Asserting these are *defined*
+# rather than undefined catches the compatibility file being dropped or excluded from the link.
+MUSL_COMPAT_SYMS='__getauxval fopen64 __isinf __isnan __strdup'
+
+rc=0
+MACHINE=$("$READELF" -h "$SO" 2>/dev/null | sed -n 's/.*Machine:[[:space:]]*//p')
+echo "== musl compatibility check: $SO"
+echo "   machine=$MACHINE profile=$PROFILE"
+
+NEEDED=$("$READELF" -d "$SO" 2>/dev/null | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p')
+
+# ---------------------------------------------------------------- 1. DT_NEEDED allowlist
+BAD_NEEDED=""
+for lib in $NEEDED; do
+  if printf '%s' "$lib" | grep -Eq "$RESERVED" || printf '%s' "$lib" | grep -Eq "$EXTRA"; then
+    continue
+  fi
+  BAD_NEEDED="$BAD_NEEDED $lib"
+done
+if [ -n "$BAD_NEEDED" ]; then
+  rc=1
+  echo "   FAIL: DT_NEEDED entries musl cannot resolve:"
+  for lib in $BAD_NEEDED; do echo "         $lib"; done
+  echo "         musl resolves only the libc/libpthread/librt/libm/libdl/libutil/libxnet"
+  echo "         aliases internally; anything else must exist as a file on bare Alpine."
+  echo "         Drop it with 'patchelf --remove-needed', or stop linking against it."
+else
+  echo "   ok: DT_NEEDED is satisfiable by musl"
+fi
+
+# ---------------------------------------------------------------- 2. still statically linked
+if [ "$PROFILE" = static ]; then
+  if printf '%s\n' "$NEEDED" | grep -Eq '^lib(ssl|crypto)\.so'; then
+    rc=1
+    echo "   FAIL: libssl.so/libcrypto.so in DT_NEEDED -- this is NOT a static BoringSSL build."
+    echo "         The APR and BoringSSL steps skip themselves when their target directory"
+    echo "         already exists, so a tree left over from another architecture or a failed"
+    echo "         run yields a green build linked against the host's shared OpenSSL."
+    echo "         Remove the module target directories and build again."
+  fi
+fi
+
+# ---------------------------------------------------------------- 3. undefined GLOBAL symbols
+# `nm -D` prints "U" for undefined GLOBAL and "w"/"v" for undefined WEAK, which is exactly the
+# distinction that matters: an undefined WEAK resolves to 0 and is harmless (APR imports
+# __pthread_key_create that way). This is also why nm is used rather than
+# `readelf --dyn-syms`: that spelling postdates the binutils in the CentOS 6 release image, and
+# readelf silently truncates long names unless -W is passed.
+#
+# Two shapes are flagged rather than a fixed list of known-bad names: __-prefixed (the
+# glibc-private namespace -- __getauxval, __isinf, __strdup, the _FORTIFY_SOURCE *_chk family,
+# __isoc99_* redirects) and the LFS64 aliases (fopen64 and friends), which musl 1.2.4 removed
+# outright. A denylist would only guard against a repeat, and the history here is that each
+# release broke on a *different* symbol.
+UND=$("$NM" -D --undefined-only "$SO" 2>/dev/null \
+  | awk '$1 == "U" { print $2 }' | sed 's/@.*//' | sort -u)
+
+ALLOW=$(printf '%s\n' $MUSL_UNDERSCORE_SYMS)
+BAD_SYMS=$(printf '%s\n' "$UND" \
+  | grep -E '^__|^[a-z][a-z0-9_]*64$' \
+  | grep -vxF "$ALLOW")
+if [ -n "$BAD_SYMS" ]; then
+  echo "   WARN: undefined GLOBAL symbols musl does not export:"
+  printf '%s\n' "$BAD_SYMS" | sed 's/^/         /'
+  echo "         Not fatal by itself -- with lazy binding an uncalled symbol never aborts, and"
+  echo "         netty-transport-native-epoll ships __xpg_strerror_r this way and works fine."
+  echo "         But triage each one: if it is reachable from an ELF .init_array constructor it"
+  echo "         runs during dlopen and crashes the JVM instead of raising UnsatisfiedLinkError."
+  echo "         The fix is a weak, default-visibility fallback in"
+  echo "         openssl-dynamic/src/main/c/musl_compat.c, implemented via the portable name."
+  echo "         If musl does export one, add it to MUSL_UNDERSCORE_SYMS in this script"
+  echo "         (arbiter: nm -D --defined-only /lib/ld-musl-\$(uname -m).so.1)."
+else
+  echo "   ok: no undefined GLOBAL symbol outside musl's exports"
+fi
+
+# The musl_compat.c fallbacks must be present, not merely absent from the undefined set: an
+# artifact that never referenced them at all is fine, but one that references them and does not
+# define them is exactly the aarch64 crash.
+MISSING_COMPAT=""
+for sym in $MUSL_COMPAT_SYMS; do
+  if printf '%s\n' "$UND" | grep -qxF "$sym"; then
+    MISSING_COMPAT="$MISSING_COMPAT $sym"
+  fi
+done
+if [ -n "$MISSING_COMPAT" ]; then
+  rc=1
+  echo "   FAIL: musl_compat.c fallbacks are referenced but undefined:$MISSING_COMPAT"
+  echo "         musl_compat.c is not being compiled into this artifact, or its definitions"
+  echo "         were dropped by -fvisibility=hidden / --exclude-libs."
+fi
+
+# The unwinder must be linked in statically. libstdc++.a pulls in _Unwind_*, and the only two
+# providers are libgcc_eh.a (static) and libgcc_s.so.1 (shared) -- so leaving these undefined is
+# the exact shape that puts libgcc_s.so.1 back into DT_NEEDED and makes the artifact unloadable on
+# an Alpine image without the `libgcc` package. Check 1 already rejects the DT_NEEDED entry; this
+# one exists so that a build whose -l:libgcc*.a flags stopped reaching the link (libtool silently
+# drops anything outside its pass-through allowlist) fails loudly here rather than producing a
+# library that is quietly missing its unwinder. Not caught by the scan above: _Unwind_ has a
+# single leading underscore.
+UND_UNWIND=$(printf '%s\n' "$UND" | grep '^_Unwind_' | tr '\n' ' ')
+if [ -n "$UND_UNWIND" ]; then
+  rc=1
+  echo "   FAIL: the unwinder is not linked in; undefined _Unwind_* symbols:"
+  echo "         $UND_UNWIND"
+  echo "         Ensure LDFLAGS keeps '-l:libgcc.a -l:libgcc_eh.a' *after* '-l:libstdc++.a'."
+  echo "         Do not spell it -static-libgcc: libtool drops that before gcc sees it."
+else
+  echo "   ok: unwinder linked statically (no undefined _Unwind_*)"
+fi
+
+# ---------------------------------------------------------------- 4. glibc floor (informational)
+# Not a gate, but a regression here would quietly cut the supported platform range, and the
+# x86_64 artifact is released from CentOS 6 precisely to keep this at 2.12.
+FLOOR=$("$READELF" -V "$SO" 2>/dev/null | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1)
+echo "   info: glibc symbol floor: ${FLOOR:-none}"
+
+if [ "$rc" -ne 0 ]; then
+  echo "== FAIL: this artifact would not load on bare Alpine."
+  echo "   See docs/musl-compatibility.md. Set -DmuslCheck.skip=true to bypass locally."
+  exit 1
+fi
+echo "== PASS (loadability invariants hold; see WARN lines above, if any)"


### PR DESCRIPTION
Motivation:

The released Linux artifacts are glibc-built but are expected to load on musl from the same
jar. That stopped being true after 2.0.65, in three different ways.

**aarch64 — the JVM crashes rather than throwing.** `__getauxval` is unresolved on musl (only
`getauxval` exists there) and is called from libgcc's `init_have_lse_atomics`, an `.init_array`
constructor that runs during `dlopen`. So the JVM dies with SIGSEGV inside `JVM_LoadLibrary`:

```
C  [libnetty_tcnative_linux_aarch_64.so+0x2466c]  init_have_lse_atomics+0xc
C  [ld-musl-aarch64.so.1+0x6cedc]  dlopen+0xc4
V  [libjvm.so+0x8f5c8c]  JVM_LoadLibrary+0x88
```

An application cannot catch that and fall back to the JDK provider.

**Installing gcompat does not help**, which is worth spelling out because it is unintuitive.
musl's loader satisfies a fixed set of libc alias names from musl itself without touching the
filesystem (`ldso/dynlink.c`: `reserved[] = "c.pthread.rt.m.dl.util.xnet."`). gcompat ships
`/lib/libc.so.6 -> libgcompat.so.0`, but `libc.so.6` is reserved, so that symlink is never read
and `libgcompat.so.0` is never loaded. 2.0.65 only worked on Alpine *by accident*, via its
`libcrypt.so.1` DT_NEEDED, which Alpine symlinks to `libgcompat.so.0`; 2.0.73 dropped it.

**Both arches — a spurious loader dependency.** `DT_NEEDED` can contain `ld-linux-<arch>.so.*`,
which does not begin with `lib` and so is a real file lookup that fails on Alpine. It is recorded
only because `__tls_get_addr` lives in glibc's loader; musl defines that symbol itself, so the
symbol was never the problem and dropping the entry is sufficient.

Whether that entry appears depends on the toolchain, not the arch or version:

| build | `ld-linux-*` present? |
|---|---|
| official x86_64 (CentOS 6), 2.0.73–2.0.81 | yes |
| official aarch64 cross (CentOS 7, ARM GCC 10.2) | no |
| native aarch64 glibc 2.28 / GCC 8 | yes |

**Both arches — `libgcc_s.so.1`.** `gcc_s.` is not a reserved stem either, so this too is a real
file lookup, and it resolves only on images that happen to ship Alpine's `libgcc` package. Alpine
JDK images disagree about that:

| image | ships `libgcc`? |
|---|---|
| `eclipse-temurin:21-jdk-alpine` | yes |
| `amazoncorretto:21-alpine` | **no** |
| many vendor / derived `*-jdk-alpine` images | **no** |

So the dependency is not safe, only *invisible* on some bases — which is why it survived every
other fix. It is recorded whenever the `_Unwind_*` symbols that `libstdc++.a` pulls in are left
undefined, and it is the failure an application actually hits:

```
java.lang.UnsatisfiedLinkError: .../libnetty_tcnative_linux_aarch_64.so:
  Error loading shared library libgcc_s.so.1: No such file or directory
```

Modifications:

- Add `openssl-dynamic/src/main/c/musl_compat.c`: weak, default-visibility fallbacks for the
  glibc-internal symbols musl does not export — `__getauxval`, `fopen64` (musl 1.2.4 removed the
  LFS64 aliases), `__isinf`, `__isnan`, `__strdup`. Deliberately **not** guarded on `__GLIBC__`:
  the release images are glibc, so the definitions must be compiled into exactly the artifacts
  that need them; `weak` is what avoids colliding with glibc's own definitions.
- Drop the `ld-linux` `DT_NEEDED` post-link with `patchelf`, next to the existing `strip`, in the
  `native-jar` antrun target of **both** release profiles. The two profiles duplicate the whole
  native build, so a change to one does not apply to the other. `patchelf` exits 0 when the entry
  is absent and is arch-agnostic, so one invocation is safe and works from the cross host.
- Install `patchelf` in the build images: `Dockerfile.centos6` from the upstream prebuilt static
  binary (CentOS 6 is EOL, no EPEL, and `objcopy` cannot remove a `DT_NEEDED`),
  `Dockerfile.cross_compile_aarch64` from EPEL 7.
- Link the unwinder statically, `-l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a`, in both Linux
  profiles. `libgcc_eh.a` defines the `_Unwind_*` family; with them resolved the driver's trailing
  `--as-needed -lgcc_s` records no `DT_NEEDED`. **The spelling is not interchangeable with
  `-static-libgcc`** — see Notes.
- Add `scripts/check_musl_compat.sh` and run it from the `native-jar` antrun target of the three
  profiles that build a Linux artifact (**CI tier 1**, static). Bound to `package` rather than
  `verify`, because every build, deploy and staging command is `clean package <plugin>:goal`; and
  unlike surefire, antrun is unaffected by `-DskipTests`, which is what gives the cross-compiled
  aarch64 artifact its only automated check. Fatal on: a `DT_NEEDED` outside the musl-reserved
  set, any undefined `_Unwind_*`, a non-static BoringSSL build, or a referenced-but-undefined
  `musl_compat.c` fallback.
- Add a `musl-verify` job to `ci-pr.yml` and `ci-build.yml` that loads the already-built jars on
  real Alpine (**CI tier 2**, runtime). The static tier cannot decide whether an undefined symbol
  is ever *reached*, nor whether reaching it throws or kills the JVM — on aarch64 it was the
  latter — so the artifact has to be executed. aarch64 runs natively on `ubuntu-24.04-arm`.
  Legs: `bare`, `nolibgcc`, `gcompat` and a glibc control.
- Add `docs/musl-compatibility.md` documenting the rules, how to verify them, and the dead ends.

Two portability details in `musl_compat.c` that only the official images exposed — every other
toolchain tried (glibc 2.17, 2.28, 2.35, musl, ARM GCC 10.2 cross) accepted the file without them:

- glibc 2.12 has no `<sys/auxv.h>` (added in 2.16), so including it unconditionally is a *fatal*
  error on the CentOS 6 x86_64 image. Probed with `__has_include`, falling back to reading
  `/proc/self/auxv`. The fallback is kept rather than compiling `__getauxval` out on old glibc,
  since dropping it is how the aarch64 breakage arose in the first place.
- glibc 2.17 macro-defines `__strdup` under `_GNU_SOURCE`, so a definition expands into the macro
  body. The overridden names are `#undef`'d first.

Result:

Built from source on **both official release images** and tested on bare Alpine 3.23
(musl 1.2.5, no `gcompat`, no `libc6-compat`):

| | image | glibc floor | unresolvable syms | bare Alpine | glibc regression |
|---|---|---|---|---|---|
| x86_64 | `docker-compose.centos-6.yaml` | **GLIBC_2.12** (unchanged) | none | PASS | none |
| aarch64 | `docker-compose.centos-7.yaml` cross | — | none | PASS | none |

"PASS" means `System.load`, `OpenSsl.isAvailable()`, **and** a full TLSv1.3 handshake with
application data round-tripped both ways (in-memory `SSLEngine` pair, OpenSSL-backed on both
sides) — not merely that the library loads. Released 2.0.81 SIGSEGVs (aarch64) or fails to load
(x86_64) in the same containers.

Two Alpine bases are used, because `libgcc` gets in two different ways and either one makes the
check vacuous: `apk add binutils` (needed for `readelf`/`nm`) pulls it in as a dependency, and on
`eclipse-temurin` the *JDK itself* depends on it, so it cannot be removed there at all. Hence the
`nolibgcc` leg on `amazoncorretto:21-alpine`, whose JDK pulls no `libgcc` and which still provides
`javac` and `jar`. It is the only leg that can prove the artifact loads without `libgcc` present,
and it fails on an artifact still carrying the `libgcc_s.so.1` entry.

**ABI reach is unchanged**: the x86_64 artifact's highest versioned reference is still
`GLIBC_2.12`, so RHEL 6 / Ubuntu 12.04 support is preserved. `patchelf` removed
`ld-linux-x86-64.so.2` (present before, absent after), BoringSSL remains statically linked
(archives `i386:x86-64`, no `libssl.so`/`libcrypto.so` in `DT_NEEDED`), and `NativeTest` passes.

On `eclipse-temurin:21-jdk-jammy` the patched build negotiates the same cipher suite
(`TLSv1.3 / TLS_AES_128_GCM_SHA256`) as 2.0.75.Final and 2.0.81.Final on both arches.

Notes:

- **`-static-libgcc` does not work here, and the reason generalises.** libtool links the shared
  library through `archive_cmds`, which expands only `$libobjs $deplibs $compiler_flags`. `-l*` is
  parsed into `deplibs`, but `-static-lib*` falls into `func_mode_link`'s catch-all `-* | +*)`
  branch and reaches only the *program* link path — so `gcc -shared` never sees it. Put both
  spellings on one `LDFLAGS` line and `grep dependency_libs target/native-build/*.la` shows only
  the `-l:` one survived. Hence `-l:libgcc.a -l:libgcc_eh.a`, and the redundant
  `-static-libstdc++` dropped. A comment in the pom and §6/§7 of the doc record this.
- On aarch64 the static libgcc pulls `init_have_lse_atomics` into the library as an `.init_array`
  constructor, so the `__getauxval` fallback stops being latent and becomes load-bearing. That is
  the crash class above, which is why tier 1 fails the build if that fallback ever goes missing.
- `Dockerfile.centos6` only builds on a host whose kernel still emulates the legacy vsyscall page.
  On kernels that disable it, CentOS 6 userspace segfaults on the image's first `sed -i` — worth
  knowing for release tooling; it is unrelated to this change.

Fixes #907
See #152, netty/netty#15112
