### PR TITLE
Update to latest netty-jni-util release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <skipJapicmp>false</skipJapicmp>
     <compileLibrary>false</compileLibrary>
     <jniUtilIncludeDir>${project.build.directory}/netty-jni-util/</jniUtilIncludeDir>
-    <jniUtilVersion>0.0.10.Final</jniUtilVersion>
+    <jniUtilVersion>0.0.11.Final</jniUtilVersion>
     <javaDefaultModuleName>io.netty.internal.tcnative</javaDefaultModuleName>
     <javaModuleName>${javaDefaultModuleName}</javaModuleName>
     <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>


### PR DESCRIPTION
Motivation:

We did cut a new netty-jni-util release, let's use it

Modifications:

Update to 0.0.11.Final

Result:

Use latest netty-jni-util release
