### PR TITLE
Fix double DeleteLocalRef call which results in UB

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1637,8 +1637,6 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
 
     result = (*e)->CallIntMethod(e, c->verifier, c->verifier_method, P2J(ssl), array, authMethodString);
 
-    NETTY_JNI_UTIL_DELETE_LOCAL(e, authMethodString);
-
     if ((*e)->ExceptionCheck(e)) {
          // We always need to set the error as stated in the SSL_CTX_set_cert_verify_callback manpage, so set the result
          // to the correct value.
@@ -1768,8 +1766,6 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
     } else {
         // Execute the java callback
         result = (*e)->CallIntMethod(e, state->ctx->verifier, state->ctx->verifier_method, P2J(ssl), array, authMethodString);
-
-        NETTY_JNI_UTIL_DELETE_LOCAL(e, authMethodString);
 
         if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
             result = X509_V_ERR_UNSPECIFIED;


### PR DESCRIPTION
Motivation:

A double DeleteLocalRef on the same local reference is present in both the OpenSSL and BoringSSL cert-verify callbacks in sslcontext.c. The NETTY_JNI_UTIL_DELETE_LOCAL macro does not null out the pointer after deleting
, so a second delete on the same stale handle is real UB per the JNI spec — it can corrupt the local-ref table and crash later in an unrelated JNI call.

This regression was introduces by https://github.com/netty/netty-tcnative/commit/990751e766b5d4bf697a4a9fb6b45e66bf415b8d

Modifications:

Remove deletion of local ref when its already done

Result:

No more UB
