### PR TITLE
Throw NPE when SSL.setOcspResponse(...) is invoked with null argument

### DIFF
--- a/openssl-dynamic/src/main/c/ssl.c
+++ b/openssl-dynamic/src/main/c/ssl.c
@@ -2486,6 +2486,11 @@ TCN_IMPLEMENT_CALL(void, SSL, setOcspResponse)(TCN_STDARGS, jlong ssl, jbyteArra
 
     TCN_CHECK_NULL(ssl_, ssl, /* void */);
 
+    if (response == NULL) {
+        tcn_ThrowNullPointerException(e, "response");
+        return;
+    }
+
     jsize length = (*e)->GetArrayLength(e, response);
     if (length <= 0) {
         return;


### PR DESCRIPTION
Motivation:

Let's guard against passing in a null argument which would previously crash.

Modifications:

Throw NPE on null argument

Result:

More robust code
