### PR TITLE
Build the FIPS profile in CI, and make it build again

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,16 @@ jobs:
           - setup: al2023-x86_64-aws_lc
             docker-compose-run: "-f docker/docker-compose.al2023.yaml run build"
             docker-bake-args: "-f docker-compose.al2023.yaml"
+          # boringssl-static on a current toolchain, and the only CI leg that builds the FIPS
+          # profile (it needs clang-17; see docker/Dockerfile.debian13). Neither is a release
+          # artifact. Before these legs the FIPS profile had no CI at all, so a change to the
+          # release profiles that was not ported to it went unnoticed until a downstream build.
+          - setup: debian13-x86_64
+            docker-compose-run: "-f docker/docker-compose.debian-13.yaml run build"
+            docker-bake-args: "-f docker-compose.debian-13.yaml"
+          - setup: debian13-x86_64-fips
+            docker-compose-run: "-f docker/docker-compose.debian-13.yaml run build-fips"
+            docker-bake-args: "-f docker-compose.debian-13.yaml"
 
     name: ${{ matrix.setup }}
     steps:
@@ -203,6 +213,28 @@ jobs:
             variant: gcompat
             extra-pkgs: gcompat
             drop-elftools: "0"
+            build-service: runtime-setup
+            run-service: verify
+          # The Debian 13-built jars: the FIPS artifact is the one that matters (its power-on
+          # self-test and integrity check run inside an ELF constructor at dlopen, so only a
+          # real load proves the patchelf'd library is still intact), and the default-profile
+          # one shows what a modern-gcc build looks like on musl. bare x86_64 only: aarch64
+          # would need an arm64 FIPS build leg, and the gcompat/nolibgcc variants add nothing
+          # the CentOS 6 legs do not already establish.
+          - setup: alpine-x86_64-fips
+            os: ubuntu-24.04
+            jars: build-debian13-x86_64-fips-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-x86_64-debian13
+            os: ubuntu-24.04
+            jars: build-debian13-x86_64-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
             build-service: runtime-setup
             run-service: verify
           - setup: glibc-control-x86_64

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,6 +38,16 @@ jobs:
           - setup: al2023-x86_64-aws_lc
             docker-compose-run: "-f docker/docker-compose.al2023.yaml run build"
             docker-bake-args: "-f docker-compose.al2023.yaml"
+          # boringssl-static on a current toolchain, and the only CI leg that builds the FIPS
+          # profile (it needs clang-17; see docker/Dockerfile.debian13). Neither is a release
+          # artifact. Before these legs the FIPS profile had no CI at all, so a change to the
+          # release profiles that was not ported to it went unnoticed until a downstream build.
+          - setup: debian13-x86_64
+            docker-compose-run: "-f docker/docker-compose.debian-13.yaml run build"
+            docker-bake-args: "-f docker-compose.debian-13.yaml"
+          - setup: debian13-x86_64-fips
+            docker-compose-run: "-f docker/docker-compose.debian-13.yaml run build-fips"
+            docker-bake-args: "-f docker-compose.debian-13.yaml"
 
     name: ${{ matrix.setup }}
     steps:
@@ -265,6 +275,28 @@ jobs:
             variant: gcompat
             extra-pkgs: gcompat
             drop-elftools: "0"
+            build-service: runtime-setup
+            run-service: verify
+          # The Debian 13-built jars: the FIPS artifact is the one that matters (its power-on
+          # self-test and integrity check run inside an ELF constructor at dlopen, so only a
+          # real load proves the patchelf'd library is still intact), and the default-profile
+          # one shows what a modern-gcc build looks like on musl. bare x86_64 only: aarch64
+          # would need an arm64 FIPS build leg, and the gcompat/nolibgcc variants add nothing
+          # the CentOS 6 legs do not already establish.
+          - setup: alpine-x86_64-fips
+            os: ubuntu-24.04
+            jars: build-pr-debian13-x86_64-fips-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
+            build-service: runtime-setup
+            run-service: verify
+          - setup: alpine-x86_64-debian13
+            os: ubuntu-24.04
+            jars: build-pr-debian13-x86_64-jars
+            variant: bare
+            extra-pkgs: ""
+            drop-elftools: "1"
             build-service: runtime-setup
             run-service: verify
           # Control: anything failing on Alpine must pass here, or the check is at fault rather

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -118,38 +118,61 @@
       <properties>
         <boringsslCheckoutDir>${project.build.directory}/boringssl-${boringsslBranch}/boringssl</boringsslCheckoutDir>
         <boringsslBuildDir>${boringsslCheckoutDir}/build</boringsslBuildDir>
-        <!--   Latest FIPS compliant boringSSL commit   -->
-        <boringsslBranch>6d503ae1cf8b2e25162435225610b8c1f063d6f4</boringsslBranch>
+        <!-- The newest BoringCrypto module that holds a certificate: FIPS 140-3 #5244, module
+             version 20240805, validated 2026-04-18. This sha is the head of BoringSSL's
+             fips-20240805 branch, the tree the certificate's security policy names. Newer
+             fips-YYYYMMDD branches exist (20250107, 20250728, 20251031, 2026xxxx) but their
+             modules are still in the CMVP queue, so they hold no certificate anyone can cite.
+             Any of them builds with this profile: -DboringsslBranch=<sha>. -->
+        <boringsslBranch>1a089be69fdf568c6cf2cab05bd55f97e1f21025</boringsslBranch>
         <linkStatic>true</linkStatic>
         <msvcSslIncludeDirs>${boringsslCheckoutDir}/include</msvcSslIncludeDirs>
         <msvcSslLibDirs>${boringsslBuildDir}/ssl;${boringsslBuildDir}/crypto;${boringsslBuildDir}/decrepit</msvcSslLibDirs>
         <msvcSslLibs>ssl.lib;crypto.lib;decrepit.lib</msvcSslLibs>
         <jniArch>${os.detected.arch}</jniArch>
         <project.artifactId>netty-tcnative-boringssl-static-fips</project.artifactId>
+        <!-- Compiler for BoringSSL itself (tcnative and APR are built with the host cc).
+             Validation covers the toolchain as well as the source, and the version comes from
+             the certificate's security policy: for #5244 that is clang 17.0.6, go 1.22.3,
+             ninja 1.12.1, cmake 3.29.3, built with `ninja bcm.o`. The CI image
+             (docker/Dockerfile.debian13) carries exactly those. clang-12 was the toolchain of
+             an older validation and had been carried forward through two BoringSSL bumps.
+             Override with -DfipsCC=... -DfipsCXX=... to build with something else. -->
+        <fipsCC>clang-17</fipsCC>
+        <fipsCXX>clang++-17</fipsCXX>
       </properties>
 
       <build>
         <plugins>
 
-          <!-- Download the BoringSSL source -->
+          <!-- Check out the FIPS-validated BoringSSL commit from git, the same way the default
+               profile does. This used to download
+               https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-<sha>.tar.xz
+               but that bucket stopped being anonymously readable (403 AccessDenied on every
+               object, 401 on the bucket itself, from several networks), so a fresh machine can
+               no longer build this profile that way - downstream builds only kept working off
+               download-maven-plugin's cache. The tarball is a snapshot of the tree at that
+               commit, so checking out the same sha yields the same sources. The directory layout
+               is kept identical to what the unpacked tarball produced, so nothing below changes. -->
           <plugin>
-            <groupId>com.googlecode.maven-download-plugin</groupId>
-            <artifactId>download-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <artifactId>maven-scm-plugin</artifactId>
             <executions>
               <execution>
-                <id>install-fips-boringssl</id>
-                <phase>process-sources</phase>
+                <id>get-fips-boringssl</id>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>wget</goal>
+                  <goal>checkout</goal>
                 </goals>
+                <configuration>
+                  <checkoutDirectory>${boringsslCheckoutDir}</checkoutDirectory>
+                  <connectionType>developerConnection</connectionType>
+                  <developerConnectionUrl>scm:git:${boringsslRepository}</developerConnectionUrl>
+                  <scmVersion>main</scmVersion>
+                  <scmVersionType>branch</scmVersionType>
+                  <skipCheckoutIfExists>true</skipCheckoutIfExists>
+                </configuration>
               </execution>
             </executions>
-            <configuration>
-              <url>https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-${boringsslBranch}.tar.xz</url>
-              <unpack>true</unpack>
-              <outputDirectory>${project.build.directory}/boringssl-${boringsslBranch}</outputDirectory>
-            </configuration>
           </plugin>
 
           <plugin>
@@ -207,6 +230,12 @@
                       <else>
                         <echo message="Building BoringSSL" />
 
+                        <!-- Pin the checkout to the FIPS-validated commit -->
+                        <exec executable="git" failonerror="true" dir="${boringsslCheckoutDir}" resolveexecutable="true">
+                          <arg value="checkout" />
+                          <arg value="${boringsslBranch}" />
+                        </exec>
+
                         <mkdir dir="${boringsslBuildDir}" />
 
                         <if>
@@ -234,11 +263,18 @@
                             <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer" />
                           </else>
                         </if>
+                        <!-- The static archives end up inside a shared library, so they must be
+                             PIC, same as the default profile asks. Without it the aarch64 link
+                             fails on libcrypto.a(crypto.cc.o): "relocation
+                             R_AARCH64_ADR_PREL_PG_HI21 against symbol stderr ... can not be used
+                             when making a shared object; recompile with -fPIC". delocate is
+                             written for PIC input, so this does not affect the FIPS module. -->
                         <exec executable="cmake" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                          <arg value="-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE" />
                           <arg value="-DCMAKE_BUILD_TYPE=Release" />
                           <arg value="-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" />
-                          <arg value="-DCMAKE_C_COMPILER=clang-12" />
-                          <arg value="-DCMAKE_CXX_COMPILER=clang++-12" />
+                          <arg value="-DCMAKE_C_COMPILER=${fipsCC}" />
+                          <arg value="-DCMAKE_CXX_COMPILER=${fipsCXX}" />
                           <arg value="-DFIPS=1" />
                           <arg value="-GNinja" />
                           <arg value="${boringsslCheckoutDir}" />
@@ -257,8 +293,14 @@
                         <if>
                           <equals arg1="${os.detected.name}" arg2="linux" />
                           <then>
-                            <!-- This is needed to generate bssl execute file to verify isfips property-->
+                            <!-- Only what the link and the isfips gate below need. A bare `ninja`
+                                 builds every target, and the test binaries alone are most of the
+                                 wall-clock time of this profile. -->
                             <exec executable="${ninjaExecutable}" failonerror="true" dir="${boringsslBuildDir}" resolveexecutable="true">
+                              <arg value="crypto" />
+                              <arg value="ssl" />
+                              <arg value="decrepit" />
+                              <arg value="bssl" />
                             </exec>
                             <exec executable="./bssl" failonerror="false" dir="${boringsslBuildDir}" outputproperty="boringssl.isfips.result">
                               <arg value="isfips" />

--- a/boringssl-static/pom.xml
+++ b/boringssl-static/pom.xml
@@ -90,7 +90,14 @@
     <msvcSslIncludeDirs>${boringsslSourceDir}/include</msvcSslIncludeDirs>
     <msvcSslLibDirs>${boringsslHome}</msvcSslLibDirs>
     <msvcSslLibs>ssl.lib;crypto.lib</msvcSslLibs>
-    <cflags>-Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3</cflags>
+    <!-- -U_FORTIFY_SOURCE: Debian-derived gcc (Ubuntu in particular) defines _FORTIFY_SOURCE=2 by
+         default, which rewrites memcpy/sprintf/fprintf/... into glibc's __*_chk variants. musl does
+         not export those, so an artifact built on such a host has undefined __*_chk imports that
+         make `ldd` fail on Alpine (observed: __fprintf_chk, __memcpy_chk, __sprintf_chk from this
+         module, plus __fgets_chk/__vsnprintf_chk from BoringSSL). It is a no-op on the RHEL-family
+         release images and on macOS. Same flag in the FIPS and linux-aarch64 profiles and in the
+         BoringSSL cmake flags below. See docs/musl-compatibility.md -->
+    <cflags>-Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -O3 -U_FORTIFY_SOURCE</cflags>
     <cppflags>-DHAVE_OPENSSL -I${boringsslSourceDir}/include</cppflags>
     <ldflags>-L${boringsslHome} -lssl -lcrypto</ldflags>
     <skipJapicmp>true</skipJapicmp>
@@ -251,9 +258,9 @@
                             <then>
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-w -std=c99 -O3 -fno-omit-frame-pointer" />
+                              <property name="cmakeCFlags" value="-w -std=c99 -O3 -fno-omit-frame-pointer -U_FORTIFY_SOURCE" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
-                              <property name="cmakeCxxFlags" value="-w -O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                              <property name="cmakeCxxFlags" value="-w -O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -U_FORTIFY_SOURCE" />
                             </then>
                           </elseif>
                           <else>
@@ -453,7 +460,7 @@
                     <configureArg>--with-apr=${aprHome}</configureArg>
                     <configureArg>--with-static-libs</configureArg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
-                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -U_FORTIFY_SOURCE</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslCheckoutDir}/include</configureArg>
                     <configureArg>LDFLAGS=-L${boringsslBuildDir} -lssl -lcrypto -ldecrepit -l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a</configureArg>
                   </configureArgs>
@@ -590,9 +597,9 @@
                             <then>
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-w -O3 -fno-omit-frame-pointer -Wno-error=stringop-overflow" />
+                              <property name="cmakeCFlags" value="-w -O3 -fno-omit-frame-pointer -Wno-error=stringop-overflow -U_FORTIFY_SOURCE" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
-                              <property name="cmakeCxxFlags" value="-w -O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                              <property name="cmakeCxxFlags" value="-w -O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -U_FORTIFY_SOURCE" />
                             </then>
                           </elseif>
                           <else>
@@ -990,9 +997,9 @@
                             <then>
                               <!-- On *nix, add ASM flags to disable executable stack -->
                               <property name="cmakeAsmFlags" value="-Wa,--noexecstack" />
-                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer" />
+                              <property name="cmakeCFlags" value="-O3 -fno-omit-frame-pointer -U_FORTIFY_SOURCE" />
                               <!-- We need to define __STDC_CONSTANT_MACROS and __STDC_FORMAT_MACROS when building boringssl on centos 6 -->
-                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" />
+                              <property name="cmakeCxxFlags" value="-O3 -fno-omit-frame-pointer -Wno-error=maybe-uninitialized -Wno-error=shadow -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -U_FORTIFY_SOURCE" />
                             </then>
                           </elseif>
                           <else>
@@ -1162,7 +1169,7 @@
                     <configureArg>--with-apr=${aprHome}</configureArg>
                     <configureArg>--with-static-libs</configureArg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
-                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value</configureArg>
+                    <configureArg>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -fvisibility=hidden -Wunused -Wno-unused-value -U_FORTIFY_SOURCE</configureArg>
                     <configureArg>CPPFLAGS=-DHAVE_OPENSSL -I${boringsslSourceDir}/include</configureArg>
                     <!-- Keep in sync with the boringssl-static-default profile: the two Linux
                          profiles duplicate the whole native build, so a change to one does not apply

--- a/docker/Dockerfile.arch
+++ b/docker/Dockerfile.arch
@@ -23,6 +23,7 @@ RUN pacman -Sy --noconfirm --needed \
  lsb-release \
  make \
  ninja \
+ patchelf \
  perl \
  tar \
  unzip \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -12,6 +12,7 @@ ENV CMAKE_VERSION $CMAKE_VERSION_BASE.2
 ENV NINJA_VERSION 1.7.2
 ENV GO_VERSION 1.9.3
 ENV GCC_VERSION 4.9.4
+ENV PATCHELF_VERSION 0.18.0
 
 ARG java_version="8.0.302-zulu"
 ENV JAVA_VERSION $java_version
@@ -69,6 +70,17 @@ RUN set -x && \
   ./Configure linux-x86_64 --prefix=/opt/openssl-$OPENSSL_VERSION --libdir=lib shared no-asm no-apps && \
   make -j1 install_sw) && \
   rm -rf openssl-$OPENSSL_VERSION openssl-$OPENSSL_VERSION.tar.gz
+
+# patchelf is used post-link by the boringssl-static profile to drop the DT_NEEDED on
+# ld-linux-x86-64.so.2 so the artifact also loads under musl. Wheezy has no patchelf package
+# (it entered Debian in jessie), so install the upstream prebuilt static binary instead, as
+# Dockerfile.centos6 does. --no-check-certificate for the same reason as the OpenSSL download.
+RUN wget -q --no-check-certificate https://github.com/NixOS/patchelf/releases/download/$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION-x86_64.tar.gz \
+ && mkdir -p /opt/patchelf-$PATCHELF_VERSION \
+ && tar zxf patchelf-$PATCHELF_VERSION-x86_64.tar.gz -C /opt/patchelf-$PATCHELF_VERSION \
+ && ln -s /opt/patchelf-$PATCHELF_VERSION/bin/patchelf /usr/local/bin/patchelf \
+ && rm -f patchelf-$PATCHELF_VERSION-x86_64.tar.gz \
+ && patchelf --version
 
 RUN rm -rf $SOURCE_DIR
 

--- a/docker/Dockerfile.debian13
+++ b/docker/Dockerfile.debian13
@@ -1,0 +1,72 @@
+ARG debian_version=13
+FROM debian:$debian_version
+# needed to do again after FROM due to docker limitation
+ARG debian_version
+ARG go_version=1.22.3
+ARG cmake_version=3.29.3
+ENV GO_VERSION $go_version
+ENV CMAKE_VERSION $cmake_version
+ENV DEBIAN_FRONTEND noninteractive
+
+# A modern glibc builder for boringssl-static, and the only in-tree image that can build the
+# fips-boringssl-static profile. That profile pins the BoringCrypto module that holds
+# certificate #5244, and this image carries the build environment its security policy names:
+#   clang 17.0.6, go 1.22.3, ninja 1.12.1, cmake 3.29.3
+# Debian 13 packages clang-17 at exactly 17.0.6 and ninja at exactly 1.12.1. Its cmake (3.31)
+# and Go (1.24) are newer than the policy's, so those two come from cmake.org and go.dev at the
+# policy's versions instead. patchelf 0.18 has --remove-needed; APR's buildconf wants the
+# `libtool` script, which is in libtool-bin.
+#
+# No JDK 8 in trixie: the build runs on JDK 21. The pom compiles with --release 8, so the
+# class files are still Java 8.
+#
+# Not pinned to linux/amd64 like the older images, so it can also be built natively on an
+# arm64 host for a quick local run. CI builds it on amd64 runners.
+#
+# Unlike the CentOS 6 image this is NOT a release builder: its artifact has a glibc 2.41 floor.
+# It exists to give the boringssl-static and FIPS builds CI coverage on a current toolchain.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ autoconf \
+ automake \
+ bzip2 \
+ ca-certificates \
+ clang-17 \
+ curl \
+ g++ \
+ gcc \
+ git \
+ gnupg \
+ libapr1-dev \
+ libtool \
+ libtool-bin \
+ make \
+ ninja-build \
+ openjdk-21-jdk-headless \
+ patch \
+ patchelf \
+ perl \
+ pkg-config \
+ tar \
+ unzip \
+ wget \
+ xz-utils \
+ zip \
+ && rm -rf /var/lib/apt/lists/*
+
+# dpkg's amd64/arm64 spelling matches go.dev's; cmake.org spells the arch x86_64/aarch64.
+RUN ARCH=$(dpkg --print-architecture) && case $ARCH in amd64) CM=x86_64;; arm64) CM=aarch64;; esac \
+ && wget -q https://go.dev/dl/go$GO_VERSION.linux-$ARCH.tar.gz \
+ && tar -C /opt -xzf go$GO_VERSION.linux-$ARCH.tar.gz && rm go$GO_VERSION.linux-$ARCH.tar.gz \
+ && wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-$CM.tar.gz \
+ && tar -C /opt -xzf cmake-$CMAKE_VERSION-linux-$CM.tar.gz && rm cmake-$CMAKE_VERSION-linux-$CM.tar.gz \
+ && ln -s /opt/cmake-$CMAKE_VERSION-linux-$CM /opt/cmake \
+ && ln -s /usr/lib/jvm/java-21-openjdk-$ARCH /usr/lib/jvm/java-21
+# The compose services run `bash -cl`, and Debian's /etc/profile resets PATH for login shells,
+# so ENV PATH alone is not enough: root's ~/.profile sources ~/.bashrc, which restores it.
+ENV PATH /opt/go/bin:/opt/cmake/bin:$PATH
+RUN echo 'export PATH=/opt/go/bin:/opt/cmake/bin:$PATH' >> ~/.bashrc
+ENV JAVA_HOME /usr/lib/jvm/java-21
+RUN go version && clang-17 --version | head -1 && ninja --version && cmake --version | head -1
+
+# /code is a bind mount owned by the host user; newer git refuses to touch it otherwise.
+RUN git config --global --add safe.directory '*'

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -28,6 +28,7 @@ RUN zypper install --force-resolution --no-recommends --no-confirm \
  make \
  ninja \
  patch \
+ patchelf \
  perl \
  tar \
  unzip \

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,6 +39,20 @@ docker compose -f docker/docker-compose.opensuse.yaml -f docker/docker-compose.o
 docker compose -f docker/docker-compose.centos-7.yaml run cross-compile-aarch64-build
 ```
 
+## Debian 13 with java 21: boringssl-static on a current toolchain, and the FIPS profile
+
+Not a release builder (glibc 2.41 floor). It is the one image that can build the
+`fips-boringssl-static` profile, and it carries the build environment named by the security
+policy of the certificate that profile pins (#5244): clang 17.0.6 and ninja 1.12.1 from the
+archive, go 1.22.3 and cmake 3.29.3 downloaded at those versions. Both services stop at
+`package`, which is where the musl compatibility check runs. Not pinned to amd64, so on an
+arm64 host it builds natively.
+
+```
+docker compose -f docker/docker-compose.debian-13.yaml run build
+docker compose -f docker/docker-compose.debian-13.yaml run build-fips
+```
+
 etc, etc
 
 

--- a/docker/docker-compose.debian-13.yaml
+++ b/docker/docker-compose.debian-13.yaml
@@ -1,0 +1,44 @@
+version: "3"
+
+# Debian 13 builder. Two things run here that no other image covers, see Dockerfile.debian13:
+#   build       boringssl-static (default profile) on a current gcc, so the Linux native
+#               build is exercised somewhere other than the CentOS 6 release image
+#   build-fips  the fips-boringssl-static profile, which needs clang-17
+# Both stop at `package`, which is where the native-jar musl check runs.
+
+services:
+
+  runtime-setup:
+    image: netty-tcnative-debian:13
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.debian13
+      args:
+        debian_version: "13"
+
+  common: &common
+    image: netty-tcnative-debian:13
+    depends_on: [runtime-setup]
+    environment:
+      - MAVEN_OPTS
+    volumes:
+      - ~/.m2/repository:/root/.m2/repository
+      - ..:/code:delegated
+    working_dir: /code
+
+  build:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -am -pl boringssl-static clean package"
+
+  build-fips:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -Pfips-boringssl-static -am -pl boringssl-static clean package"
+
+  shell:
+    <<: *common
+    volumes:
+      - ~/.m2/repository:/root/.m2/repository
+      - ~/.gitconfig:/root/.gitconfig:delegated
+      - ~/.gitignore:/root/.gitignore:delegated
+      - ..:/code:delegated
+    entrypoint: /bin/bash

--- a/docs/musl-compatibility.md
+++ b/docs/musl-compatibility.md
@@ -224,6 +224,14 @@ The check must go further than loading. Minimum bar, in order of strength:
 
 Only (3) would catch a library that loads but whose crypto is broken.
 
+In CI this is the `musl-verify` job. It runs against the CentOS 6 and CentOS 7 release jars on
+several Alpine variants, and, bare x86_64 only, against the two Debian 13 jars: the
+default-profile one and the **FIPS** one (`debian13-x86_64-fips`, see `docker/Dockerfile.debian13`).
+The FIPS leg is the one with no substitute: its power-on self-test and integrity check run in an
+ELF constructor during `dlopen`, so only a real load shows that the post-link `patchelf` left the
+module intact. Before that leg existed the FIPS profile was built by nobody but downstream users,
+and a change made to the release profiles and not ported to it surfaced only there.
+
 Two TLS 1.3 behaviours will make a naive handshake test report false failures:
 - the client reaches `NOT_HANDSHAKING` while the server still sits in `NEED_UNWRAP` waiting
   for optional post-handshake traffic — treat an idle `NEED_UNWRAP` as settled;

--- a/docs/musl-compatibility.md
+++ b/docs/musl-compatibility.md
@@ -241,6 +241,7 @@ protocol/cipher against a released version. It must be identical.
 | `boringssl-static/pom.xml`, antrun `native-jar` target | post-link `patchelf --remove-needed ld-linux-*` (Class A). Present in the FIPS profile and both release profiles: `fips-boringssl-static`, `boringssl-static-default` (x86_64), and `linux-aarch64`. |
 | `docker/Dockerfile.centos6` | installs `patchelf` from the upstream prebuilt **static** binary — CentOS 6 is EOL with no EPEL, and `objcopy` cannot remove a `DT_NEEDED`. Needs `--no-check-certificate`, same as the OpenSSL download: the CA bundle cannot verify modern GitHub TLS. |
 | `docker/Dockerfile.cross_compile_aarch64` | installs `patchelf` from EPEL 7 (available there, unlike CentOS 6) |
+| `docker/Dockerfile.debian`, `docker/Dockerfile.arch`, `docker/Dockerfile.opensuse` | also install `patchelf`. Their `build` compose service runs a module-unfiltered `./mvnw clean package`, which builds `boringssl-static` and so hits the `patchelf` exec (`failonerror="true"`). CI only runs Debian's `build-dynamic-only`, so a missing binary here is invisible to CI. Arch and openSUSE take the distro package; Debian 7 needs the prebuilt static binary like CentOS 6, wheezy has no `patchelf` package at all. |
 
 Note the FIPS profile and two release profiles duplicate the whole native build, so **a change to
 one does not apply to the others**. `linux-aarch64` cross-compiles from an x86_64 host; patchelf

--- a/docs/musl-compatibility.md
+++ b/docs/musl-compatibility.md
@@ -102,6 +102,10 @@ Error relocating <lib>.so: __getauxval: symbol not found
 | `__isinf`, `__isnan` | APR-era glibc math aliases | no |
 | `__strdup` | APR | no |
 | `__pthread_key_create` | APR | no — but it is imported **WEAK**, so it may stay unresolved harmlessly |
+| `__sprintf_chk`, `__fprintf_chk` | Debian-derived toolchains ship a fortified `libstdc++.a` / `libgcc.a`; `cp-demangle.o` comes in via the verbose terminate handler | no. Our own code is compiled `-U_FORTIFY_SOURCE`, these two cover the archives we do not build |
+| `__libc_single_threaded` | libstdc++ 11+ headers on glibc 2.32+ read this byte to skip atomic refcounting; C++ in BoringSSL (seen with the `fips-20260721` branch on Ubuntu 22.04) imports it as a **data** symbol | no. Defined as `0`, the conservative value |
+| `__isoc23_strto{l,ul,ll,ull,imax,umax}`, `__isoc23_{s,vs}scanf` | glibc 2.38+ redirects the integer parsers and scanf family there under `_GNU_SOURCE`; APR and the packaged `libstdc++.a` on any glibc 2.38+ builder such as Debian 13 (`strtoull` only on x86_64) | no. Forwarded to the plain names via asm labels (a literal `strtol()` in the fallback would be redirected too and recurse on musl) |
+| `_dl_find_object` | `libgcc_eh.a` from gcc 12 on, when built against glibc 2.35+, uses it to find `.eh_frame` while unwinding | no. Stub returns -1 ("not found"); nothing in the artifact throws |
 
 ### Class C — Class B inside an ELF init constructor → **JVM crash, not an exception**
 
@@ -438,6 +442,11 @@ Other notes:
   *before* hawtjni. Use the `native-jar` target (phase `package`) or `process-classes`.
 - Ant's `<exec>` does not echo silent commands, so absence of `strip`/`patchelf` output in the
   log does **not** mean they did not run. Verify on the artifact instead.
+- `-U_FORTIFY_SOURCE` is on every Linux compile line (module `cflags`, the FIPS and
+  `linux-aarch64` `CFLAGS`, and the BoringSSL cmake flags of all three). Debian-derived gcc
+  defines `_FORTIFY_SOURCE=2` by default and rewrites libc calls into `__*_chk` variants musl
+  does not export: the artifact still loads (nothing on the load path calls them) but `ldd`
+  on Alpine fails; the modern-distro CI legs showed exactly that. No-op on the RHEL release images.
 - Link flags are set per profile and are duplicated: the x86_64 default profile sets
   `hawtjniLdflags` in the `ldflags-setup` antrun execution, while the FIPS and `linux-aarch64`
   profiles hardcode `LDFLAGS` in their hawtjni `configureArgs`. Changing one does not change the

--- a/openssl-dynamic/src/main/c/musl_compat.c
+++ b/openssl-dynamic/src/main/c/musl_compat.c
@@ -51,8 +51,11 @@
 #endif
 
 #include <fcntl.h>
+#include <inttypes.h>
 #include <math.h>
+#include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -145,6 +148,128 @@ TCN_MUSL_COMPAT int __isnan(double value) {
 /* glibc-internal alias APR links against directly. */
 TCN_MUSL_COMPAT char *__strdup(const char *str) {
     return strdup(str);
+}
+
+/*
+ * _FORTIFY_SOURCE entry points. Everything this project compiles passes -U_FORTIFY_SOURCE, so
+ * none of our own objects reference these. Two archives we link but do not build can: on a
+ * Debian-derived toolchain the packaged libstdc++.a (cp-demangle.o, floating_to_chars.o,
+ * debug.o) and libgcc.a (_eprintf.o) are themselves fortified, and cp-demangle.o is pulled in
+ * through the verbose terminate handler. The result is an undefined __sprintf_chk that makes
+ * `ldd` fail on Alpine even though nothing on the load path calls it. Same shape as the rest
+ * of this file: weak so glibc's own definition wins on glibc, defined here so musl has one.
+ *
+ * Semantics follow glibc: slen is the destination size, or (size_t) -1 when unknown.
+ */
+TCN_MUSL_COMPAT int __sprintf_chk(char *s, int flag, size_t slen, const char *format, ...) {
+    va_list ap;
+    int written;
+    (void) flag;
+    va_start(ap, format);
+    if (slen == (size_t) -1) {
+        written = vsprintf(s, format, ap);
+    } else {
+        written = vsnprintf(s, slen, format, ap);
+    }
+    va_end(ap);
+    return written;
+}
+
+TCN_MUSL_COMPAT int __fprintf_chk(FILE *stream, int flag, const char *format, ...) {
+    va_list ap;
+    int written;
+    (void) flag;
+    va_start(ap, format);
+    written = vfprintf(stream, format, ap);
+    va_end(ap);
+    return written;
+}
+
+/*
+ * glibc 2.32+ exports this byte, and libstdc++ 11+ headers read it (ext/atomicity.h,
+ * __gnu_cxx::__is_single_threaded) to skip atomic reference counting while a process is still
+ * single-threaded. Any C++ compiled against such headers -- BoringSSL's libssl on a current
+ * toolchain -- imports it as a plain data symbol, and musl has no such thing. Zero is the
+ * conservative value: "not single-threaded", so the atomic path is always taken. On glibc the
+ * libc definition wins as usual. The JVM is multi-threaded long before this library loads, so
+ * the value could never legitimately be nonzero here anyway.
+ */
+TCN_MUSL_COMPAT char __libc_single_threaded = 0;
+
+/*
+ * glibc 2.38 made the integer parsers and the scanf family C23-conformant (binary "0b"
+ * prefixes) under a new symbol version, and redirects every call to an __isoc23_* name
+ * whenever _GNU_SOURCE is defined, whatever -std says. Anything built on glibc >= 2.38
+ * (Ubuntu 24.04, Debian 13) imports them: APR (sockaddr.o, apr_strings.o), the packaged libstdc++.a
+ * (eh_alloc.o, debug.o), and on x86_64 something else again brings in strtoull. musl exports
+ * only the plain names. The whole family is covered here so the next builder does not find
+ * the next member.
+ *
+ * The bodies must call the PLAIN symbols. A literal strtol() here is subject to the same
+ * redirect, so on musl it would resolve to this very function and recurse. The asm labels
+ * bind each reference to the unversioned name, which both libcs export.
+ *
+ * __restrict, not restrict: the Debian 7 image compiles with GCC 4.9, whose default is gnu90,
+ * where `restrict` is not a keyword.
+ */
+extern long tcn_plain_strtol(const char *, char **, int) __asm__("strtol");
+extern unsigned long tcn_plain_strtoul(const char *, char **, int) __asm__("strtoul");
+extern long long tcn_plain_strtoll(const char *, char **, int) __asm__("strtoll");
+extern unsigned long long tcn_plain_strtoull(const char *, char **, int) __asm__("strtoull");
+extern intmax_t tcn_plain_strtoimax(const char *, char **, int) __asm__("strtoimax");
+extern uintmax_t tcn_plain_strtoumax(const char *, char **, int) __asm__("strtoumax");
+extern int tcn_plain_vsscanf(const char *, const char *, va_list) __asm__("vsscanf");
+
+TCN_MUSL_COMPAT long __isoc23_strtol(const char *__restrict nptr, char **__restrict endptr, int base) {
+    return tcn_plain_strtol(nptr, endptr, base);
+}
+
+TCN_MUSL_COMPAT unsigned long __isoc23_strtoul(const char *__restrict nptr, char **__restrict endptr, int base) {
+    return tcn_plain_strtoul(nptr, endptr, base);
+}
+
+TCN_MUSL_COMPAT long long __isoc23_strtoll(const char *__restrict nptr, char **__restrict endptr, int base) {
+    return tcn_plain_strtoll(nptr, endptr, base);
+}
+
+TCN_MUSL_COMPAT unsigned long long __isoc23_strtoull(const char *__restrict nptr, char **__restrict endptr, int base) {
+    return tcn_plain_strtoull(nptr, endptr, base);
+}
+
+TCN_MUSL_COMPAT intmax_t __isoc23_strtoimax(const char *__restrict nptr, char **__restrict endptr, int base) {
+    return tcn_plain_strtoimax(nptr, endptr, base);
+}
+
+TCN_MUSL_COMPAT uintmax_t __isoc23_strtoumax(const char *__restrict nptr, char **__restrict endptr, int base) {
+    return tcn_plain_strtoumax(nptr, endptr, base);
+}
+
+TCN_MUSL_COMPAT int __isoc23_vsscanf(const char *__restrict str, const char *__restrict format, va_list ap) {
+    return tcn_plain_vsscanf(str, format, ap);
+}
+
+TCN_MUSL_COMPAT int __isoc23_sscanf(const char *__restrict str, const char *__restrict format, ...) {
+    va_list ap;
+    int matched;
+    va_start(ap, format);
+    matched = tcn_plain_vsscanf(str, format, ap);
+    va_end(ap);
+    return matched;
+}
+
+/*
+ * glibc 2.35 added _dl_find_object, and libgcc_eh.a from gcc 12 on (unwind-dw2-fde-dip.o)
+ * calls it to locate a frame's .eh_frame when unwinding. musl has no equivalent. Returning
+ * -1 means "no object found": the unwinder then reports no FDE and a C++ exception would
+ * terminate instead of propagating. Nothing here throws - BoringSSL compiles its C++ with
+ * -fno-exceptions, APR and this module are C - so the only observable effect is that the
+ * symbol resolves. Declared with a void * result on purpose: the real struct only exists in
+ * glibc >= 2.35 headers and the release image is glibc 2.12.
+ */
+TCN_MUSL_COMPAT int _dl_find_object(void *address, void *result) {
+    (void) address;
+    (void) result;
+    return -1;
 }
 
 #endif /* __linux__ */

--- a/openssl-dynamic/src/main/c/sslcredential.c
+++ b/openssl-dynamic/src/main/c/sslcredential.c
@@ -30,6 +30,13 @@
 #define SSLCREDENTIAL_CLASSNAME "io/netty/internal/tcnative/SSLCredential"
 
 // Helper functions
+/*
+ * Three of the setters below exist only in newer BoringSSL: must_match_issuer from API version
+ * 33 (fips-20250107), certificate_properties and trust_anchor_id from 36 (fips-20250728). The
+ * FIPS profile pins the certified module, fips-20240805 = API 32, so they are gated on
+ * BORINGSSL_API_VERSION and throw UnsupportedOperationException there, like the whole API does
+ * on non-BoringSSL builds.
+ */
 #ifdef OPENSSL_IS_BORINGSSL
 static void throw_openssl_error(JNIEnv* env, const char* msg) {
     unsigned long err = ERR_get_error();
@@ -194,7 +201,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setSigningAlgorithmPrefs)(TCN_STDARGS, j
 }
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setCertificateProperties)(TCN_STDARGS, jlong cred, jbyteArray cert_props) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) && BORINGSSL_API_VERSION >= 36
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(cert_props, certificateProperties, /* void */);
@@ -220,7 +227,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setCertificateProperties)(TCN_STDARGS, j
         throw_openssl_error(e, "Failed to set certificate properties");
     }
 #else
-    tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL API not available.");
+    tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL_set1_certificate_properties requires BoringSSL API version 36 or newer.");
 #endif
 }
 
@@ -256,18 +263,18 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setSignedCertTimestampList)(TCN_STDARGS,
 }
 
 TCN_IMPLEMENT_CALL(void, SSLCredential, setMustMatchIssuer)(TCN_STDARGS, jlong cred, jboolean match) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) && BORINGSSL_API_VERSION >= 33
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     SSL_CREDENTIAL_set_must_match_issuer(c, match == JNI_TRUE ? 1 : 0);
 #else
-    tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL API not available.");
+    tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL_set_must_match_issuer requires BoringSSL API version 33 or newer.");
 #endif
 }
 
 // Trust anchor configuration
 TCN_IMPLEMENT_CALL(void, SSLCredential, setTrustAnchorId)(TCN_STDARGS, jlong cred, jbyteArray id) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) && BORINGSSL_API_VERSION >= 36
     SSL_CREDENTIAL* c = (SSL_CREDENTIAL*)(intptr_t)cred;
     TCN_CHECK_NULL(c, credential, /* void */);
     TCN_CHECK_NULL(id, trustAnchorId, /* void */);
@@ -289,7 +296,7 @@ TCN_IMPLEMENT_CALL(void, SSLCredential, setTrustAnchorId)(TCN_STDARGS, jlong cre
         return;
     }
 #else
-    tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL API not available.");
+    tcn_ThrowUnsupportedOperationException(e, "SSL_CREDENTIAL_set1_trust_anchor_id requires BoringSSL API version 36 or newer.");
 #endif
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -766,7 +766,7 @@
                                      Also ensure that we can use locks as detection fails when cross-compiling.
                                      See https://github.com/netty/netty-tcnative/issues/974
                                   -->
-                                <arg line="--disable-shared --prefix=${aprHome} --host=aarch64-linux-gnu CC=aarch64-none-linux-gnu-gcc CFLAGS='-O3 -fno-omit-frame-pointer -fPIC -DHAVE_PTHREAD_RWLOCKS=1' ac_cv_have_decl_sys_siglist=no ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8" />
+                                <arg line="--disable-shared --prefix=${aprHome} --host=aarch64-linux-gnu CC=aarch64-none-linux-gnu-gcc CFLAGS='-O3 -fno-omit-frame-pointer -fPIC -DHAVE_PTHREAD_RWLOCKS=1 -U_FORTIFY_SOURCE' ac_cv_have_decl_sys_siglist=no ac_cv_file__dev_zero=yes ac_cv_func_setpgrp_void=yes apr_cv_tcp_nodelay_with_cork=yes ac_cv_sizeof_struct_iovec=8" />
                               </exec>
                               <!--
                                 Make will fail when it tries to use the gen_test_char program.
@@ -790,7 +790,7 @@
                                 Disable the detection of sys_siglist and just use apr's own implementation to workaround problems when trying to use static jars on alpine linux
                                 See https://github.com/netty/netty-tcnative/issues/853
                               -->
-                              <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC' ${macOsxDeploymentTarget} ac_cv_have_decl_sys_siglist=no" />
+                              <arg line="--disable-shared --prefix=${aprHome} CFLAGS='-O3 -fno-omit-frame-pointer -fPIC -U_FORTIFY_SOURCE' ${macOsxDeploymentTarget} ac_cv_have_decl_sys_siglist=no" />
                             </exec>
                             <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true" />
                             <exec executable="make" failonerror="true" dir="${aprSourceDir}" resolveexecutable="true">

--- a/scripts/check_musl_compat.sh
+++ b/scripts/check_musl_compat.sh
@@ -97,11 +97,13 @@ __ctype_b_loc __ctype_get_mb_cur_max __ctype_tolower_loc __ctype_toupper_loc
 __errno_location __fpclassify __fpclassifyf __fpclassifyl
 __h_errno_location __libc_start_main __signbit __signbitf __signbitl
 __stack_chk_fail __stack_chk_guard __tls_get_addr
+__isoc99_fscanf __isoc99_fwscanf __isoc99_scanf __isoc99_sscanf __isoc99_swscanf __isoc99_vfscanf
+__isoc99_vfwscanf __isoc99_vscanf __isoc99_vsscanf __isoc99_vswscanf __isoc99_vwscanf __isoc99_wscanf
 '
 
 # The fallbacks openssl-dynamic/src/main/c/musl_compat.c defines. Asserting these are *defined*
 # rather than undefined catches the compatibility file being dropped or excluded from the link.
-MUSL_COMPAT_SYMS='__getauxval fopen64 __isinf __isnan __strdup'
+MUSL_COMPAT_SYMS='__getauxval fopen64 __isinf __isnan __strdup __sprintf_chk __fprintf_chk __libc_single_threaded __isoc23_strtol __isoc23_strtoul __isoc23_strtoll __isoc23_strtoull __isoc23_strtoimax __isoc23_strtoumax __isoc23_sscanf __isoc23_vsscanf _dl_find_object'
 
 rc=0
 MACHINE=$("$READELF" -h "$SO" 2>/dev/null | sed -n 's/.*Machine:[[:space:]]*//p')


### PR DESCRIPTION
Follow-up to #997 and #1008. Draft: the amd64 validation of the final state is still running, see "Verification".

## Motivation

#1008 showed the blind spot: nothing in CI builds the FIPS profile, so a change to the release profiles that is not ported to it only fails on someone's downstream build. Building it in CI turned up more than the missing port: the profile no longer builds on a fresh machine at all (the FIPS tarball bucket is private now), does not link on aarch64, pinned a module that holds no certificate, and called clang-12 "the validated toolchain" when the current certificate names clang 17.

## What is in here (one commit each)

1. **patchelf in the Debian, Arch and openSUSE dev images.** Their `build` service has failed since #997; CI only runs Debian's dynamic-only service.
2. **FIPS profile.** BoringSSL is checked out from git at the pinned sha, which is what [FIPS.md](https://boringssl.googlesource.com/boringssl/+/refs/heads/main/crypto/fipsmodule/FIPS.md) recommends anyway (the tarball at `commondatastorage.googleapis.com/chromium-boringssl-fips` returns 403 now); `CMAKE_POSITION_INDEPENDENT_CODE` is back (dropped in #950, breaks the aarch64 link); ninja builds only `crypto ssl decrepit bssl`; the pin moves to `fips-20240805`, the module of certificate #5244 (validated 2026-04-18), the newest one that holds a certificate; the compiler is a property (`fipsCC`/`fipsCXX`, default clang-17, the version in that certificate's security policy).
3. **musl on modern toolchains.** Built on a current distro the artifact imports glibc-only symbols from code we do not compile with our flags (fortify `__*_chk`, `__libc_single_threaded`, glibc 2.38's `__isoc23_*` redirects, `_dl_find_object`): it loads on Alpine but `ldd` fails. `-U_FORTIFY_SOURCE` on the Linux compile lines and weak fallbacks in `musl_compat.c`, following the existing pattern. No-op on the CentOS release images.
4. **CI.** A Debian 13 image carrying the build environment from #5244's policy (clang 17.0.6, ninja 1.12.1 from the archive; go 1.22.3, cmake 3.29.3 at those versions), legs `debian13-x86_64` and `debian13-x86_64-fips`, and bare-Alpine `musl-verify` legs on both jars. The FIPS one matters most: the module's integrity check and self-tests run in an ELF constructor at `dlopen`, so only a real load proves the post-link patchelf left it intact.

## Verification

- amd64: the same tree, minus the pin change, passed the full PR workflow on my fork (all 17 jobs). The run with the 2024-08-05 pin and matching toolchain is in progress locally; the PR stays a draft until it is green.
- arm64: both profiles built natively on Debian 13, zero musl-check warnings, both jars load on bare Alpine.

## Open points

- Which module to pin is a policy decision. `fips-20251031` (previous pin) and `fips-20260721` both build with this profile via `-DboringsslBranch=<sha>`; neither holds a certificate yet.
- The fallbacks in commit 3 add a few exported weak symbols to the release artifacts, which never reference them. CentOS 6 and 7 builds pass unchanged.
- The Debian 13 image builds on JDK 21 (`--release 8` keeps the class files at 8); trixie has no JDK 8.

## For discussion: is a certified pin the right default?

- The only BoringCrypto module with a certificate today is the 2024-08-05 one (#5244, issued 2026-04-18): source that is two years old, which contradicts ordinary patch hygiene. The three 2025 modules are still in the CMVP queue ("Comment Resolution" on the [modules-in-process list](https://csrc.nist.gov/projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list)), 10 to 20 months after their version dates.
- The CMVP's stated goal, as relayed at the [OpenSSL Conference in October 2025](https://archive.openssl-conference.org/2025/presentations/Jason_Lawlor_OpenSSL_Presentation_JL_October_5_2025.pdf), was a six-month queue by the end of 2025 and no queue by mid-2026. That is not what the BoringCrypto entries show.
- [FIPS.md](https://boringssl.googlesource.com/boringssl/+/refs/heads/main/crypto/fipsmodule/FIPS.md) now documents an "update stream": `main`, built with `-DFIPS=1`, following the [FedRAMP policy of January 2025](https://www.fedramp.gov/rev5/fips/) that asks vendors to promote update streams over validated module streams. On that stream `FIPS_version()` returns 0.
- So the profile can serve two different needs: a certified pin for whoever must cite a certificate, and the update stream for whoever wants current crypto with FIPS-mode self-tests. This PR makes the certified module the default and keeps the other one a `-DboringsslBranch` away; the reverse default is equally defensible and is worth deciding explicitly.
