### PR TITLE
Check if hostname matcher is NULL and if so return early

### DIFF
--- a/openssl-dynamic/src/main/c/sslcontext.c
+++ b/openssl-dynamic/src/main/c/sslcontext.c
@@ -2602,6 +2602,9 @@ static int ssl_servername_cb(SSL *ssl, int *ad, void *arg)
 
     const char *servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
     if (servername != NULL) {
+        if (c->sni_hostname_matcher == NULL) {
+            return SSL_TLSEXT_ERR_OK;
+        }
         if (tcn_get_java_env(&e) != JNI_OK) {
             return SSL_TLSEXT_ERR_ALERT_FATAL;
         }


### PR DESCRIPTION
Motivation:

We should better check if the matcher is NULL before trying to invoke it as it might be set to NULL while the handshake is still in flight

Modifications:

Add NULL check

Result:

Safer code
