### PR TITLE
Guard against crash when sk_CRYPTO_BUFFER_new_null() returns NULL

### DIFF
--- a/openssl-dynamic/src/main/c/sslutils.c
+++ b/openssl-dynamic/src/main/c/sslutils.c
@@ -473,6 +473,9 @@ static int SSL_CTX_setup_certs(SSL_CTX *ctx, BIO *bio, bool skipfirst, bool ca)
 {
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
     STACK_OF(CRYPTO_BUFFER) *names = sk_CRYPTO_BUFFER_new_null();
+    if (names == NULL) {
+        return -1;
+    }
     CRYPTO_BUFFER *buffer = NULL;
     uint8_t *outp = NULL;
     int len;


### PR DESCRIPTION
Motivation:

When out of memory sk_CRYPTO_BUFFER_new_null() will return NULL, so we should better guard against it as otherwise we might crash

Modifications:

Check for NULL and handle it

Result:

More robust code even when out of memory
