### PR TITLE
Do not delete the authentication method local reference twice

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -1638,6 +1638,9 @@ static int SSL_cert_verify(X509_STORE_CTX *ctx, void *arg) {
     result = (*e)->CallIntMethod(e, c->verifier, c->verifier_method, P2J(ssl), array, authMethodString);
 
     NETTY_JNI_UTIL_DELETE_LOCAL(e, authMethodString);
+    // NULL it out: every exit from here runs the complete: block below, and deleting the same
+    // local reference twice is a fatal error under -Xcheck:jni.
+    authMethodString = NULL;
 
     if ((*e)->ExceptionCheck(e)) {
          // We always need to set the error as stated in the SSL_CTX_set_cert_verify_callback manpage, so set the result
@@ -1770,6 +1773,9 @@ enum ssl_verify_result_t tcn_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_alert
         result = (*e)->CallIntMethod(e, state->ctx->verifier, state->ctx->verifier_method, P2J(ssl), array, authMethodString);
 
         NETTY_JNI_UTIL_DELETE_LOCAL(e, authMethodString);
+        // NULL it out: every exit from here runs the complete: block below, and deleting the same
+        // local reference twice is a fatal error under -Xcheck:jni.
+        authMethodString = NULL;
 
         if ((*e)->ExceptionCheck(e) == JNI_TRUE) {
             result = X509_V_ERR_UNSPECIFIED;


### PR DESCRIPTION
Motivation:

#996 added an early `NETTY_JNI_UTIL_DELETE_LOCAL` of `authMethodString` in both cert verify callbacks. The macro does not NULL its argument, and both functions already delete that reference again at their `complete:` label. A double `DeleteLocalRef` is fatal under `-Xcheck:jni`, so every openssl-dynamic job in netty/netty#17356 dies with:

```
FATAL ERROR in native method: Bad global or local ref passed to JNI
    at io.netty.internal.tcnative.SSL.readFromSSL(Native Method)
    at io.netty.handler.ssl.ReferenceCountedOpenSslEngine.readPlaintextData
```

Only openssl is affected because `SSL_cert_verify` has no task path and always reaches both deletes. `tcn_SSL_cert_custom_verify` has the same defect, but netty defaults `useTasks` to true so that branch is skipped, which is why the boringssl jobs stay green. It is fixed here too rather than left waiting for someone to set `useTasks` to false.

Modification:

NULL `authMethodString` after the early delete in both functions, matching what `get_certs` and every other delete site in this file already do.

Result:

Fixes netty/netty#17356. Verified on macOS aarch64 against OpenSSL 3.6.3, driving a pair of netty SSLEngines through a handshake under `-Xcheck:jni`: unpatched the JVM dies on the first handshake, patched 50 handshakes complete over TLSv1.3.

https://claude.ai/code/session_01RVaAsJndUk7hxtG38JTxTc
